### PR TITLE
Added backend and requirements for login with edX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.5
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 
@@ -20,7 +20,7 @@ RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 # Install project packages
 COPY requirements.txt /tmp/requirements.txt
 COPY test_requirements.txt /tmp/test_requirements.txt
-RUN pip install -r requirements.txt && pip install -r test_requirements.txt
+RUN pip install -r requirements.txt -r test_requirements.txt
 
 # Add project
 COPY . /src

--- a/backends/edxorg.py
+++ b/backends/edxorg.py
@@ -1,0 +1,110 @@
+"""
+EdX.org backend for Python Social Auth
+"""
+from datetime import datetime
+from urllib.parse import urljoin
+
+from django.conf import settings
+import pytz
+from social_core.backends.oauth import BaseOAuth2
+
+
+class EdxOrgOAuth2(BaseOAuth2):
+    """
+    EDX.org OAuth2 authentication backend
+    """
+    name = 'edxorg'
+    ID_KEY = 'edx_id'
+    REQUEST_TOKEN_URL = None
+    EDXORG_BASE_URL = settings.EDXORG_BASE_URL
+
+    # Settings for Django OAUTH toolkit
+    AUTHORIZATION_URL = urljoin(EDXORG_BASE_URL, '/oauth2/authorize/')
+    ACCESS_TOKEN_URL = urljoin(EDXORG_BASE_URL, '/oauth2/access_token/')
+    DEFAULT_SCOPE = ['read', 'write']
+
+    ACCESS_TOKEN_METHOD = 'POST'
+    REDIRECT_STATE = False
+    EXTRA_DATA = [
+        ('refresh_token', 'refresh_token', True),
+        ('expires_in', 'expires_in'),
+        ('token_type', 'token_type', True),
+        ('scope', 'scope'),
+    ]
+
+    def user_data(self, access_token, *args, **kwargs):
+        """
+        Loads user data from service.
+
+        This is the function that has to pull the data from edx
+
+        Args:
+            access_token (str): the OAUTH access token
+
+        Returns:
+            dict: a dictionary containing user information
+                coming from the remote service.
+        """
+        return self.get_json(
+            urljoin(self.EDXORG_BASE_URL, "/api/mobile/v0.5/my_user_info"),
+            headers={
+                "Authorization": "Bearer {}".format(access_token),
+            }
+        )
+
+    def get_user_details(self, response):
+        """
+        Returns user details in a known internal struct.
+
+        This is the function that, given the data coming from edx,
+        formats the content to return a dictionary with the keys
+        like the following one.
+
+        Args:
+            response (dict): dictionary containing user information
+                coming from the remote service.
+
+        Returns:
+            dict: dictionary with a defined structure containing
+                the following keys:
+                <remote_id>, `username`, `email`, `fullname`, `first_name`, `last_name`
+        """
+        full, _, _ = self.get_user_names(response['name'])
+
+        return {
+            'edx_id': response['username'],
+            'username': response['username'],
+            'email': response['email'],
+            'fullname': full,
+            # the following are not necessary because they are used only inside the User object.
+            'first_name': '',
+            'last_name': '',
+        }
+
+    def get_user_id(self, details, response):
+        """
+        Return a unique ID for the current user, by default from server
+        response.
+
+        Args:
+            details (dict): the user formatted info coming from `get_user_details`
+            response (dict): the user raw info coming from `user_data`
+
+        Returns:
+            string: the unique identifier for the user in the remote service.
+        """
+        return details.get(self.ID_KEY)
+
+    def refresh_token(self, token, *args, **kwargs):
+        """
+        Overridden method to add extra info during refresh token.
+
+        Args:
+            token (str): valid refresh token
+
+        Returns:
+            dict of information about the user
+        """
+        response = super(EdxOrgOAuth2, self).refresh_token(token, *args, **kwargs)
+        response['updated_at'] = datetime.now(tz=pytz.UTC).timestamp()
+        return response

