### PR TITLE
Integrated klasses API information with front end

### DIFF
--- a/bootcamp/serializers.py
+++ b/bootcamp/serializers.py
@@ -1,0 +1,22 @@
+"""
+Serializers that are needed across all areas of the bootcamp-ecommerce application
+"""
+from django.core.exceptions import ObjectDoesNotExist
+
+from backends.utils import get_social_username
+
+
+def serialize_maybe_user(user):
+    """
+    Serialize a logged-in user to Python primitives, or an anonymous user to `None`.
+    """
+    if user.is_anonymous():
+        return None
+    try:
+        full_name = user.profile.name
+    except ObjectDoesNotExist:
+        full_name = None
+    return {
+        'username': get_social_username(user),
+        'full_name': full_name
+    }

--- a/bootcamp/serializers_test.py
+++ b/bootcamp/serializers_test.py
@@ -1,0 +1,36 @@
+"""Tests for general bootcamp serializing functionality"""
+from unittest.mock import patch, Mock
+from django.test import TestCase
+
+from profiles.factories import UserFactory, ProfileFactory
+from bootcamp.serializers import serialize_maybe_user
+
+
+class SerializeMaybeUserTests(TestCase):
+    """Tests for serialize_maybe_user"""
+    @classmethod
+    def setUpTestData(cls):
+        cls.profile = ProfileFactory.create(name='Full Name')
+
+    def test_serialize_maybe_user(self):
+        """Test that a user is correctly serialized"""
+        with patch('bootcamp.serializers.get_social_username', return_value='abc'):
+            assert serialize_maybe_user(self.profile.user) == {
+                'full_name': self.profile.name,
+                'username': 'abc'
+            }
+
+    def test_serialize_maybe_user_without_profile(self):
+        """Test that a user without a profile is correctly serialized"""
+        user_without_profile = UserFactory.create()
+        with patch('bootcamp.serializers.get_social_username', return_value='abc'):
+            assert serialize_maybe_user(user_without_profile) == {
+                'full_name': None,
+                'username': 'abc'
+            }
+
+    def test_serialize_maybe_user_anonymous(self):
+        """Test that an anonymous user serializes to None"""
+        is_anonymous = Mock(return_value=True)
+        anon_user = Mock(is_anonymous=is_anonymous)
+        assert serialize_maybe_user(anon_user) is None

--- a/bootcamp/views.py
+++ b/bootcamp/views.py
@@ -9,25 +9,24 @@ from django.shortcuts import render, redirect
 from raven.contrib.django.raven_compat.models import client as sentry
 
 from bootcamp.templatetags.render_bundle import public_path
+from bootcamp.serializers import serialize_maybe_user
 
 
-def index(request):
-    """
-    The index view. Display available programs
-    """
-    # if the user is logged in, there is no need to see the home page
-    if request.user.is_authenticated():
-        return redirect(to='pay')
-
-    js_settings = {
+def _serialize_js_settings(request):  # pylint: disable=missing-docstring
+    return {
         "release_version": settings.VERSION,
         "environment": settings.ENVIRONMENT,
         "sentry_dsn": sentry.get_public_dsn(),
-        'public_path': public_path(request),
+        "public_path": public_path(request),
+        "user": serialize_maybe_user(request.user)
     }
 
+
+def index(request):  # pylint: disable=missing-docstring
+    if request.user.is_authenticated():
+        return redirect(to='pay')
     return render(request, "bootcamp/index.html", context={
-        "js_settings_json": json.dumps(js_settings),
+        "js_settings_json": json.dumps(_serialize_js_settings(request)),
     })
 
 
@@ -36,14 +35,6 @@ def pay(request):
     """
     View for the payment page
     """
-    js_settings = {
-        "release_version": settings.VERSION,
-        "environment": settings.ENVIRONMENT,
-        "sentry_dsn": sentry.get_public_dsn(),
-        'public_path': public_path(request),
-        'full_name': request.user.profile.name,
-    }
-
     return render(request, "bootcamp/pay.html", context={
-        "js_settings_json": json.dumps(js_settings),
+        "js_settings_json": json.dumps(_serialize_js_settings(request)),
     })

--- a/bootcamp/views_test.py
+++ b/bootcamp/views_test.py
@@ -51,6 +51,7 @@ class TestViews(TestCase):
             'release_version': version,
             'sentry_dsn': None,
             'public_path': '/static/bundles/',
+            'user': None
         }
 
     def test_index_logged_in(self):
