### PR TITLE
Implement Order fulfillment

### DIFF
--- a/bootcamp/settings.py
+++ b/bootcamp/settings.py
@@ -117,6 +117,7 @@ INSTALLED_APPS = (
     'backends',
     'bootcamp',
     'ecommerce',
+    'mail',
     'klasses',
     'profiles',
 )

--- a/bootcamp/urls_test.py
+++ b/bootcamp/urls_test.py
@@ -12,3 +12,4 @@ class URLTests(TestCase):
         assert reverse('bootcamp-index') == '/'
         assert reverse('pay') == '/pay/'
         assert reverse('create-payment') == '/api/v0/payment/'
+        assert reverse('order-fulfillment') == '/api/v0/order_fulfillment/'

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -16,6 +16,10 @@ import pytz
 from rest_framework.exceptions import ValidationError
 
 from backends.utils import get_social_username
+from ecommerce.exceptions import (
+    EcommerceException,
+    ParseException,
+)
 from ecommerce.models import (
     Line,
     Order,
@@ -174,6 +178,42 @@ def generate_cybersource_sa_payload(order, redirect_url):
     payload['signature'] = generate_cybersource_sa_signature(payload)
 
     return payload
+
+
+def get_new_order_by_reference_number(reference_number):
+    """
+    Parse a reference number received from CyberSource and lookup the corresponding Order.
+
+    Args:
+        reference_number (str):
+            A string which contains the order id and the instance which generated it
+    Returns:
+        Order:
+            An order
+    """
+    if not reference_number.startswith(_REFERENCE_NUMBER_PREFIX):
+        raise ParseException("Reference number must start with {}".format(_REFERENCE_NUMBER_PREFIX))
+    reference_number = reference_number[len(_REFERENCE_NUMBER_PREFIX):]
+
+    try:
+        order_id_pos = reference_number.rindex('-')
+    except ValueError:
+        raise ParseException("Unable to find order number in reference number")
+
+    try:
+        order_id = int(reference_number[order_id_pos + 1:])
+    except ValueError:
+        raise ParseException("Unable to parse order number")
+
+    prefix = reference_number[:order_id_pos]
+    if prefix != settings.CYBERSOURCE_REFERENCE_PREFIX:
+        log.error("CyberSource prefix doesn't match: %s != %s", prefix, settings.CYBERSOURCE_REFERENCE_PREFIX)
+        raise ParseException("CyberSource prefix doesn't match")
+
+    try:
+        return Order.objects.get(id=order_id)
+    except Order.DoesNotExist:
+        raise EcommerceException("Unable to find order {}".format(order_id))
 
 
 def make_reference_id(order):

--- a/ecommerce/permissions.py
+++ b/ecommerce/permissions.py
@@ -1,0 +1,33 @@
+"""
+Permission classes for ecommerce
+"""
+import logging
+
+from rest_framework.permissions import BasePermission
+
+from ecommerce.api import generate_cybersource_sa_signature
+
+
+log = logging.getLogger(__name__)
+
+
+class IsSignedByCyberSource(BasePermission):
+    """
+    Confirms that the message is signed by CyberSource
+    """
+
+    def has_permission(self, request, view):
+        """
+        Returns true if request params are signed by CyberSource
+        """
+        signature = generate_cybersource_sa_signature(request.data)
+        if request.data['signature'] == signature:
+            return True
+        else:
+            log.error(
+                "Cybersource signature failed: we expected %s but we got %s. Payload: %s",
+                signature,
+                request.data['signature'],
+                request.data,
+            )
+            return False

--- a/ecommerce/permissions_test.py
+++ b/ecommerce/permissions_test.py
@@ -1,0 +1,51 @@
+"""
+Tests for ecommerce permissions
+"""
+from unittest.mock import MagicMock
+
+from django.test import (
+    override_settings,
+    TestCase,
+)
+
+from ecommerce.api import generate_cybersource_sa_signature
+from ecommerce.permissions import IsSignedByCyberSource
+
+
+@override_settings(CYBERSOURCE_SECURITY_KEY="fake")
+class PermissionsTests(TestCase):
+    """
+    Tests for ecommerce permissions
+    """
+
+    def test_has_signature(self):
+        """
+        If the payload has a valid signature, it should pass the permissions test
+        """
+        payload = {
+            'a': 'b',
+            'c': 'd',
+            'e': 'f',
+        }
+        keys = sorted(payload.keys())
+        payload['signed_field_names'] = ','.join(keys)
+        payload['signature'] = generate_cybersource_sa_signature(payload)
+
+        request = MagicMock(data=payload)
+        assert IsSignedByCyberSource().has_permission(request, MagicMock()) is True
+
+    def test_has_wrong_signature(self):
+        """
+        If the payload has an invalid signature, it should fail the permissions test
+        """
+        payload = {
+            'a': 'b',
+            'c': 'd',
+            'e': 'f',
+        }
+        keys = sorted(payload.keys())
+        payload['signed_field_names'] = ','.join(keys)
+        payload['signature'] = 'signed'
+
+        request = MagicMock(data=payload)
+        assert IsSignedByCyberSource().has_permission(request, MagicMock()) is False

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -4,10 +4,12 @@ URLs for bootcamp
 from django.conf.urls import url
 
 from ecommerce.views import (
+    OrderFulfillmentView,
     PaymentView,
 )
 
 
 urlpatterns = [
     url(r'^api/v0/payment/$', PaymentView.as_view(), name='create-payment'),
+    url(r'^api/v0/order_fulfillment/$', OrderFulfillmentView.as_view(), name='order-fulfillment'),
 ]

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -114,7 +114,7 @@ class OrderFulfillmentView(APIView):
                     )
         else:
             order.status = Order.FULFILLED