--- a/backends/edxorg_test.py
+++ b/backends/edxorg_test.py
@@ -1,0 +1,53 @@
+"""
+Oauth Backend Tests
+"""
+from unittest import TestCase
+
+from social_django.utils import load_strategy
+
+from backends.edxorg import EdxOrgOAuth2
+
+
+class EdxOrgOAuth2Tests(TestCase):
+    """Tests for EdxOrgOAuth2"""
+    def test_response_parsing(self):
+        """
+        Should have properly formed payload if working.
+        """
+        eoo = EdxOrgOAuth2(strategy=load_strategy())
+        result = eoo.get_user_details({
+            'id': 5,
+            'username': 'darth',
+            'email': 'darth@deathst.ar',
+            'name': 'Darth Vader'
+        })
+
+        assert {
+            'edx_id': 'darth',
+            'username': 'darth',
+            'fullname': 'Darth Vader',
+            'email': 'darth@deathst.ar',
+            'first_name': '',
+            'last_name': ''
+        } == result
+
+    def test_single_name(self):
+        """
+        If the user only has one name, last_name should be blank.
+        """
+        eoo = EdxOrgOAuth2(strategy=load_strategy())
+        result = eoo.get_user_details({
+            'id': 5,
+            'username': 'staff',
+            'email': 'staff@example.com',
+            'name': 'staff'
+        })
+
+        assert {
+            'edx_id': 'staff',
+            'username': 'staff',
+            'fullname': 'staff',
+            'email': 'staff@example.com',
+            'first_name': '',
+            'last_name': ''
+        } == result

--- a/backends/exceptions.py
+++ b/backends/exceptions.py
@@ -1,0 +1,10 @@
+"""
+Exceptions for backends app
+"""
+
+
+class InvalidCredentialStored(Exception):
+    """Custom exception to throw in some specific situations"""
+    def __init__(self, message, http_status_code):
+        super(InvalidCredentialStored, self).__init__(message)
+        self.http_status_code = http_status_code

--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -1,0 +1,25 @@
+"""
+APIs for extending the python social auth pipeline
+"""
+import logging
+from datetime import datetime
+
+import pytz
+
+
+log = logging.getLogger(__name__)
+
+
+def set_last_update(details, *args, **kwargs):  # pylint: disable=unused-argument
+    """
+    Pipeline function to add extra information about when the social auth
+    profile has been updated.
+
+    Args:
+        details (dict): dictionary of informations about the user
+
+    Returns:
+        dict: updated details dictionary
+    """
+    details['updated_at'] = datetime.now(tz=pytz.UTC).timestamp()
+    return details

--- a/backends/utils.py
+++ b/backends/utils.py
@@ -1,0 +1,46 @@
+"""
+Utility functions for the backends
+"""
+from datetime import datetime, timedelta
+import pytz
+
+from requests.exceptions import HTTPError
+from social_django.utils import load_strategy
+
+from backends.exceptions import InvalidCredentialStored
+
+
+def _send_refresh_request(user_social):
+    """
+    Private function that refresh an user access token
+    """
+    strategy = load_strategy()
+    try:
+        user_social.refresh_token(strategy)
+    except HTTPError as exc:
+        if exc.response.status_code in (400, 401,):
+            raise InvalidCredentialStored(
+                message='Received a {} status code from the OAUTH server'.format(
+                    exc.response.status_code),
+                http_status_code=exc.response.status_code
+            )
+        raise
+
+
+def refresh_user_token(user_social):
+    """
+    Utility function to refresh the access token if is (almost) expired
+
+    Args:
+        user_social (UserSocialAuth): a user social auth instance
+    """
+    try:
+        last_update = datetime.fromtimestamp(user_social.extra_data.get('updated_at'), tz=pytz.UTC)
+        expires_in = timedelta(seconds=user_social.extra_data.get('expires_in'))
+    except TypeError:
+        _send_refresh_request(user_social)
+        return
+    # small error margin of 5 minutes to be safe
+    error_margin = timedelta(minutes=5)
+    if datetime.now(tz=pytz.UTC) - last_update >= expires_in - error_margin:
+        _send_refresh_request(user_social)

