### PR TITLE
User is redirected to pay if logged in

### DIFF
--- a/bootcamp/views.py
+++ b/bootcamp/views.py
@@ -5,7 +5,7 @@ import json
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from raven.contrib.django.raven_compat.models import client as sentry
 
 from bootcamp.templatetags.render_bundle import public_path
@@ -15,6 +15,9 @@ def index(request):
     """
     The index view. Display available programs
     """
+    # if the user is logged in, there is no need to see the home page
+    if request.user.is_authenticated():
+        return redirect(to='pay')
 
     js_settings = {
         "release_version": settings.VERSION,


### PR DESCRIPTION
#### What are the relevant tickets?
closes #52 

#### What's this PR do?
Redirects the user to the `pay` page if the user is logged in

#### How should this be manually tested?
go to `/`: if you are not logged in you can see it, otherwise you get redirected to `/pay`
