### PR TITLE
Use python 3.6 by default in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.1


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Sets the default python for docker and heroku to 3.6

#### How should this be manually tested?
docker should default to python 3.6