--- a/backends/utils_test.py
+++ b/backends/utils_test.py
@@ -1,0 +1,123 @@
+"""
+Tests for the utils
+"""
+from datetime import datetime, timedelta
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
+import pytz
+from django.test import TestCase
+from requests.exceptions import HTTPError
+
+from backends import utils
+from backends.edxorg import EdxOrgOAuth2
+from bootcamp.factories import UserFactory
+# pylint: disable=protected-access
+
+
+class RefreshTest(TestCase):
+    """Class to test refresh token"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super(RefreshTest, cls).setUpTestData()
+        # create an user
+        cls.user = UserFactory.create()
+        # create a social auth for the user
+        cls.user.social_auth.create(
+            provider=EdxOrgOAuth2.name,
+            uid="{}_edx".format(cls.user.username),
+            extra_data={
+                "access_token": "fooooootoken",
+                "refresh_token": "baaaarrefresh",
+            }
+        )
+
+    def setUp(self):
+        super(RefreshTest, self).setUp()
+        self.now = datetime.now(pytz.utc)
+
+    def update_social_extra_data(self, data):
+        """Helper function to update the python social auth extra data"""
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
+        social_user.extra_data.update(data)
+        social_user.save()
+        return social_user
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh(self, mock_refresh):
+        """The refresh needs to be called"""
+        extra_data = {
+            "updated_at": (self.now - timedelta(weeks=1)).timestamp(),
+            "expires_in": 100  # seconds
+        }
+        social_user = self.update_social_extra_data(extra_data)
+        utils.refresh_user_token(social_user)
+        assert mock_refresh.called
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_no_extradata(self, mock_refresh):
+        """The refresh needs to be called because there is not valid timestamps"""
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
+        social_user.extra_data = {"access_token": "fooooootoken", "refresh_token": "baaaarrefresh"}
+        social_user.save()
+        utils.refresh_user_token(social_user)
+        assert mock_refresh.called
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_no_refresh(self, mock_refresh):
+        """The refresh does not need to be called"""
+        extra_data = {
+            "updated_at": (self.now - timedelta(minutes=1)).timestamp(),
+            "expires_in": 31535999  # 1 year - 1 second
+        }
+        social_user = self.update_social_extra_data(extra_data)
+        utils.refresh_user_token(social_user)
+        assert not mock_refresh.called
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_400_error_server(self, mock_refresh):
+        """Test to check what happens when the OAUTH server returns 400 code"""
+        def raise_http_error(*args, **kwargs):  # pylint: disable=unused-argument
+            """Mock function to raise an exception"""
+            error = HTTPError()
+            error.response = MagicMock()
+            error.response.status_code = 400
+            raise error
+
+        mock_refresh.side_effect = raise_http_error
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
+        with self.assertRaises(utils.InvalidCredentialStored):
+            utils._send_refresh_request(social_user)
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_401_error_server(self, mock_refresh):
+        """Test to check what happens when the OAUTH server returns 401 code"""
+        def raise_http_error(*args, **kwargs):  # pylint: disable=unused-argument
+            """Mock function to raise an exception"""
+            error = HTTPError()
+            error.response = MagicMock()
+            error.response.status_code = 401
+            raise error
+
+        mock_refresh.side_effect = raise_http_error
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
+        with self.assertRaises(utils.InvalidCredentialStored):
+            utils._send_refresh_request(social_user)
+
+    @patch('backends.edxorg.EdxOrgOAuth2.refresh_token', autospec=True)
+    def test_refresh_500_error_server(self, mock_refresh):
+        """Test to check what happens when the OAUTH server returns 500 code"""
+        def raise_http_error(*args, **kwargs):  # pylint: disable=unused-argument
+            """Mock function to raise an exception"""
+            error = HTTPError()
+            error.response = MagicMock()
+            error.response.status_code = 500
+            raise error
+
+        mock_refresh.side_effect = raise_http_error
+        social_user = self.user.social_auth.get(provider=EdxOrgOAuth2.name)
+        with self.assertRaises(HTTPError):
+            utils._send_refresh_request(social_user)

--- a/bootcamp/factories.py
+++ b/bootcamp/factories.py
@@ -1,0 +1,16 @@
+"""
+Factory for Users
+"""
+from django.contrib.auth.models import User
+from factory import Sequence
+from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyText
+
+
+class UserFactory(DjangoModelFactory):
+    """Factory for Users"""
+    username = Sequence(lambda n: "user_%d" % n)
+    email = FuzzyText(suffix='@example.com')
+
+    class Meta:
+        model = User

--- a/bootcamp/settings.py
+++ b/bootcamp/settings.py
@@ -108,7 +108,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework.authtoken',
     'server_status',
-    'social.apps.django_app.default',
+    'social_django',
 
     # other third party APPS
     'raven.contrib.django.raven_compat',
@@ -132,7 +132,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-    'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
 )
 
 # enable the nplusone profiler only in debug mode
@@ -156,18 +156,17 @@ EDXORG_BASE_URL = get_var('EDXORG_BASE_URL', 'https://courses.edx.org/')
 SOCIAL_AUTH_EDXORG_KEY = get_var('EDXORG_CLIENT_ID', '')
 SOCIAL_AUTH_EDXORG_SECRET = get_var('EDXORG_CLIENT_SECRET', '')
 SOCIAL_AUTH_PIPELINE = (
-    'social.pipeline.social_auth.social_details',
-    'social.pipeline.social_auth.social_uid',
-    'social.pipeline.social_auth.auth_allowed',
-    'social.pipeline.social_auth.social_user',
-    'social.pipeline.user.get_username',
-    'social.pipeline.user.create_user',
-    'social.pipeline.social_auth.associate_user',
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.auth_allowed',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.user.get_username',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
     # the following custom pipeline func goes before load_extra_data
     'backends.pipeline_api.set_last_update',
-    'social.pipeline.social_auth.load_extra_data',
-    'social.pipeline.user.user_details',
-    'backends.pipeline_api.update_profile_from_edx',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details',
 )
 SOCIAL_AUTH_EDXORG_AUTH_EXTRA_ARGUMENTS = {
     'access_type': 'offline',
@@ -175,7 +174,7 @@ SOCIAL_AUTH_EDXORG_AUTH_EXTRA_ARGUMENTS = {
 }
 SOCIAL_AUTH_EDXORG_EXTRA_DATA = ['updated_at']
 
-LOGIN_REDIRECT_URL = '/dashboard'
+LOGIN_REDIRECT_URL = '/redirect_url'
 LOGIN_URL = '/'
 LOGIN_ERROR_URL = '/'
 
@@ -194,8 +193,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'social.apps.django_app.context_processors.backends',
-                'social.apps.django_app.context_processors.login_redirect',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
         },
     },

--- a/bootcamp/urls.py
+++ b/bootcamp/urls.py
@@ -3,6 +3,7 @@ URLs for bootcamp
 """
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 
 from bootcamp.views import index
 
