### PR TITLE
Added payment view

### DIFF
--- a/bootcamp/settings.py
+++ b/bootcamp/settings.py
@@ -262,7 +262,6 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ],
-    'EXCEPTION_HANDLER': 'bootcamp.utils.custom_exception_handler'
 }
 
 # Request files from the webpack dev server

--- a/bootcamp/urls.py
+++ b/bootcamp/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     url(r'^pay/$', pay, name='pay'),
     url(r'^status/', include('server_status.urls')),
     url(r'^admin/', include(admin.site.urls)),
+    url('', include('ecommerce.urls')),
     url('', include('social_django.urls', namespace='social')),
     url(r'^logout/$', auth_views.logout, {'next_page': '/'}),
 ]

--- a/bootcamp/urls_test.py
+++ b/bootcamp/urls_test.py
@@ -1,0 +1,14 @@
+"""Tests for URLs"""
+from unittest import TestCase
+
+from django.core.urlresolvers import reverse
+
+
+class URLTests(TestCase):
+    """URL tests"""
+
+    def test_urls(self):
+        """Make sure URLs match with resolved names"""
+        assert reverse('bootcamp-index') == '/'
+        assert reverse('pay') == '/pay/'
+        assert reverse('create-payment') == '/api/v0/payment/'

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -2,16 +2,99 @@
 Functions for ecommerce
 """
 from base64 import b64encode
+from datetime import datetime
+from decimal import Decimal
 import hashlib
 import hmac
 import logging
+import uuid
 
 from django.conf import settings
+from django.db import transaction
+from django.db.models.aggregates import Sum
+import pytz
+from rest_framework.exceptions import ValidationError
+
+from backends.utils import get_social_username
+from ecommerce.models import (
+    Line,
+    Order,
+)
+from klasses.models import Klass
 
 
 ISO_8601_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 log = logging.getLogger(__name__)
 _REFERENCE_NUMBER_PREFIX = 'BOOTCAMP-'
+
+
+def get_total_paid(user, klass_id):
+    """
+    Get total paid for a klass for a user
+    Args:
+        user (User):
+            The purchaser of the klass
+        klass_id (int):
+            A klass id, a class within a bootcamp
+
+    Returns:
+        Decimal: The total amount paid by a user for a klass
+    """
+    return Line.objects.filter(
+        order__status=Order.FULFILLED,
+        order__user=user,
+        klass_id=klass_id,
+    ).aggregate(price=Sum('price'))['price'] or Decimal(0)
+
+
+@transaction.atomic
+def create_unfulfilled_order(user, klass_id, total):
+    """
+    Create a new Order which is not fulfilled for a klass.
+
+    Args:
+        user (User):
+            The purchaser of the klass
+        klass_id (int):
+            A klass id, a class within a bootcamp
+        total (Decimal): The payment of the user
+    Returns:
+        Order: A newly created Order for the klass
+    """
+    total = Decimal(total)
+    try:
+        klass = Klass.objects.get(klass_id=klass_id)
+    except Klass.DoesNotExist:
+        # In the near future we should do other checking here based on information from Bootcamp REST API
+        raise ValidationError("Incorrect klass id {}".format(klass_id))
+    if total <= 0:
+        raise ValidationError("Payment is less than or equal to zero")
+
+    already_paid = get_total_paid(user, klass_id)
+    if total + already_paid > klass.price:
+        raise ValidationError(
+            "Payment of ${total} plus already paid ${already_paid} for {klass} would be"
+            " greater than total price of ${klass_price}".format(
+                total=total,
+                klass=klass.title,
+                already_paid=already_paid,
+                klass_price=klass.price,
+            )
+        )
+
+    order = Order.objects.create(
+        status=Order.CREATED,
+        total_price_paid=total,
+        user=user,
+    )
+    Line.objects.create(
+        order=order,
+        klass_id=klass_id,
+        description='Installment for {}'.format(klass.title),
+        price=total,
+    )
+    order.save_and_log(user)
+    return order
 
 
 def generate_cybersource_sa_signature(payload):
@@ -35,6 +118,63 @@ def generate_cybersource_sa_signature(payload):
     ).digest()
 
     return b64encode(digest).decode('utf-8')
+
+
+def generate_cybersource_sa_payload(order, redirect_url):
+    """
+    Generates a payload dict to send to CyberSource for Secure Acceptance
+
+    Args:
+        order (Order): An order
+        redirect_url: (str): The URL to redirect to after order completion
+    Returns:
+        dict: the payload to send to CyberSource via Secure Acceptance
+    """
+    # http://apps.cybersource.com/library/documentation/dev_guides/Secure_Acceptance_WM/Secure_Acceptance_WM.pdf
+    # Section: API Fields
+
+    # Course key is used only to show the confirmation message to the user
+    klass_id = None
+    line = order.line_set.first()
+    if line is not None:
+        klass_id = line.klass_id
+    klass = Klass.objects.get(klass_id=klass_id)
+
+    # NOTE: be careful about max length here, many (all?) string fields have a max
+    # length of 255. At the moment none of these fields should go over that, due to database
+    # constraints or other reasons
+
+    payload = {
+        'access_key': settings.CYBERSOURCE_ACCESS_KEY,
+        'amount': str(order.total_price_paid),
+        'consumer_id': get_social_username(order.user),
+        'currency': 'USD',
+        'locale': 'en-us',
+        'item_0_code': 'klass',
+        'item_0_name': '{}'.format(klass.title),
+        'item_0_quantity': 1,
+        'item_0_sku': '{}'.format(klass_id),
+        'item_0_tax_amount': '0',
+        'item_0_unit_price': str(order.total_price_paid),
+        'line_item_count': 1,
+        'override_custom_cancel_page': redirect_url,
+        'override_custom_receipt_page': redirect_url,
+        'reference_number': make_reference_id(order),
+        'profile_id': settings.CYBERSOURCE_PROFILE_ID,
+        'signed_date_time': datetime.now(tz=pytz.UTC).strftime(ISO_8601_FORMAT),
+        'transaction_type': 'sale',
+        'transaction_uuid': uuid.uuid4().hex,
+        'unsigned_field_names': '',
+        'merchant_defined_data1': 'klass',
+        'merchant_defined_data2': '{}'.format(klass.title),
+        'merchant_defined_data3': '{}'.format(klass_id),
+    }
+
+    field_names = sorted(list(payload.keys()) + ['signed_field_names'])
+    payload['signed_field_names'] = ','.join(field_names)
+    payload['signature'] = generate_cybersource_sa_signature(payload)
+
+    return payload
 
 
 def make_reference_id(order):

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -133,7 +133,6 @@ def generate_cybersource_sa_payload(order, redirect_url):
     # http://apps.cybersource.com/library/documentation/dev_guides/Secure_Acceptance_WM/Secure_Acceptance_WM.pdf
     # Section: API Fields
 
-    # Course key is used only to show the confirmation message to the user
     klass_id = None
     line = order.line_set.first()
     if line is not None:

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -101,7 +101,7 @@ class PurchasableTests(TestCase):
 
     def test_create_order(self):  # pylint: disable=too-many-locals
         """
