### PR TITLE
Fixed redirect from index from cybersource

### DIFF
--- a/bootcamp/views.py
+++ b/bootcamp/views.py
@@ -5,7 +5,8 @@ import json
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, reverse
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
 from raven.contrib.django.raven_compat.models import client as sentry
 
@@ -23,9 +24,16 @@ def _serialize_js_settings(request):  # pylint: disable=missing-docstring
     }
 
 
-def index(request):  # pylint: disable=missing-docstring
+@csrf_exempt
+def index(request):
+    """
+    Index page
+    """
     if request.user.is_authenticated():
-        return redirect(to='pay')
+        to_url = reverse('pay')
+        if request.GET:
+            to_url = "{}?{}".format(to_url, request.GET.urlencode())
+        return redirect(to=to_url)
     return render(request, "bootcamp/index.html", context={
         "js_settings_json": json.dumps(_serialize_js_settings(request)),
     })

--- a/bootcamp/views_test.py
+++ b/bootcamp/views_test.py
@@ -59,6 +59,16 @@ class TestViews(TestCase):
         self.client.force_login(self.user)
         assert self.client.get(reverse('bootcamp-index')).status_code == HTTP_302_FOUND
 
+    def test_index_logged_in_post(self):
+        """
+        Verify the user is redirected to pay if logged in on a POST request without CSRF token
+        and that the GET parameters are kept
+        """
+        self.client.force_login(self.user)
+        resp = self.client.post(reverse('bootcamp-index')+'?foo=bar')
+        assert resp.status_code == HTTP_302_FOUND
+        assert resp.url == reverse('pay') + '?foo=bar'
+
     def test_pay_anonymous(self):
         """
         Test that anonymous users can't see the anonymous view


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #65 

#### What's this PR do?
fixes the behavior of the home page on the POST from cybersource

#### How should this be manually tested?
1. login in the bootcamp app
2. go to `/api/v0/klasses/<username>/`
3. in the browser console type `$.post('/?foo=bar&foo=baz')`

you should be able to see 2 response: first a 301 redirect, then a 200 ok from `/pay/?foo=bar&foo=baz`. Note that the parameters are kept during the redirect.