@@ -11,4 +12,6 @@ urlpatterns = [
     url(r'^$', index, name='bootcamp-index'),
     url(r'^status/', include('server_status.urls')),
     url(r'^admin/', include(admin.site.urls)),
+    url('', include('social_django.urls', namespace='social')),
+    url(r'^logout/$', auth_views.logout, {'next_page': '/'}),
 ]

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django==1.10.3
+Django==1.10.5
 PyYAML==3.11
 celery==3.1.23
 dj-database-url==0.3.0
@@ -15,9 +15,10 @@ ipython
 newrelic
 psycopg2==2.6
 python-dateutil
-python-social-auth==0.2.21
+pytz
 raven
 redis==2.10.5
 requests
+social-auth-app-django==1.1.0
 static3==0.5.1
 uwsgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,29 +6,29 @@
 #
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-appdirs==1.4.0            # via setuptools
+appdirs==1.4.3            # via setuptools
 billiard==3.3.0.23        # via celery
 celery==3.1.23
 contextlib2==0.5.4        # via raven
 decorator==4.0.11         # via ipython, traitlets
-defusedxml==0.5.0         # via python3-openid
+defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0
 django-server-status==0.3.2
 django-webpack-loader==0.4.1
-Django==1.10.3            # via django-server-status
+Django==1.10.5            # via django-server-status
 djangorestframework==3.5.2
 edx-api-client==0.3.0