-        Create Order from a purchasable course
+        Create Order from a purchasable klass
         """
         payment = 123
         order = create_unfulfilled_order(self.user, self.klass.klass_id, payment)

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -2,19 +2,182 @@
 Test for ecommerce functions
 """
 from base64 import b64encode
+from datetime import datetime
 import hashlib
 import hmac
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 
+import ddt
 from django.test import (
     override_settings,
     TestCase,
 )
+import pytz
+from rest_framework.exceptions import ValidationError
 
+from backends.pipeline_api import EdxOrgOAuth2
 from ecommerce.api import (
+    create_unfulfilled_order,
+    generate_cybersource_sa_payload,
     generate_cybersource_sa_signature,
+    get_total_paid,
+    ISO_8601_FORMAT,
     make_reference_id,
 )
-from ecommerce.factories import OrderFactory
+from ecommerce.factories import LineFactory
+from ecommerce.models import (
+    Order,
+    OrderAudit,
+)
+from klasses.factories import InstallmentFactory
+from profiles.factories import UserFactory
+
+
+def create_purchasable_klass():
+    """
+    Creates a purchasable klass and an associated user. Klass price is at least $200, in two installments
+    """
+    installment_1 = InstallmentFactory.create(amount=200)
+    InstallmentFactory.create(klass=installment_1.klass)
+    user = UserFactory.create()
+    user.social_auth.create(
+        provider=EdxOrgOAuth2.name,
+        uid="{}_edx".format(user.username),
+    )
+    return installment_1.klass, user
+
+
+@ddt.ddt
+class PurchasableTests(TestCase):
+    """
+    Tests for create_unfulfilled_order
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.klass, cls.user = create_purchasable_klass()
+
+    def test_too_much(self):
+        """
+        An order cannot exceed the total amount for the klass
+        """
+        LineFactory.create(
+            order__status=Order.FULFILLED,
+            order__user=self.user,
+            klass_id=self.klass.klass_id,
+            order__total_price_paid=self.klass.price - 10
+        )
+
+        with self.assertRaises(ValidationError) as ex:
+            # payment is $15 here but there is only $10 left to pay
+            total = 15
+            create_unfulfilled_order(self.user, self.klass.klass_id, total)
+
+        message = (
+            "Payment of ${total} plus already paid ${already_paid} for {klass} would be"
+            " greater than total price of ${klass_price}".format(
+                total=total,
+                already_paid=self.klass.price - 10,
+                klass=self.klass.title,
+                klass_price=self.klass.price,
+            )
+        )
+        assert ex.exception.args[0] == message
+
+    @ddt.data(0, -1.23)
+    def test_less_or_equal_to_zero(self, total):
+        """
+        An order may not have a negative or zero price
+        """
+        with self.assertRaises(ValidationError) as ex:
+            create_unfulfilled_order(self.user, self.klass.klass_id, total)
+
+        assert ex.exception.args[0] == 'Payment is less than or equal to zero'
+
+    def test_create_order(self):  # pylint: disable=too-many-locals
+        """
+        Create Order from a purchasable course
+        """
+        payment = 123
+        order = create_unfulfilled_order(self.user, self.klass.klass_id, payment)
+
+        assert Order.objects.count() == 1
+        assert order.status == Order.CREATED
+        assert order.total_price_paid == payment
+        assert order.user == self.user
+
+        assert order.line_set.count() == 1
+        line = order.line_set.first()
+        assert line.klass_id == self.klass.klass_id
+        assert line.description == 'Installment for {}'.format(self.klass.title)
+        assert line.price == payment
+
+        assert OrderAudit.objects.count() == 1
+        order_audit = OrderAudit.objects.first()
+        assert order_audit.order == order
+        assert order_audit.data_after == order.to_dict()
+
+        # data_before only has modified_at different, since we only call save_and_log
+        # after Order is already created
+        data_before = order_audit.data_before
+        dict_before = order.to_dict()
+        del data_before['updated_on']
+        del dict_before['updated_on']
+        assert data_before == dict_before
+
+
+class GetPaidTests(TestCase):
+    """Tests for get_total_paid"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.klass, cls.user = create_purchasable_klass()
+        cls.payment = 123
+        order = create_unfulfilled_order(cls.user, cls.klass.klass_id, cls.payment)
+        order.status = Order.FULFILLED
+        order.save()
+
+    def test_multiple_payments(self):
+        """
+        get_total_paid should look through all fulfilled orders for the payment for a particular user
+        """
+        # Multiple payments should be added together
+        next_payment = 50
+        order = create_unfulfilled_order(self.user, self.klass.klass_id, next_payment)
+        order.status = Order.FULFILLED
+        order.save()
+        assert get_total_paid(self.user, self.klass.klass_id) == self.payment + next_payment
+
+    def test_other_user(self):
+        """other_user's payments shouldn't affect user"""
+        other_user = UserFactory.create()
+        assert get_total_paid(other_user, self.klass.klass_id) == 0
+
+    def test_skip_unfulfilled(self):
+        """Unfulfilled orders should be ignored"""
+        create_unfulfilled_order(self.user, self.klass.klass_id, 45)
+        assert get_total_paid(self.user, self.klass.klass_id) == self.payment
+
+    def test_skip_other_klass(self):
+        """Orders for other klasses should be ignored"""
+        other_klass, other_user = create_purchasable_klass()
+        other_order = create_unfulfilled_order(other_user, other_klass.klass_id, 50)
+        other_order.status = Order.FULFILLED
+        other_order.save()
+
+        assert get_total_paid(self.user, self.klass.klass_id) == self.payment
+
+    def test_no_payments(self):
+        """If there are no payments get_total_paid should return 0"""
+        Order.objects.all().update(status=Order.REFUNDED)
+        assert get_total_paid(self.user, self.klass.klass_id) == 0
 
 
 CYBERSOURCE_ACCESS_KEY = 'access'