@@ -90,8 +91,11 @@ class TestViews(TestCase):
         js_settings = json.loads(resp.context['js_settings_json'])
         assert js_settings == {
             'environment': environment,
-            'full_name': self.user.profile.name,
             'release_version': version,
             'sentry_dsn': None,
             'public_path': '/static/bundles/',
+            'user': {
+                'full_name': self.user.profile.name,
+                'username': None
+            },
         }

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -81,13 +81,13 @@ class PurchasableTests(TestCase):
 
         with self.assertRaises(ValidationError) as ex:
             # payment is $15 here but there is only $10 left to pay
-            total = 15
-            create_unfulfilled_order(self.user, self.klass.klass_id, total)
+            payment_amount = 15
+            create_unfulfilled_order(self.user, self.klass.klass_id, payment_amount)
 
         message = (
-            "Payment of ${total} plus already paid ${already_paid} for {klass} would be"
+            "Payment of ${payment_amount} plus already paid ${already_paid} for {klass} would be"
             " greater than total price of ${klass_price}".format(
-                total=total,
+                payment_amount=payment_amount,
                 already_paid=self.klass.price - 10,
                 klass=self.klass.title,
                 klass_price=self.klass.price,
@@ -96,12 +96,12 @@ class PurchasableTests(TestCase):
         assert ex.exception.args[0] == message
 
     @ddt.data(0, -1.23)
-    def test_less_or_equal_to_zero(self, total):
+    def test_less_or_equal_to_zero(self, payment_amount):
         """
         An order may not have a negative or zero price
         """
         with self.assertRaises(ValidationError) as ex:
-            create_unfulfilled_order(self.user, self.klass.klass_id, total)
+            create_unfulfilled_order(self.user, self.klass.klass_id, payment_amount)
 
         assert ex.exception.args[0] == 'Payment is less than or equal to zero'
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -8,7 +8,7 @@ class PaymentSerializer(serializers.Serializer):
     """
     Serializer for payment API, used to do basic validation.
     """
-    total = serializers.DecimalField(max_digits=20, decimal_places=2, min_value=0.01)
+    payment_amount = serializers.DecimalField(max_digits=20, decimal_places=2, min_value=0.01)
     klass_id = serializers.IntegerField()
 
 

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -22,9 +22,9 @@ class PaymentSerializersTests(TestCase):
     """Tests for payment serializers"""
 
     @data(
-        [{"total": "345", "klass_id": 3}, True],
-        [{"total": "-3", "klass_id": 3}, False],
-        [{"total": "345"}, False],
+        [{"payment_amount": "345", "klass_id": 3}, True],
+        [{"payment_amount": "-3", "klass_id": 3}, False],
+        [{"payment_amount": "345"}, False],
         [{"klass_id": "345"}, False],
     )
     @unpack

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -47,10 +47,10 @@ class PaymentView(CreateAPIView):
         """
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        total = Decimal(serializer.data['total'])
+        payment_amount = Decimal(serializer.data['payment_amount'])
         klass_id = serializer.data['klass_id']
 
-        order = create_unfulfilled_order(self.request.user, klass_id, total)
+        order = create_unfulfilled_order(self.request.user, klass_id, payment_amount)
         redirect_url = self.request.build_absolute_uri(reverse('bootcamp-index'))
 
         return Response({

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -48,12 +48,12 @@ class PaymentTests(TestCase):
         user = UserFactory.create()
         self.client.force_login(user)
         resp = self.client.post(payment_url, data={
-            "total": "-1",
+            "payment_amount": "-1",
             "klass_id": 3,
         })
         assert resp.status_code == statuses.HTTP_400_BAD_REQUEST
         assert resp.json() == {
-            "total": ["Ensure this value is greater than or equal to 0.01."]
+            "payment_amount": ["Ensure this value is greater than or equal to 0.01."]
         }
 
     def test_login_required(self):
@@ -80,7 +80,7 @@ class PaymentTests(TestCase):
             'ecommerce.views.create_unfulfilled_order', autospec=True, return_value=fake_order
         ) as create_unfulfilled_order_mock:
             resp = self.client.post(reverse('create-payment'), data={
-                "total": klass.price,
+                "payment_amount": klass.price,
                 "klass_id": klass.klass_id,
             })
         assert resp.status_code == statuses.HTTP_200_OK

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -1,11 +1,14 @@
 // @flow
 import { createAction } from 'redux-actions';
 
-export const SET_TOTAL = 'SET_TOTAL';
-export const setTotal = createAction(SET_TOTAL);
+export const CLEAR_UI = 'CLEAR_UI';
+export const clearUI = createAction(CLEAR_UI);
 
-export const SET_KLASS_ID = 'SET_KLASS_ID';
-export const setKlassId = createAction(SET_KLASS_ID);
+export const SET_PAYMENT_AMOUNT = 'SET_PAYMENT_AMOUNT';
+export const setPaymentAmount = createAction(SET_PAYMENT_AMOUNT);
+
+export const SET_SELECTED_KLASS_INDEX = 'SET_SELECTED_KLASS_INDEX';
+export const setSelectedKlassIndex = createAction(SET_SELECTED_KLASS_INDEX);
 
 export const FETCH_PROCESSING = 'FETCH_PROCESSING';
 export const FETCH_SUCCESS = 'FETCH_SUCCESS';

--- a/static/js/actions/index_test.js
+++ b/static/js/actions/index_test.js
@@ -1,18 +1,17 @@
 import { assertCreatedActionHelper } from './test_util';
 
 import {
-  setKlassId,
-  setTotal,
-
-  SET_KLASS_ID,
-  SET_TOTAL,
+  setSelectedKlassIndex,
+  setPaymentAmount,
+  SET_SELECTED_KLASS_INDEX,
+  SET_PAYMENT_AMOUNT,
 } from './index';
 
 describe('actions', () => {
   it('should create all action creators', () => {
     [
-      [setTotal, SET_TOTAL],
-      [setKlassId, SET_KLASS_ID],
+      [setPaymentAmount, SET_PAYMENT_AMOUNT],
+      [setSelectedKlassIndex, SET_SELECTED_KLASS_INDEX],
     ].forEach(assertCreatedActionHelper);
   });
 });

--- a/static/js/containers/Payment.js
+++ b/static/js/containers/Payment.js
@@ -3,28 +3,67 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
+import _ from 'lodash';
 
 import type {
   UIState,
 } from '../reducers';
 import {
-  setKlassId,
-  setTotal,
+  clearUI,
+  setPaymentAmount,
+  setSelectedKlassIndex
 } from '../actions';
 import { actions } from '../rest';
 import type { RestState } from '../rest';
-import { createForm } from '../util/util';
+import { createForm, isNilOrBlank } from '../util/util';
 
 class Payment extends React.Component {
   props: {
+    dispatch: Dispatch,
     ui: UIState,
     payment: RestState,
-    dispatch: Dispatch,
+    klasses: RestState,
+    selectedKlass: Object,
   };
 
+  fetchAPIdata() {
+    this.fetchKlasses();
+  }
+
+  componentDidMount() {
+    this.fetchAPIdata();
+  }
+
+  componentDidUpdate() {
+    this.fetchAPIdata();
+  }
+
+  componentWillUnmount() {
+    const { dispatch } = this.props;
+    dispatch(clearUI());
+  }
+
+  fetchKlasses() {
+    const { dispatch, klasses } = this.props;
+    if (!klasses.fetchStatus) {
+      dispatch(
+        actions.klasses({username: SETTINGS.user.username})
+      );
+    }
+  }
+
   sendPayment = () => {
-    const { dispatch, ui: { total, klassId } } = this.props;
-    dispatch(actions.payment(total, klassId)).then(result => {
+    const {
+      dispatch,
+      ui: { paymentAmount },
+      selectedKlass
+    } = this.props;
+    dispatch(
+      actions.payment({
+        paymentAmount: paymentAmount,
+        klassId: selectedKlass.klass_id
+      })
+    ).then(result => {
       const { url, payload } = result;
       const form = createForm(url, payload);
       const body = document.querySelector("body");
@@ -33,49 +72,112 @@ class Payment extends React.Component {
     });
   };
 
-  setTotal = (event) => {
+  setPaymentAmount = (event) => {
     const { dispatch } = this.props;
-    dispatch(setTotal(event.target.value));
+    dispatch(setPaymentAmount(event.target.value));
   };
 
-  setKlassId = event => {
+  setSelectedKlassIndex = (event) => {
     const { dispatch } = this.props;
-    dispatch(setKlassId(event.target.value));
+    dispatch(setSelectedKlassIndex(parseInt(event.target.value)));
   };
 
-  render() {
+  renderKlassDropdown = () => {
     const {
-      ui: { total, klassId },
-      payment: { processing },
+      klasses,
+      ui: { selectedKlassIndex }
     } = this.props;
 
-    return <div className="payment">
-      <h3 className="intro">{SETTINGS.full_name}, Welcome to MIT Bootcamps</h3>
-      <h2 className="bootcamp-title">Internet of Things</h2>
-      <span>You have paid $2000 out of $6000</span>
+    let options = _.map(
+      klasses.data,
+      (klass, i) => (<option value={i} key={i}>{ klass.klass_name }</option>)
+    );
+    options.unshift(
+      <option value="" key="default" disabled style={{display: 'none'}}>Select...</option>
+    );
+    let valueProp = selectedKlassIndex ?
+      {value: selectedKlassIndex} :
+      {defaultValue: ""};
+
+    return (
+      <select
+        className="klass-select"
+        onChange={this.setSelectedKlassIndex}
+        {...valueProp}
+      >
+        {options}
+      </select>
+    );
+  };
+
+  renderSelectedKlass() {
+    const {
+      ui: { paymentAmount },
+      payment: { processing },
+      selectedKlass
+    } = this.props;
+
+    return <div>
+      <h2 className="klass-title">{selectedKlass.klass_name}</h2>
+      <span>You have paid ${selectedKlass.total_paid} out of ${selectedKlass.price}</span>
       <div className="payment">
         <span>Make a payment of:</span>
         <span>
-          $<input type="number" id="total" value={total} onChange={this.setTotal} />
-        </span>
-        For klass id:
-        <span>
-          <input type="number" value={klassId} onChange={this.setKlassId} />
+          $<input type="number" id="payment-amount" value={paymentAmount} onChange={this.setPaymentAmount}/>
         </span>
         <button className="payment-button" onClick={this.sendPayment} disabled={processing}>
           Pay
         </button>
       </div>
-
       <a href="#">Print your statement</a>
+    </div>;
+  }
+
+  render() {
+    const { klasses, selectedKlass } = this.props;
+
+    let welcomeMessage = "Welcome to MIT Bootcamps";
+    if (!isNilOrBlank(SETTINGS.user.full_name)) {
+      welcomeMessage = `${SETTINGS.user.full_name}, ${welcomeMessage}`;
+    }
+    let renderedKlassDropdown = (klasses.data && klasses.data.length > 1) ?
+      this.renderKlassDropdown() :
+      null;
+    let renderedSelectedKlass = selectedKlass ?
+      this.renderSelectedKlass() :
+      null;
+
+    return <div className="payment">
+      <h3 className="intro">{welcomeMessage}</h3>
+      {renderedKlassDropdown}
+      {renderedSelectedKlass}
     </div>;
   }
 }
 
+const deriveSelectedKlass = state => {
+  let {
+    klasses,
+    ui: { selectedKlassIndex }
+  } = state;
+
+  let klassesExist = klasses.data && klasses.data.length > 0;
+  // If there's only one klass available, set selectedKlassIndex such that the one klass
+  // will be set as the selected klass.
+  if (klassesExist && klasses.data.length === 1) {
+    selectedKlassIndex = 0;
+  }
+  return klassesExist && _.isNumber(selectedKlassIndex) ?
+    klasses.data[selectedKlassIndex] :
+    undefined;
+};
+
 const mapStateToProps = state => {
   return {
     payment: state.payment,
+    klasses: state.klasses,
     ui: state.ui,
+    selectedKlass: deriveSelectedKlass(state),
   };
 };
 

--- a/static/js/containers/Payment_test.js
+++ b/static/js/containers/Payment_test.js
@@ -1,90 +1,202 @@
+/* global SETTINGS: false */
 import React from 'react';
 import configureTestStore from 'redux-asserts';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import _ from 'lodash';
 
 import * as api from '../lib/api';
-import { setTotal } from '../actions';
+import {
+  setPaymentAmount,
+  setSelectedKlassIndex
+} from '../actions';
 import rootReducer from '../reducers';
 import Payment from '../containers/Payment';
 import * as util from '../util/util';
-import { makeRequestActionType, makeReceiveSuccessActionType } from '../rest';
+import {
+  makeRequestActionType,
+  makeReceiveSuccessActionType
+} from '../rest';
 
 const REQUEST_PAYMENT = makeRequestActionType('payment');
 const RECEIVE_PAYMENT_SUCCESS = makeReceiveSuccessActionType('payment');
+const REQUEST_KLASSES = makeRequestActionType('klasses');
+const RECEIVE_KLASSES_SUCCESS = makeReceiveSuccessActionType('klasses');
 
-describe('Payment', () => {
-  let store, listenForActions, sandbox;
+const generateFakeKlasses = (numKlasses = 1) => {
+  return _.times(numKlasses, (i) => ({
+    klass_name: `Bootcamp 1 Klass ${i}`,
+    klass_id: i
+  }));
+};
+
+describe('Payment container', () => {
+  let store, listenForActions, sandbox, fetchStub,
+    klassesUrl, klassesStub; // eslint-disable-line no-unused-vars
+
   beforeEach(() => {
+    SETTINGS.user = {
+      full_name: "john doe",
+      username: "johndoe"
+    };
+
     store = configureTestStore(rootReducer);
-    sandbox = sinon.sandbox.create();
     listenForActions = store.createListenForActions();
+    sandbox = sinon.sandbox.create();
+    fetchStub = sandbox.stub(api, 'fetchJSONWithCSRF');
+    klassesUrl = `/api/v0/klasses/${SETTINGS.user.username}/`;
   });
+
   afterEach(() => {
     sandbox.restore();
   });
 
-  let renderPayment = () => {
-    return mount(
+  let renderPaymentComponent = (props = {}) => (
+    mount(
       <Provider store={store}>
-        <Payment />
+        <Payment {...props} />
       </Provider>
-    );
+    )
+  );
+
+  let renderFullPaymentPage = (props = {}) => {
+    let wrapper;
+    return listenForActions([REQUEST_KLASSES, RECEIVE_KLASSES_SUCCESS], () => {
+      wrapper = renderPaymentComponent(props);
+    }).then(() => {
+      return Promise.resolve(wrapper);
+    });
   };
 
-  it('sets a price', () => {
-    let payment = renderPayment();
-    payment.find('input[id="total"]').props().onChange({
-      target: {
-        value: "123"
-      }
-    });
-    assert.equal(store.getState().ui.total, "123");
-  });
+  it('does not have a selected klass by default', () => {
+    let fakeKlasses = generateFakeKlasses(3);
+    klassesStub = fetchStub.withArgs(klassesUrl)
+      .returns(Promise.resolve(fakeKlasses));
 
-  it('sends a payment when API is contacted', () => {
-    store.dispatch(setTotal("123"));
-    sandbox.stub(api, 'fetchJSONWithCSRF').withArgs('/api/v0/payment/').returns(Promise.resolve());
-    let payment = renderPayment();
-
-    return listenForActions([REQUEST_PAYMENT, RECEIVE_PAYMENT_SUCCESS], () => {
-      payment.find('.payment-button').simulate('click');
+    return renderFullPaymentPage().then((wrapper) => {
+      assert.isUndefined(wrapper.find('Payment').prop('selectedKlass'));
     });
   });
 
-  it('constructs a form to be sent to Cybersource and submits it', () => {
-    let url = '/x/y/z';
-    let payload = {
-      'pay': 'load'
-    };
-    sandbox.stub(api, 'fetchJSONWithCSRF').withArgs('/api/v0/payment/').returns(Promise.resolve({
-      'url': url,
-      'payload': payload
-    }));
+  it('sets a selected klass', () => {
+    let fakeKlasses = generateFakeKlasses(3);
+    klassesStub = fetchStub.withArgs(klassesUrl)
+      .returns(Promise.resolve(fakeKlasses));
+    store.dispatch(setSelectedKlassIndex(2));
 
-    let submitStub = sandbox.stub();
-    let fakeForm = document.createElement("form");
-    fakeForm.setAttribute("class", "fake-form");
-    fakeForm.submit = submitStub;
-    let createFormStub = sandbox.stub(util, 'createForm').returns(fakeForm);
+    return renderFullPaymentPage().then((wrapper) => {
+      assert.deepEqual(wrapper.find('Payment').prop('selectedKlass'), fakeKlasses[2]);
+    });
+  });
 
-    let wrapper = renderPayment();
-    return listenForActions([REQUEST_PAYMENT, RECEIVE_PAYMENT_SUCCESS], () => {
-      wrapper.find('.payment-button').simulate('click');
-    }).then(() => {
-      return new Promise(resolve => {
-        setTimeout(() => {
-          assert.equal(createFormStub.callCount, 1);
-          assert.deepEqual(createFormStub.args[0], [url, payload]);
+  describe('UI', () => {
+    const klassTitleSelector = 'h2.klass-title',
+      klassDropdownSelector = 'select.klass-select',
+      welcomeMessageSelector = 'h3.intro';
 
-          assert(document.body.querySelector(".fake-form"), 'fake form not found in body');
-          assert.equal(submitStub.callCount, 1);
-          assert.deepEqual(submitStub.args[0], []);
+    it('shows the selected klass', () => {
+      let fakeKlasses = generateFakeKlasses(3);
+      klassesStub = fetchStub.withArgs(klassesUrl)
+        .returns(Promise.resolve(fakeKlasses));
+      store.dispatch(setSelectedKlassIndex(0));
 
-          resolve();
-        }, 50);
+      return renderFullPaymentPage().then((wrapper) => {
+        let title = wrapper.find(klassTitleSelector);
+        assert.equal(title.text(), fakeKlasses[0].klass_name);
+      });
+    });
+
+    it('shows a dropdown if multiple klasses are available', () => {
+      [
+        [1, false],
+        [2, true]
+      ].forEach((numKlasses, shouldShowDropdown) => {
+        let fakeKlasses = generateFakeKlasses(numKlasses);
+        klassesStub = fetchStub.withArgs(klassesUrl)
+          .returns(Promise.resolve(fakeKlasses));
+
+        return renderFullPaymentPage().then((wrapper) => {
+          assert.equal(wrapper.find(klassDropdownSelector).exists(), shouldShowDropdown);
+        });
+      });
+    });
+
+    it('does not show the name of the user if it is blank', () => {
+      SETTINGS.user.full_name = '';
+      klassesStub = fetchStub
+        .withArgs(klassesUrl)
+        .returns(Promise.resolve(generateFakeKlasses(1)));
+      return renderFullPaymentPage().then((wrapper) => {
+        let welcomeMessage = wrapper.find(welcomeMessageSelector);
+        assert.equal(welcomeMessage.text(), "Welcome to MIT Bootcamps");
+      });
+    });
+  });
+
+  describe('payment functionality', () => {
+    beforeEach(() => {
+      klassesStub = fetchStub
+        .withArgs(klassesUrl)
+        .returns(Promise.resolve(generateFakeKlasses(1)));
+      store.dispatch(setSelectedKlassIndex(0));
+    });
+
+    it('sets a price', () => {
+      return renderFullPaymentPage().then((wrapper) => {
+        wrapper.find('input[id="payment-amount"]').props().onChange({
+          target: {
+            value: "123"
+          }
+        });
+        assert.equal(store.getState().ui.paymentAmount, "123");
+      });
+    });
+
+    it('sends a payment when API is contacted', () => {
+      store.dispatch(setPaymentAmount("123"));
+      fetchStub.withArgs('/api/v0/payment/').returns(Promise.resolve());
+      return renderFullPaymentPage().then((wrapper) => {
+        return listenForActions([REQUEST_PAYMENT, RECEIVE_PAYMENT_SUCCESS], () => {
+          wrapper.find('.payment-button').simulate('click');
+        });
+      });
+    });
+
+    it('constructs a form to be sent to Cybersource and submits it', () => {
+      let url = '/x/y/z';
+      let payload = {
+        'pay': 'load'
+      };
+      fetchStub.withArgs('/api/v0/payment/').returns(Promise.resolve({
+        'url': url,
+        'payload': payload
+      }));
+
+      let submitStub = sandbox.stub();
+      let fakeForm = document.createElement("form");
+      fakeForm.setAttribute("class", "fake-form");
+      fakeForm.submit = submitStub;
+      let createFormStub = sandbox.stub(util, 'createForm').returns(fakeForm);
+
+      return renderFullPaymentPage().then((wrapper) => {
+        return listenForActions([REQUEST_PAYMENT, RECEIVE_PAYMENT_SUCCESS], () => {
+          wrapper.find('.payment-button').simulate('click');
+        }).then(() => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              assert.equal(createFormStub.callCount, 1);
+              assert.deepEqual(createFormStub.args[0], [url, payload]);
+
+              assert(document.body.querySelector(".fake-form"), 'fake form not found in body');
+              assert.equal(submitStub.callCount, 1);
+              assert.deepEqual(submitStub.args[0], []);
+
+              resolve();
+            }, 50);
+          });
+        });
       });
     });
   });

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -1,6 +1,9 @@
 // @flow
 declare var SETTINGS: {
-  full_name: string,
+  user: {
+    full_name: string,
+    username: string
+  }
 };
 
 // mocha

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -1,6 +1,9 @@
 // Define globals we would usually get from Django
 const _createSettings = () => ({
-  full_name: 'Jane Doe',
+  user: {
+    full_name: 'Jane Doe',
+    username: 'janedoe'
+  },
 });
 
 global.SETTINGS = _createSettings();

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -111,4 +111,3 @@ export const fetchJSONWithCSRF = (input: string, init: Object = {}, loginOnError
     return Promise.reject(respJson);
   });
 };
-

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -1,25 +1,30 @@
 // @flow
 import { combineReducers } from 'redux';
 
-import { SET_KLASS_ID, SET_TOTAL } from '../actions';
+import {
+  CLEAR_UI,
+  SET_SELECTED_KLASS_INDEX,
+  SET_PAYMENT_AMOUNT
+} from '../actions';
 import type { Action } from '../flow/reduxTypes';
 import { reducers as restReducers } from '../rest';
 
 export type UIState = {
-  total: string,
-  klassId: string,
+  paymentAmount: string,
+  selectedKlassIndex?: number
 };
 const INITIAL_UI_STATE = {
-  total: '',
-  klassId: '',
+  paymentAmount: ''
 };
 
 export const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   switch (action.type) {
-  case SET_KLASS_ID:
-    return { ...state, klassId: action.payload };
-  case SET_TOTAL:
-    return { ...state, total: action.payload };
+  case CLEAR_UI:
+    return INITIAL_UI_STATE;
+  case SET_PAYMENT_AMOUNT:
+    return { ...state, paymentAmount: action.payload };
+  case SET_SELECTED_KLASS_INDEX:
+    return { ...state, selectedKlassIndex: action.payload };
   default:
     return state;
   }

--- a/static/js/reducers/index_test.js
+++ b/static/js/reducers/index_test.js
@@ -2,8 +2,8 @@ import configureTestStore from 'redux-asserts';
 import sinon from 'sinon';
 
 import {
-  setKlassId,
-  setTotal,
+  setSelectedKlassIndex,
+  setPaymentAmount,
 } from '../actions';
 import rootReducer from '../reducers';
 import { createAssertReducerResultState } from '../util/test_utils';
@@ -22,12 +22,12 @@ describe('reducers', () => {
   });
 
   describe('ui', () => {
-    it('should set the total price', () => {
-      assertReducerResultState(setTotal, ui => ui.total, '');
+    it('should set the payment amount', () => {
+      assertReducerResultState(setPaymentAmount, ui => ui.paymentAmount, '');
     });
 
-    it('should set the klass id', () => {
-      assertReducerResultState(setKlassId, ui => ui.klassId, '');
+    it('should set the selected klass index', () => {
+      assertReducerResultState(setSelectedKlassIndex, ui => ui.selectedKlassIndex, undefined);
     });
   });
 

--- a/static/js/rest_test.js
+++ b/static/js/rest_test.js
@@ -23,10 +23,13 @@ describe('rest', () => {
   const fakeEndpoint = {
     name: 'fake',
     url: '/api/v0/fake/',
-    makeOptions: (...args) => ({
+    fetchOptions: (params) => ({
       method: 'POST',
-      body: JSON.stringify([...args])
-    }),
+      body: JSON.stringify({
+        param1: params.param1,
+        param2: params.param2,
+      })
+    })
   };
 
   let sandbox, store;
@@ -101,10 +104,13 @@ describe('rest', () => {
 
     it('dispatches a success action if the API returned successfully', () => {
       const fetchAction = makeAction(fakeEndpoint);
-      const args = ["arg1", "arg2"];
+      const params = {
+        param1: '1',
+        param2: '2'
+      };
       fetchMock.returns(Promise.resolve("data"));
 
-      return dispatchThen(fetchAction(...args), [
+      return dispatchThen(fetchAction(params), [
         makeRequestActionType(fakeEndpoint.name),
         makeReceiveSuccessActionType(fakeEndpoint.name),
       ]).then(state => {
@@ -117,17 +123,20 @@ describe('rest', () => {
 
         sinon.assert.calledWith(fetchMock, '/api/v0/fake/', {
           method: "POST",
-          body: JSON.stringify(args),
+          body: JSON.stringify(params),
         });
       });
     });
 
     it('dispatches a failure action if the API failed', () => {
       const fetchAction = makeAction(fakeEndpoint);
-      const args = ["arg1", "arg2"];
+      const params = {
+        param1: '1',
+        param2: '2'
+      };
       fetchMock.returns(Promise.reject("error"));
 
-      return dispatchThen(fetchAction(...args), [
+      return dispatchThen(fetchAction(params), [
         makeRequestActionType(fakeEndpoint.name),
         makeReceiveFailureActionType(fakeEndpoint.name),
       ]).then(state => {
@@ -140,22 +149,26 @@ describe('rest', () => {
 
         sinon.assert.calledWith(fetchMock, '/api/v0/fake/', {
           method: "POST",
-          body: JSON.stringify(args),
+          body: JSON.stringify(params),
         });
       });
     });
   });
 
   describe("endpoints", () => {
-    it('has /api/v0/payment/', () => {
+    it('include /api/v0/payment/', () => {
       let endpoint = endpoints.find(endpoint => endpoint.name === 'payment');
       assert.equal(endpoint.url, '/api/v0/payment/');
-      assert.deepEqual(endpoint.makeOptions("123"), {
-        method: 'POST',
-        body: JSON.stringify({
-          total: "123"
-        })
-      });
+      assert.deepEqual(
+        endpoint.fetchOptions({klassId: 1, paymentAmount: "123"}),
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            klass_id: 1,
+            payment_amount: "123"
+          })
+        }
+      );
     });
   });
 });

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -1,4 +1,5 @@
 // @flow
+import R from 'ramda';
 
 /**
  * Creates a POST form with hidden input fields
@@ -21,3 +22,5 @@ export function createForm(url: string, payload: Object): HTMLFormElement {
   }
   return form;
 }
+
+export const isNilOrBlank = R.either(R.isNil, R.isEmpty);

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import { createForm } from './util';
+import { createForm, isNilOrBlank } from './util';
 
 describe('util', () => {
   describe('createForm', () => {
@@ -20,6 +20,18 @@ describe('util', () => {
       assert.deepEqual(clone, {});
       assert.equal(form.getAttribute("action"), url);
       assert.equal(form.getAttribute("method"), "post");
+    });
+  });
+
+  describe('isNilOrBlank', () => {
+    it('returns true for undefined, null, and a blank string', () => {
+      [undefined, null, ''].forEach(value => {
+        assert.isTrue(isNilOrBlank(value));
+      });
+    });
+
+    it('returns false for a non-blank string', () => {
+      assert.isFalse(isNilOrBlank('not blank'));
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #41 

#### What's this PR do?
Essentially this hooks together the back end and front end of the application. The `/pay` page is now reflective of the actual klasses that a user can pay for, and the user can switch between available klasses via a dropdown

#### How should this be manually tested?
1. Set up a single bootcamp/klass that a User can pay for. Navigate to `/pay` and make sure that the data is accurate and there is no dropdown to select among many klasses
1. Set up more bootcamps/klasses and navigate to `/pay`. Make sure the dropdown is visible and that the view is updated according to the selection

#### Where should the reviewer start?
Probably `static/js/containers/Payment.js`

#### Any background context you want to provide?
Submitting this form via the 'Pay' button doesn't work on this branch or on master due to missing CSRF settings

#### Screenshots (if appropriate)
![ss 2017-04-25 at 13 45 51](https://cloud.githubusercontent.com/assets/14932219/25399456/87131e18-29bd-11e7-89c4-8a1cee1cd15e.png)