-elasticsearch==2.3.0      # via django-server-status
+elasticsearch==5.2.0      # via django-server-status
 factory-boy==2.8.1
-faker==0.7.7
+faker==0.7.9
 html5lib==0.999999999
 ipython-genutils==0.1.0   # via traitlets
-ipython==5.2.2
+ipython==5.3.0
 kombu==3.0.37             # via celery, django-server-status
-newrelic==2.78.0.57
-oauthlib==2.0.1           # via python-social-auth, requests-oauthlib
+newrelic==2.80.1.61
+oauthlib==2.0.1           # via requests-oauthlib, social-auth-core
 packaging==16.8           # via setuptools
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
@@ -36,21 +36,22 @@ prompt-toolkit==1.0.13    # via ipython
 psycopg2==2.6
 ptyprocess==0.5.1         # via pexpect
 pygments==2.2.0           # via ipython
-pyjwt==1.4.2              # via python-social-auth
-pyparsing==2.1.10         # via packaging
+PyJWT==1.4.2              # via social-auth-core
+pyparsing==2.2.0          # via packaging
 python-dateutil==2.5.3
-python-social-auth==0.2.21
-python3-openid==3.0.10    # via python-social-auth
-pytz==2016.10             # via celery
+python3-openid==3.1.0     # via social-auth-core
+pytz==2016.10
 PyYAML==3.11
-raven==5.32.0
+raven==6.0.0
 redis==2.10.5
-requests-oauthlib==0.8.0  # via python-social-auth
+requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.11.1
 simplegeneric==0.8.1      # via ipython
-six==1.10.0               # via django-server-status, edx-api-client, faker, html5lib, packaging, prompt-toolkit, python-dateutil, python-social-auth, setuptools, traitlets
+six==1.10.0               # via django-server-status, edx-api-client, faker, html5lib, packaging, prompt-toolkit, python-dateutil, setuptools, social-auth-app-django, social-auth-core, traitlets
+social-auth-app-django==1.1.0
+social-auth-core==1.2.0   # via social-auth-app-django
 static3==0.5.1
-traitlets==4.3.1          # via ipython
+traitlets==4.3.2          # via ipython
 urllib3==1.20             # via elasticsearch
 uwsgi==2.0.14
 wcwidth==0.1.7            # via prompt-toolkit

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.1
+python-3.5.3


### PR DESCRIPTION
#### What are the relevant tickets?
closes #16 

#### What's this PR do?
Adds the "login with edX" functionality

It also changes the python back to 3.5 given the issues that 3.6 has with pylint

#### How should this be manually tested?
Configure an OAUTH app on edX.

1.  load the home page
2. go to `/login/edxorg` 

You should be redirected to `/redirect_url` that should return a 404 (we still not have a landing page.

#### Where should the reviewer start?
`bootcamp/settings.py`

#### Any background context you want to provide?
Python social auth library has been deprecated and split in multiple libraries, so here we use the new `social-auth-app-django` plus the `social-auth-core`.