@@ -30,7 +193,7 @@ CYBERSOURCE_REFERENCE_PREFIX = 'prefix'
 )
 class CybersourceTests(TestCase):
     """
-    Tests for generate_cybersource_sa_signature
+    Tests for generate_cybersource_sa_payload and generate_cybersource_sa_signature
     """
     def test_valid_signature(self):
         """
@@ -54,6 +217,56 @@ class CybersourceTests(TestCase):
 
         assert b64encode(digest).decode('utf-8') == signature
 
+    def test_signed_payload(self):
+        """
+        A valid payload should be signed appropriately
+        """
+        klass, user = create_purchasable_klass()
+        payment = 123.45
+        order = create_unfulfilled_order(user, klass.klass_id, payment)
+        username = 'username'
+        transaction_uuid = 'hex'
+
+        now = datetime.now(tz=pytz.UTC)
+        now_mock = MagicMock(return_value=now)
+
+        with patch('ecommerce.api.get_social_username', autospec=True, return_value=username):
+            with patch('ecommerce.api.datetime', autospec=True, now=now_mock):
+                with patch('ecommerce.api.uuid.uuid4', autospec=True, return_value=MagicMock(hex=transaction_uuid)):
+                    payload = generate_cybersource_sa_payload(order, 'dashboard_url')
+        signature = payload.pop('signature')
+        assert generate_cybersource_sa_signature(payload) == signature
+        signed_field_names = payload['signed_field_names'].split(',')
+        assert signed_field_names == sorted(payload.keys())
+
+        assert payload == {
+            'access_key': CYBERSOURCE_ACCESS_KEY,
+            'amount': str(order.total_price_paid),
+            'consumer_id': username,
+            'currency': 'USD',
+            'item_0_code': 'klass',
+            'item_0_name': '{}'.format(klass.title),
+            'item_0_quantity': 1,
+            'item_0_sku': '{}'.format(klass.klass_id),
+            'item_0_tax_amount': '0',
+            'item_0_unit_price': str(order.total_price_paid),
+            'line_item_count': 1,
+            'locale': 'en-us',
+            'override_custom_cancel_page': 'dashboard_url',
+            'override_custom_receipt_page': 'dashboard_url',
+            'reference_number': make_reference_id(order),
+            'profile_id': CYBERSOURCE_PROFILE_ID,
+            'signed_date_time': now.strftime(ISO_8601_FORMAT),
+            'signed_field_names': ','.join(signed_field_names),
+            'transaction_type': 'sale',
+            'transaction_uuid': transaction_uuid,
+            'unsigned_field_names': '',
+            'merchant_defined_data1': 'klass',
+            'merchant_defined_data2': '{}'.format(klass.title),
+            'merchant_defined_data3': '{}'.format(klass.klass_id),
+        }
+        now_mock.assert_called_with(tz=pytz.UTC)
+
 
 @override_settings(CYBERSOURCE_REFERENCE_PREFIX=CYBERSOURCE_REFERENCE_PREFIX)
 class ReferenceNumberTests(TestCase):
@@ -65,5 +278,6 @@ class ReferenceNumberTests(TestCase):
         """
         make_reference_id should concatenate the reference prefix and the order id
         """
-        order = OrderFactory.create()
+        klass, user = create_purchasable_klass()
+        order = create_unfulfilled_order(user, klass.klass_id, 123)
         assert "BOOTCAMP-{}-{}".format(CYBERSOURCE_REFERENCE_PREFIX, order.id) == make_reference_id(order)

--- a/ecommerce/constants.py
+++ b/ecommerce/constants.py
@@ -1,0 +1,9 @@
+"""Ecommerce constants"""
+
+# From secure acceptance documentation, under API reply fields:
+# http://apps.cybersource.com/library/documentation/dev_guides/Secure_Acceptance_SOP/Secure_Acceptance_SOP.pdf
+CYBERSOURCE_DECISION_ACCEPT = 'ACCEPT'
+CYBERSOURCE_DECISION_DECLINE = 'DECLINE'
+CYBERSOURCE_DECISION_REVIEW = 'REVIEW'
+CYBERSOURCE_DECISION_ERROR = 'ERROR'
+CYBERSOURCE_DECISION_CANCEL = 'CANCEL'

--- a/ecommerce/exceptions.py
+++ b/ecommerce/exceptions.py
@@ -1,0 +1,27 @@
+"""
+Exceptions for ecommerce
+"""
+
+
+class EcommerceException(Exception):
+    """
+    General exception regarding ecommerce
+    """
+
+
+class EcommerceEdxApiException(Exception):
+    """
+    Exception regarding edx_api_client
+    """
+
+
+class EcommerceModelException(Exception):
+    """
+    Exception regarding ecommerce models
+    """
+
+
+class ParseException(Exception):
+    """
+    Exception regarding parsing CyberSource reference numbers
+    """

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -1,0 +1,14 @@
+"""Serializers for ecommerce"""
+from rest_framework.serializers import (
+    DecimalField,
+    IntegerField,
+    Serializer,
+)
+
+
+class PaymentSerializer(Serializer):
+    """
+    Serializer for payment API, used to do basic validation.
+    """
+    total = DecimalField(max_digits=20, decimal_places=2, min_value=0.01)
+    klass_id = IntegerField()

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -1,0 +1,28 @@
+"""Tests for serializers"""
+from unittest import TestCase
+
+from ddt import (
+    data,
+    ddt,
+    unpack,
+)
+
+from ecommerce.serializers import PaymentSerializer
+
+
+@ddt
+class PaymentSerializersTests(TestCase):
+    """Tests for payment serializers"""
+
+    @data(
+        [{"total": "345", "klass_id": 3}, True],
+        [{"total": "-3", "klass_id": 3}, False],
+        [{"total": "345"}, False],
+        [{"klass_id": "345"}, False],
+    )
+    @unpack
+    def test_validation(self, payload, is_valid):
+        """
+        Assert that validation is turned on for the things we care about
+        """
+        assert is_valid == PaymentSerializer(data=payload).is_valid()

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -1,0 +1,13 @@
+"""
+URLs for bootcamp
+"""
+from django.conf.urls import url
+
+from ecommerce.views import (
+    PaymentView,
+)
+
+
+urlpatterns = [
+    url(r'^api/v0/payment/$', PaymentView.as_view(), name='create-payment'),
+]

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -1,0 +1,40 @@
+"""Views for ecommerce"""
+from decimal import Decimal
+
+from django.conf import settings
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.generics import CreateAPIView
+
+from ecommerce.api import (
+    create_unfulfilled_order,
+    generate_cybersource_sa_payload,
+)
+from ecommerce.serializers import PaymentSerializer
+
+
+class PaymentView(CreateAPIView):
+    """
+    View for payment API. This creates an Order in our system and provides a dictionary to send to Cybersource.
+    """
+    authentication_classes = (SessionAuthentication,)
+    permission_classes = (IsAuthenticated,)
+    serializer_class = PaymentSerializer
+
+    def post(self, request, *args, **kwargs):
+        """
+        Create an unfulfilled order and return a response for it.
+        """
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        total = Decimal(serializer.data['total'])
+        klass_id = serializer.data['klass_id']
+
+        order = create_unfulfilled_order(self.request.user, klass_id, total)
+        redirect_url = self.request.build_absolute_uri('/')
+
+        return Response({
+            'payload': generate_cybersource_sa_payload(order, redirect_url),
+            'url': settings.CYBERSOURCE_SECURE_ACCEPTANCE_URL,
+        })

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -2,6 +2,7 @@
 from decimal import Decimal
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -32,7 +33,7 @@ class PaymentView(CreateAPIView):
         klass_id = serializer.data['klass_id']
 
         order = create_unfulfilled_order(self.request.user, klass_id, total)
-        redirect_url = self.request.build_absolute_uri('/')
+        redirect_url = self.request.build_absolute_uri(reverse('bootcamp-index'))
 
         return Response({
             'payload': generate_cybersource_sa_payload(order, redirect_url),

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -1,0 +1,81 @@
+"""Tests for ecommerce views"""
+from unittest.mock import patch
+
+from django.core.urlresolvers import (
+    resolve,
+    reverse,
+)
+from django.test import (
+    override_settings,
+    TestCase,
+)
+from rest_framework import status as statuses
+
+from ecommerce.api_test import create_purchasable_klass
+from ecommerce.serializers import PaymentSerializer
+from profiles.factories import UserFactory
+
+
+CYBERSOURCE_SECURITY_KEY = '🔑'
+CYBERSOURCE_SECURE_ACCEPTANCE_URL = 'http://fake'
+CYBERSOURCE_REFERENCE_PREFIX = 'fake'
+
+
+class PaymentTests(TestCase):
+    """Tests for payment API"""
+
+    def test_using_serializer_validation(self):
+        """
+        The view should use the serializer for validation
+        """
+        payment_url = reverse('create-payment')
+        assert resolve(payment_url).func.view_class.serializer_class is PaymentSerializer
+
+        # Make sure we haven't overridden something which would skip validation
+        user = UserFactory.create()
+        self.client.force_login(user)
+        resp = self.client.post(payment_url, data={
+            "total": "-1",
+            "klass_id": 3,
+        })
+        assert resp.status_code == statuses.HTTP_400_BAD_REQUEST
+        assert resp.json() == {
+            "total": ["Ensure this value is greater than or equal to 0.01."]
+        }
+
+    def test_login_required(self):
+        """Anonymous users are forbidden"""
+        resp = self.client.post(reverse('create-payment'), data={})
+        assert resp.status_code == statuses.HTTP_403_FORBIDDEN
+
+    @override_settings(
+        CYBERSOURCE_SECURITY_KEY=CYBERSOURCE_SECURITY_KEY,
+        CYBERSOURCE_SECURE_ACCEPTANCE_URL=CYBERSOURCE_SECURE_ACCEPTANCE_URL,
+        CYBERSOURCE_REFERENCE_PREFIX=CYBERSOURCE_REFERENCE_PREFIX,
+    )
+    def test_payment(self):
+        """
+        If a user POSTs to the payment API an unfulfilled order should be created
+        """
+        klass, user = create_purchasable_klass()
+        self.client.force_login(user)
+        fake_payload = "fake_payload"
+        fake_order = 'fake_order'
+        with patch(
+            'ecommerce.views.generate_cybersource_sa_payload', autospec=True, return_value=fake_payload
+        ) as generate_cybersource_sa_payload_mock, patch(
+            'ecommerce.views.create_unfulfilled_order', autospec=True, return_value=fake_order
+        ) as create_unfulfilled_order_mock:
+            resp = self.client.post(reverse('create-payment'), data={
+                "total": klass.price,
+                "klass_id": klass.klass_id,
+            })
+        assert resp.status_code == statuses.HTTP_200_OK
+        assert resp.json() == {
+            'payload': fake_payload,
+            'url': CYBERSOURCE_SECURE_ACCEPTANCE_URL,
+        }
+        assert generate_cybersource_sa_payload_mock.call_count == 1
+        generate_cybersource_sa_payload_mock.assert_any_call(fake_order, "http://testserver/")
+        assert create_unfulfilled_order_mock.call_count == 1
+        create_unfulfilled_order_mock.assert_any_call(user, klass.klass_id, klass.price)

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -4,6 +4,9 @@ import { createAction } from 'redux-actions';
 export const SET_TOTAL = 'SET_TOTAL';
 export const setTotal = createAction(SET_TOTAL);
 
+export const SET_KLASS_ID = 'SET_KLASS_ID';
+export const setKlassId = createAction(SET_KLASS_ID);
+
 export const FETCH_PROCESSING = 'FETCH_PROCESSING';
 export const FETCH_SUCCESS = 'FETCH_SUCCESS';
 export const FETCH_FAILURE = 'FETCH_FAILURE';

--- a/static/js/actions/index_test.js
+++ b/static/js/actions/index_test.js
@@ -1,8 +1,10 @@
 import { assertCreatedActionHelper } from './test_util';
 
 import {
+  setKlassId,
   setTotal,
 
+  SET_KLASS_ID,
   SET_TOTAL,
 } from './index';
 
@@ -10,6 +12,7 @@ describe('actions', () => {
   it('should create all action creators', () => {
     [
       [setTotal, SET_TOTAL],
+      [setKlassId, SET_KLASS_ID],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/containers/Payment.js
+++ b/static/js/containers/Payment.js
@@ -8,10 +8,12 @@ import type {
   UIState,
 } from '../reducers';
 import {
+  setKlassId,
   setTotal,
 } from '../actions';
 import { actions } from '../rest';
 import type { RestState } from '../rest';
+import { createForm } from '../util/util';
 
 class Payment extends React.Component {
   props: {
@@ -21,8 +23,14 @@ class Payment extends React.Component {
   };
 
   sendPayment = () => {
-    const { dispatch, ui: { total } } = this.props;
-    dispatch(actions.payment(total));
+    const { dispatch, ui: { total, klassId } } = this.props;
+    dispatch(actions.payment(total, klassId)).then(result => {
+      const { url, payload } = result;
+      const form = createForm(url, payload);
+      const body = document.querySelector("body");
+      body.appendChild(form);
+      form.submit();
+    });
   };
 
   setTotal = (event) => {
@@ -30,9 +38,14 @@ class Payment extends React.Component {
     dispatch(setTotal(event.target.value));
   };
 
+  setKlassId = event => {
+    const { dispatch } = this.props;
+    dispatch(setKlassId(event.target.value));
+  };
+
   render() {
     const {
-      ui: { total },
+      ui: { total, klassId },
       payment: { processing },
     } = this.props;
 
@@ -44,6 +57,10 @@ class Payment extends React.Component {
         <span>Make a payment of:</span>
         <span>
           $<input type="number" id="total" value={total} onChange={this.setTotal} />
+        </span>
+        For klass id:
+        <span>
+          <input type="number" value={klassId} onChange={this.setKlassId} />
         </span>
         <button className="payment-button" onClick={this.sendPayment} disabled={processing}>
           Pay

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -1,19 +1,23 @@
 // @flow
 import { combineReducers } from 'redux';
 
-import { SET_TOTAL } from '../actions';
+import { SET_KLASS_ID, SET_TOTAL } from '../actions';
 import type { Action } from '../flow/reduxTypes';
 import { reducers as restReducers } from '../rest';
 
 export type UIState = {
   total: string,
+  klassId: string,
 };
 const INITIAL_UI_STATE = {
-  total: ''
+  total: '',
+  klassId: '',
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   switch (action.type) {
+  case SET_KLASS_ID:
+    return { ...state, klassId: action.payload };
   case SET_TOTAL:
     return { ...state, total: action.payload };
   default:

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -1,15 +1,20 @@
-import { assert } from 'chai';
 import configureTestStore from 'redux-asserts';
 import sinon from 'sinon';
 
-import { setTotal } from '../actions';
+import {
+  setKlassId,
+  setTotal,
+} from '../actions';
 import rootReducer from '../reducers';
+import { createAssertReducerResultState } from '../util/test_utils';
+
 
 describe('reducers', () => {
-  let sandbox, store;
+  let sandbox, store, assertReducerResultState;
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     store = configureTestStore(rootReducer);
+    assertReducerResultState = createAssertReducerResultState(store, state => state.ui);
   });
 
   afterEach(() => {
@@ -18,9 +23,11 @@ describe('reducers', () => {
 
   describe('ui', () => {
     it('should set the total price', () => {
-      assert.equal(store.getState().ui.total, '');
-      store.dispatch(setTotal("price"));
-      assert.equal(store.getState().ui.total, "price");
+      assertReducerResultState(setTotal, ui => ui.total, '');
+    });
+
+    it('should set the klass id', () => {
+      assertReducerResultState(setKlassId, ui => ui.klassId, '');
     });
   });
 

--- a/static/js/rest.js
+++ b/static/js/rest.js
@@ -89,10 +89,10 @@ export const makeAction = (endpoint: Endpoint): ((...params: any) => Dispatcher<
       dispatch(requestAction());
       return fetchFunc(...params).then(data => {
         dispatch(receiveSuccessAction(data));
-        return Promise.resolve();
+        return Promise.resolve(data);
       }).catch(error => {
         dispatch(receiveFailureAction(error));
-        return Promise.reject();
+        return Promise.reject(error);
       });
     };
   };
@@ -102,10 +102,11 @@ export const endpoints: Array<Endpoint> = [
   {
     name: 'payment',
     url: '/api/v0/payment/',
-    makeOptions: total => ({
+    makeOptions: (total, klassId) => ({
       method: 'POST',
       body: JSON.stringify({
         total: total,
+        klass_id: klassId,
       })
     }),
   },

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -1,0 +1,18 @@
+import { assert } from 'chai';
+import type { Store } from 'redux';
+
+import type { Action } from '../flow/reduxTypes';
+
+export function createAssertReducerResultState<State>(store: Store, getReducerState: (x: any) => State) {
+  return (
+    action: () => Action<*,*>, stateLookup: (state: State) => any, defaultValue: any
+  ): void => {
+    const getState = () => stateLookup(getReducerState(store.getState()));
+
+    assert.deepEqual(defaultValue, getState());
+    for (let value of [true, null, false, 0, 3, 'x', {'a': 'b'}, {}, [3, 4, 5], [], '']) {
+      store.dispatch(action(value));
+      assert.deepEqual(value, getState());
+    }
+  };
+}

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -1,0 +1,23 @@
+// @flow
+
+/**
+ * Creates a POST form with hidden input fields
+ * @param url the url for the form action
+ * @param payload Each key value pair will become an input field
+ */
+export function createForm(url: string, payload: Object): HTMLFormElement {
+  const form = document.createElement("form");
+  form.setAttribute("action", url);
+  form.setAttribute("method", "post");
+  form.setAttribute("class", "cybersource-payload");
+
+  for (let key: string of Object.keys(payload)) {
+    const value = payload[key];
+    const input = document.createElement("input");
+    input.setAttribute("name", key);
+    input.setAttribute("value", value);
+    input.setAttribute("type", "hidden");
+    form.appendChild(input);
+  }
+  return form;
+}

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -1,0 +1,25 @@
+import { assert } from 'chai';
+
+import { createForm } from './util';
+
+describe('util', () => {
+  describe('createForm', () => {
+    it('creates a form with hidden values corresponding to the payload', () => {
+      const url = 'url';
+      const payload = {'pay': 'load'};
+      const form = createForm(url, payload);
+
+      let clone = {...payload};
+      for (let hidden of form.querySelectorAll("input[type=hidden]")) {
+        const key = hidden.getAttribute('name');
+        const value = hidden.getAttribute('value');
+        assert.equal(clone[key], value);
+        delete clone[key];
+      }
+      // all keys exhausted
+      assert.deepEqual(clone, {});
+      assert.equal(form.getAttribute("action"), url);
+      assert.equal(form.getAttribute("method"), "post");
+    });
+  });
+});


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #4 

#### What's this PR do?
Adds a view for the payment and tweaks the skeleton UI to make use of it. This view creates an unfulfilled `Order` and returns a form which is submitted to CyberSource. This PR does not include the order fulfillment view, that will be in the next PR.

#### How should this be manually tested?
Create a `Installment` with related a `Klass` and `Bootcamp`. Then log in and type in the klass id into the textbox (this is `klass.klass_id`, not `klass.id`) and a total. Click 'Pay' and you should be directed to an error page on Cybersource. If you go into the database you should see an `Order` that has status `CREATED` and a `Line` which has the `klass_id` you typed in.