-        order.save_and_log(None)
+        order.save_and_log(acting_user=None)
 
         # The response does not matter to CyberSource
         return Response(status=statuses.HTTP_200_OK)

--- a/mail/api.py
+++ b/mail/api.py
@@ -1,0 +1,187 @@
+"""
+Provides functions for sending and retrieving data about in-app email
+"""
+import logging
+from itertools import islice
+import json
+import requests
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework import status
+
+from mail.exceptions import SendBatchException
+
+
+log = logging.getLogger(__name__)
+
+
+class MailgunClient:
+    """
+    Provides functions for communicating with the Mailgun REST API.
+    """
+    _basic_auth_credentials = ('api', settings.MAILGUN_KEY)
+
+    @staticmethod
+    def default_params():
+        """
+        Default params for Mailgun request. This a method instead of an attribute to allow for the
+        overriding of settings values.
+
+        Returns:
+            dict: A dict of default parameters for the Mailgun API
+        """
+        return {'from': settings.EMAIL_SUPPORT}
+
+    @classmethod
+    def _mailgun_request(  # pylint: disable=too-many-arguments
+            cls, request_func, endpoint, params, sender_name=None, raise_for_status=True
+    ):
+        """
+        Sends a request to the Mailgun API
+
+        Args:
+            request_func (function): requests library HTTP function (get/post/etc.)
+            endpoint (str): Mailgun endpoint (eg: 'messages', 'events')
+            params (dict): Dict of params to add to the request as 'data'
+            raise_for_status (bool): If true, check the status and raise for non-2xx statuses
+        Returns:
+            requests.Response: HTTP response
+        """
+        mailgun_url = '{}/{}'.format(settings.MAILGUN_URL, endpoint)
+        email_params = cls.default_params()
+        email_params.update(params)
+        # Update 'from' address if sender_name was specified
+        if sender_name is not None:
+            email_params['from'] = "{sender_name} <{email}>".format(
+                sender_name=sender_name,
+                email=email_params['from']
+            )
+        response = request_func(
+            mailgun_url,
+            auth=cls._basic_auth_credentials,
+            data=email_params
+        )
+        if response.status_code == status.HTTP_401_UNAUTHORIZED:
+            message = "Mailgun API keys not properly configured."
+            log.error(message)
+            raise ImproperlyConfigured(message)
+        if raise_for_status:
+            response.raise_for_status()
+        return response
+
+    @classmethod
+    def _recipient_override(cls, body, recipients):
+        """
+        Helper method to override body and recipients of an email.
+        If the MAILGUN_RECIPIENT_OVERRIDE setting is specified, the list of recipients
+        will be ignored in favor of the recipients in that setting value.
+
+        Args:
+            body (str): Text email body
+            recipients (list): A list of recipient emails
+        Returns:
+            tuple: A tuple of the (possibly) overridden recipients list and email body
+        """
+        if settings.MAILGUN_RECIPIENT_OVERRIDE is not None:
+            body = '{0}\n\n[overridden recipient]\n{1}'.format(body, '\n'.join(recipients))
+            recipients = [settings.MAILGUN_RECIPIENT_OVERRIDE]
+        return body, recipients
+
+    @classmethod
+    def send_batch(cls, subject, body, recipients,  # pylint: disable=too-many-arguments, too-many-locals
+                   sender_address=None, sender_name=None, chunk_size=settings.MAILGUN_BATCH_CHUNK_SIZE,
+                   raise_for_status=True):
+        """
+        Sends a text email to a list of recipients (one email per recipient) via batch.
+
+        Args:
+            subject (str): Email subject
+            body (str): Text email body
+            recipients (iterable): A list of recipient emails
+            sender_address (str): Sender email address
+            sender_name (str): Sender name
+            chunk_size (int): The maximum amount of emails to be sent at the same time
+            raise_for_status (bool): If true, raise for non 2xx statuses
+
+        Returns:
+            list:
+                List of responses which are HTTP responses from Mailgun.
+
+        Raises:
+            SendBatchException:
+               If there is at least one exception, this exception is raised with all other exceptions in a list
+               along with recipients we failed to send to.
+        """
+        original_recipients = recipients
+        body, recipients = cls._recipient_override(body, original_recipients)
+        responses = []
+        exception_pairs = []
+
+        recipients = iter(recipients)
+        chunk = list(islice(recipients, chunk_size))
+        while len(chunk) > 0:
+            params = dict(
+                to=chunk,
+                subject=subject,
+                text=body
+            )
+            params['recipient-variables'] = json.dumps({email: {} for email in chunk})
+            if sender_address:
+                params['from'] = sender_address
+
+            if settings.MAILGUN_RECIPIENT_OVERRIDE is not None:
+                original_recipients_chunk = original_recipients
+            else:
+                original_recipients_chunk = chunk
+
+            try:
+                response = cls._mailgun_request(
+                    requests.post,
+                    'messages',
+                    params,
+                    sender_name=sender_name,
+                    raise_for_status=raise_for_status,
+                )
+
+                responses.append(response)
+            except ImproperlyConfigured:
+                raise
+            except Exception as exception:  # pylint: disable=broad-except
+                exception_pairs.append(
+                    (original_recipients_chunk, exception)
+                )
+            chunk = list(islice(recipients, chunk_size))
+
+        if len(exception_pairs) > 0:
+            raise SendBatchException(exception_pairs)
+
+        return responses
+
+    @classmethod
+    def send_individual_email(cls, subject, body, recipient,  # pylint: disable=too-many-arguments
+                              sender_address=None, sender_name=None, raise_for_status=True):
+        """
+        Sends a text email to a single recipient.
+
+        Args:
+            subject (str): email subject
+            body (str): email body
+            recipient (str): email recipient
+            sender_address (str): Sender email address
+            sender_name (str): Sender name
+            raise_for_status (bool): If true and a non-zero response was received,
+
+        Returns:
+            requests.Response: response from Mailgun
+        """
+        # Since .send_batch() returns a list, we need to return the first in the list
+        responses = cls.send_batch(
+            subject,
+            body,
+            [recipient],
+            sender_address=sender_address,
+            sender_name=sender_name,
+            raise_for_status=raise_for_status,
+        )
+        return responses[0]

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -1,0 +1,285 @@
+"""
+Test cases for email API
+"""
+import json
+import string
+from unittest.mock import Mock, patch
+
+from ddt import ddt, data
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.test import (
+    override_settings,
+    TestCase,
+)
+from requests import Response
+from requests.exceptions import HTTPError
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_400_BAD_REQUEST,
+    HTTP_401_UNAUTHORIZED,
+)
+
+from mail.exceptions import SendBatchException
+from mail.api import MailgunClient
+
+
+def mocked_json(return_data=None):
+    """Mocked version of the json method for the Response class"""
+    if return_data is None:
+        return_data = {}
+
+    def _json(*args, **kwargs):  # pylint:disable=unused-argument, missing-docstring
+        return return_data
+    return _json
+
+
+@ddt
+@patch('requests.post', autospec=True, return_value=Mock(
+    spec=Response,
+    status_code=HTTP_200_OK,
+    json=mocked_json()
+))
+class MailAPITests(TestCase):
+    """
+    Tests for the Mailgun client class
+    """
+    batch_recipient_arg = ['a@example.com', 'b@example.com']
+    individual_recipient_arg = 'a@example.com'
+
+    @override_settings(MAILGUN_RECIPIENT_OVERRIDE=None)
+    @data(None, 'Tester')
+    def test_send_batch(self, sender_name, mock_post):
+        """
+        Test that MailgunClient.send_batch sends expected parameters to the Mailgun API
+        Base case with only one batch call to the Mailgun API.
+        """
+        emails_to = ['a@example.com', 'b@example.com']
+        MailgunClient.send_batch('email subject', 'email body', emails_to, sender_name=sender_name)
+        assert mock_post.called
+        called_args, called_kwargs = mock_post.call_args
+        assert list(called_args)[0] == '{}/{}'.format(settings.MAILGUN_URL, 'messages')
+        assert called_kwargs['auth'] == ('api', settings.MAILGUN_KEY)
+        assert called_kwargs['data']['text'].startswith('email body')
+        assert called_kwargs['data']['subject'] == 'email subject'
+        assert called_kwargs['data']['to'] == emails_to
+        assert called_kwargs['data']['recipient-variables'] == json.dumps(
+            {email: {} for email in emails_to}
+        )
+        if sender_name is not None:
+            self.assertEqual(
+                called_kwargs['data']['from'],
+                "{sender_name} <{email}>".format(sender_name=sender_name, email=settings.EMAIL_SUPPORT)
+            )
+        else:
+            self.assertEqual(called_kwargs['data']['from'], settings.EMAIL_SUPPORT)
+
+    @override_settings(MAILGUN_RECIPIENT_OVERRIDE=None)
+    def test_send_batch_chunk(self, mock_post):
+        """
+        Test that MailgunClient.send_batch chunks recipients
+        """
+        chunk_size = 10
+        emails_to = ["{0}@example.com".format(letter) for letter in string.ascii_letters]
+        chunked_emails_to = [emails_to[i:i + chunk_size] for i in range(0, len(emails_to), chunk_size)]
+        assert len(emails_to) == 52
+        responses = MailgunClient.send_batch('email subject', 'email body', emails_to, chunk_size=chunk_size)
+        assert mock_post.called
+        assert mock_post.call_count == 6
+        for call_num, args in enumerate(mock_post.call_args_list):
+            called_args, called_kwargs = args
+            assert list(called_args)[0] == '{}/{}'.format(settings.MAILGUN_URL, 'messages')
+            assert called_kwargs['data']['text'].startswith('email body')
+            assert called_kwargs['data']['subject'] == 'email subject'
+            assert called_kwargs['data']['to'] == chunked_emails_to[call_num]
+            assert called_kwargs['data']['recipient-variables'] == json.dumps(
+                {email: {} for email in chunked_emails_to[call_num]}
+            )
+
+            response = responses[call_num]
+            assert response.status_code == HTTP_200_OK
+
+    @data(None, 'recipient_override@example.com')
+    def test_send_batch_error(self, recipient_override, mock_post):
+        """
+        Test that MailgunClient.send_batch returns a non-zero error code where the mailgun API returns a non-zero code
+        """
+        mock_post.return_value = Response()
+        mock_post.return_value.status_code = HTTP_400_BAD_REQUEST
+
+        chunk_size = 10
+        emails_to = ["{0}@example.com".format(letter) for letter in string.ascii_letters]
+        chunked_emails_to = [emails_to[i:i + chunk_size] for i in range(0, len(emails_to), chunk_size)]
+        assert len(emails_to) == 52
+        with override_settings(
+            MAILGUN_RECIPIENT_OVERRIDE=recipient_override,
+        ), self.assertRaises(SendBatchException) as send_batch_exception:
+            MailgunClient.send_batch('email subject', 'email body', emails_to, chunk_size=chunk_size)
+
+        if recipient_override is None:
+            assert mock_post.call_count == 6
+        else:
+            assert mock_post.call_count == 1
+            chunked_emails_to = [[recipient_override]]
+
+        for call_num, args in enumerate(mock_post.call_args_list):
+            called_args, called_kwargs = args
+            assert list(called_args)[0] == '{}/{}'.format(settings.MAILGUN_URL, 'messages')
+            assert called_kwargs['data']['text'].startswith('email body')
+            assert called_kwargs['data']['subject'] == 'email subject'
+            assert called_kwargs['data']['to'] == chunked_emails_to[call_num]
+            assert called_kwargs['data']['recipient-variables'] == json.dumps(
+                {email: {} for email in chunked_emails_to[call_num]}
+            )
+
+        exception_pairs = send_batch_exception.exception.exception_pairs
+        if recipient_override is None:
+            assert len(exception_pairs) == 6
+            for call_num, (recipients, exception) in enumerate(exception_pairs):
+                assert recipients == chunked_emails_to[call_num]
+                assert isinstance(exception, HTTPError)
+        else:
+            # The exception list should contain the original recipient emails, not the override
+            assert len(exception_pairs) == 1
+            assert exception_pairs[0][0] == emails_to
+            assert isinstance(exception_pairs[0][1], HTTPError)
+
+    def test_send_batch_400_no_raise(self, mock_post):
+        """
+        Test that if raise_for_status is False we don't raise an exception for a 400 response
+        """
+        mock_post.return_value = Mock(
+            spec=Response,
+            status_code=HTTP_400_BAD_REQUEST,
+            json=mocked_json()
+        )
+
+        chunk_size = 10
+        emails_to = ["{0}@example.com".format(letter) for letter in string.ascii_letters]
+        assert len(emails_to) == 52
+        with override_settings(
+            MAILGUN_RECIPIENT_OVERRIDE=None,
+        ):
+            resp_list = MailgunClient.send_batch(
+                'email subject', 'email body', emails_to, chunk_size=chunk_size, raise_for_status=False
+            )
+
+        assert len(resp_list) == 6
+        for resp in resp_list:
+            assert resp.status_code == HTTP_400_BAD_REQUEST
+        assert mock_post.call_count == 6
+        assert mock_post.return_value.raise_for_status.called is False
+
+    @override_settings(MAILGUN_RECIPIENT_OVERRIDE=None)
+    def test_send_batch_exception(self, mock_post):
+        """
+        Test that MailgunClient.send_batch returns a non-zero error code where the mailgun API returns a non-zero code
+        """
+        mock_post.side_effect = KeyError
+
+        chunk_size = 10
+        emails_to = ["{0}@example.com".format(letter) for letter in string.ascii_letters]
+        chunked_emails_to = [emails_to[i:i + chunk_size] for i in range(0, len(emails_to), chunk_size)]
+        assert len(emails_to) == 52
+        with self.assertRaises(SendBatchException) as send_batch_exception:
+            MailgunClient.send_batch('email subject', 'email body', emails_to, chunk_size=chunk_size)
+        assert mock_post.called
+        assert mock_post.call_count == 6
+        for call_num, args in enumerate(mock_post.call_args_list):
+            called_args, called_kwargs = args
+            assert list(called_args)[0] == '{}/{}'.format(settings.MAILGUN_URL, 'messages')
+            assert called_kwargs['data']['text'].startswith('email body')
+            assert called_kwargs['data']['subject'] == 'email subject'
+            assert called_kwargs['data']['to'] == chunked_emails_to[call_num]
+            assert called_kwargs['data']['recipient-variables'] == json.dumps(
+                {email: {} for email in chunked_emails_to[call_num]}
+            )
+
+        exception_pairs = send_batch_exception.exception.exception_pairs
+        assert len(exception_pairs) == 6
+        for call_num, (recipients, exception) in enumerate(exception_pairs):
+            assert recipients == chunked_emails_to[call_num]
+            assert isinstance(exception, KeyError)
+
+    @override_settings(MAILGUN_RECIPIENT_OVERRIDE=None)
+    def test_send_batch_improperly_configured(self, mock_post):
+        """
+        If MailgunClient.send_batch returns a 401, it should raise a ImproperlyConfigured exception
+        """
+        mock_post.return_value = Mock(
+            spec=Response,
+            status_code=HTTP_401_UNAUTHORIZED,
+        )
+
+        chunk_size = 10
+        emails_to = ["{0}@example.com".format(letter) for letter in string.ascii_letters]
+        with self.assertRaises(ImproperlyConfigured) as ex:
+            MailgunClient.send_batch('email subject', 'email body', emails_to, chunk_size=chunk_size)
+        assert ex.exception.args[0] == "Mailgun API keys not properly configured."
+
+    @override_settings(MAILGUN_RECIPIENT_OVERRIDE=None)
+    @data(None, 'Tester')
+    def test_send_individual_email(self, sender_name, mock_post):
+        """
+        Test that MailgunClient.send_individual_email() sends an individual message
+        """
+        response = MailgunClient.send_individual_email(
+            subject='email subject',
+            body='email body',
+            recipient='a@example.com',
+            sender_name=sender_name
+        )
+        assert response.status_code == HTTP_200_OK
+        assert mock_post.called
+        called_args, called_kwargs = mock_post.call_args
+        assert list(called_args)[0] == '{}/{}'.format(settings.MAILGUN_URL, 'messages')
+        assert called_kwargs['auth'] == ('api', settings.MAILGUN_KEY)
+        assert called_kwargs['data']['text'].startswith('email body')
+        assert called_kwargs['data']['subject'] == 'email subject'
+        assert called_kwargs['data']['to'] == ['a@example.com']
+        if sender_name is not None:
+            self.assertEqual(
+                called_kwargs['data']['from'],
+                "{sender_name} <{email}>".format(sender_name=sender_name, email=settings.EMAIL_SUPPORT)
+            )
+        else:
+            self.assertEqual(called_kwargs['data']['from'], settings.EMAIL_SUPPORT)
+
+    @data(True, False)
+    def test_send_individual_email_error(self, raise_for_status, mock_post):
+        """
+        Test handling of errors for send_individual_email
+        """
+        mock_post.return_value = Mock(
+            spec=Response,
+            status_code=HTTP_400_BAD_REQUEST,
+            json=mocked_json()
+        )
+
+        response = MailgunClient.send_individual_email(
+            subject='email subject',
+            body='email body',
+            recipient='a@example.com',
+            raise_for_status=raise_for_status,
+        )
+
+        assert response.raise_for_status.called is raise_for_status
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert response.json() == {}
+
+    @override_settings(MAILGUN_RECIPIENT_OVERRIDE=None)
+    def test_send_with_sender_address(self, mock_post):
+        """
+        Test that specifying a sender address in our mail API functions will result in an email
+        with the sender address in the 'from' field
+        """
+        sender_address = 'sender@example.com'
+        MailgunClient.send_batch(
+            'email subject', 'email body', self.batch_recipient_arg, sender_address=sender_address
+        )
+        MailgunClient.send_individual_email(
+            'email subject', 'email body', self.individual_recipient_arg, sender_address=sender_address
+        )
+        for args in mock_post.call_args_list:
+            _, called_kwargs = args
+            assert called_kwargs['data']['from'] == sender_address

--- a/mail/exceptions.py
+++ b/mail/exceptions.py
@@ -1,0 +1,26 @@
+"""Exceptions for mail"""
+
+
+class SendBatchException(Exception):
+    """
+    An exception which occurs when batch processing of email fails. This contains a list of other exceptions and
+    the emails which caused the failure.
+    """
+
+    def __init__(self, exception_pairs):
+        """
+        Creates a SendBatchException
+
+        Args:
+            exception_pairs (list): A list of (list of recipients, exception)
+        """
+        super().__init__(exception_pairs)
+        self.exception_pairs = exception_pairs
+
+    @property
+    def failed_recipient_emails(self):
+        """
+        Yields a list of recipient emails that we failed to send to
+        """
+        for recipients, _ in self.exception_pairs:
+            yield from recipients


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #4

#### What's this PR do?
Implements order fulfillment API so that CyberSource can mark an Order as fulfilled

#### How should this be manually tested?
Talk to me. We need to set up the environment to purchase a klass and change CyberSource's test receipt URL to point to a request bin to verify order fulfillment