### PR TITLE
Added payment history component

### DIFF
--- a/bootcamp/templates/background-images.css
+++ b/bootcamp/templates/background-images.css
@@ -1,9 +1,9 @@
 {% load static %}
-.body-inner-content {
+.top-content {
   background: url({% static "images/bootcamp-logo.png" %}) top left no-repeat;
 }
 
-.body-content.photo-bg {
+.photo-bg {
   background: url({% static "images/background1.jpg" %}) top right no-repeat;
   background-size: cover;
   height: 83vh;

--- a/bootcamp/templates/base.html
+++ b/bootcamp/templates/base.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% load raven %}
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" type="text/css" href="{% url 'background-images-css' %}" />
     <script type="text/javascript">
     var SETTINGS = {{ js_settings_json|safe }};
@@ -22,7 +23,7 @@
     {% endspaceless %}
   </head>
   <body>
-    <div class="body-row">
+    <div class="body-rows">
       {% block content %}
       {% endblock %}
     </div>

--- a/bootcamp/templates/bootcamp/index.html
+++ b/bootcamp/templates/bootcamp/index.html
@@ -4,14 +4,16 @@
 {% block title %}MIT Bootcamps{% endblock %}
 
 {% block content %}
-<div class="body-content photo-bg">
-  <div id="home" class="body-inner-content">
-    <h1>Pay Here for your MIT Bootcamp</h1>
-    <p class="desc">
-      We are excited that you want to join us! To pay for MIT Bootcamps, you need to
-      login with your edX account below.
-    </p>
-    <a href="{% url 'social:begin' 'edxorg' %}" class="btn large-cta">Login with edX</a>
+<div class="body-row">
+  <div class="photo-bg top-content-container">
+    <div id="home" class="top-content">
+      <h1>Pay Here for your MIT Bootcamp</h1>
+      <p class="desc">
+        We are excited that you want to join us! To pay for MIT Bootcamps, you need to
+        login with your edX account below.
+      </p>
+      <a href="{% url 'social:begin' 'edxorg' %}" class="btn large-cta">Login with edX</a>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/bootcamp/templates/bootcamp/pay.html
+++ b/bootcamp/templates/bootcamp/pay.html
@@ -4,9 +4,7 @@
 {% block title %}MIT Bootcamps{% endblock %}
 
 {% block content %}
-<div class="body-content">
-  <div id="pay" class="body-inner-content">
-  </div>
+<div id="pay">
 </div>
 {% load render_bundle %}
 {% render_bundle "payment" %}

--- a/klasses/conftest.py
+++ b/klasses/conftest.py
@@ -28,9 +28,9 @@ def patch_get_admissions(mocker, user):
                             "klass_name": klass.title,
                             "is_user_eligible_to_pay": True
                         } for klass in bootcamp.klass_set.order_by('id')
-                        ]
+                    ]
                 } for bootcamp in Bootcamp.objects.all().order_by('id')
-                ]
+            ]
         }
     )
 

--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -1,0 +1,118 @@
+// @flow
+/* global SETTINGS: false */
+import React from 'react';
+import _ from 'lodash';
+import moment from 'moment';
+
+import { isNilOrBlank, formatDollarAmount } from '../util/util';
+import type { UIState } from '../reducers';
+import type { RestState } from '../rest';
+import type { InputEvent } from '../flow/events';
+
+export default class Payment extends React.Component {
+  props: {
+    ui: UIState,
+    payment: RestState,
+    klasses: RestState,
+    selectedKlass: Object,
+    sendPayment: () => void,
+    setPaymentAmount: (event: InputEvent) => void,
+    setSelectedKlassIndex: (event: InputEvent) => void
+  };
+
+  renderKlassDropdown = () => {
+    const {
+      klasses,
+      ui: { selectedKlassIndex },
+      setSelectedKlassIndex
+    } = this.props;
+
+    let options = _.map(
+      klasses.data,
+      (klass, i) => (<option value={i} key={i}>{ klass.klass_name }</option>)
+    );
+    options.unshift(
+      <option value="" key="default" disabled style={{display: 'none'}}>Select...</option>
+    );
+    let valueProp = selectedKlassIndex ?
+      {value: selectedKlassIndex} :
+      {defaultValue: ""};
+
+    return (
+      <div className="klass-select-section">
+        <p className="desc">
+          Which Bootcamp do you want to pay for?
+        </p>
+        <div className="styled-select-container">
+          <select
+            className="klass-select"
+            onChange={setSelectedKlassIndex}
+            {...valueProp}
+          >
+            {options}
+          </select>
+        </div>
+      </div>
+    );
+  };
+
+  renderSelectedKlass = () => {
+    const {
+      ui: { paymentAmount },
+      payment: { processing },
+      selectedKlass,
+      setPaymentAmount,
+      sendPayment
+    } = this.props;
+
+    let deadlineDateText;
+    if (!_.isEmpty(selectedKlass.payment_deadline)) {
+      let deadlineDate = moment(selectedKlass.payment_deadline).format("MMM D, YYYY");
+      deadlineDateText = `You can pay any amount, but the full payment must be complete by ${deadlineDate}`;
+    } else {
+      deadlineDateText = 'You can pay any amount toward the total cost.';
+    }
+    let totalPaid = selectedKlass.total_paid || 0;
+
+    return <div className="klass-display-section">
+      <p className="desc">
+        You have been accepted to the {selectedKlass.klass_name} Bootcamp.<br />
+        You have paid {formatDollarAmount(totalPaid)} out
+        of {formatDollarAmount(selectedKlass.price)}.
+      </p>
+      <p className="deadline-date">{deadlineDateText}</p>
+      <div className="payment">
+        <input
+          type="number"
+          id="payment-amount"
+          value={paymentAmount}
+          onChange={setPaymentAmount}
+          placeholder="Enter amount"
+        />
+        <button className="btn large-cta" onClick={sendPayment} disabled={processing}>
+          Pay Now
+        </button>
+      </div>
+    </div>;
+  };
+
+  render() {
+    const { klasses, selectedKlass } = this.props;
+
+    let welcomeMessage = !isNilOrBlank(SETTINGS.user.full_name) ?
+      <h1 className="greeting">Hi {SETTINGS.user.full_name}!</h1> :
+      null;
+    let renderedKlassDropdown = (klasses.data && klasses.data.length > 1) ?
+      this.renderKlassDropdown() :
+      null;
+    let renderedSelectedKlass = selectedKlass ?
+      this.renderSelectedKlass() :
+      null;
+
+    return <div className="payment-section">
+      {welcomeMessage}
+      {renderedKlassDropdown}
+      {renderedSelectedKlass}
+    </div>;
+  }
+}

--- a/static/js/components/PaymentHistory.js
+++ b/static/js/components/PaymentHistory.js
@@ -1,0 +1,60 @@
+// @flow
+/* global SETTINGS: false */
+import React from 'react';
+import R from 'ramda';
+
+import { formatDollarAmount } from '../util/util';
+import type { RestState } from '../rest';
+
+export default class PaymentHistory extends React.Component {
+  props: {
+    klasses: RestState
+  };
+
+  renderPaymentRow = (klass: Object) => {
+    let paymentAmountMsg = klass.total_paid !== klass.price ?
+      `${formatDollarAmount(klass.total_paid)} out of ${formatDollarAmount(klass.price)}` :
+      `${formatDollarAmount(klass.total_paid)}`;
+
+    return <tr key={klass.klass_key}>
+      <td>{klass.klass_name}</td>
+      <td>{paymentAmountMsg}</td>
+      <td className="statement-column">
+        <i className="material-icons">print</i><a href="#" className="statement-link">View Statement</a>
+      </td>
+    </tr>;
+  };
+
+  renderPaymentRows = R.pipe(
+    R.filter(
+      R.compose(
+        R.not,
+        R.equals(0),
+        R.propOr(0, 'total_paid')
+      )
+    ),
+    R.map(this.renderPaymentRow)
+  );
+
+  render() {
+    const { klasses } = this.props;
+
+    return <div className="payment-history-section">
+      <div className="payment-history-block">
+        <h3>Payment History</h3>
+        <table>
+          <thead>
+            <tr>
+              <th className="col1">Bootcamp</th>
+              <th className="col2">Amount Paid</th>
+              <th className="col3" />
+            </tr>
+          </thead>
+          <tbody>
+            {this.renderPaymentRows(klasses.data)}
+          </tbody>
+        </table>
+      </div>
+    </div>;
+  }
+}

--- a/static/js/components/PaymentHistory_test.js
+++ b/static/js/components/PaymentHistory_test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { assert } from 'chai';
+import _ from 'lodash';
+
+import PaymentHistory from './PaymentHistory';
+import { generateFakeKlasses } from '../factories';
+
+describe("PaymentHistory", () => {
+  let renderPaymentHistory = (klassesData) => (
+    shallow(
+      <PaymentHistory
+        klasses={{
+          data: klassesData
+        }}
+      />
+    )
+  );
+
+  let setPaymentValues = (klassesData, paymentAmount) => (
+    _.map(klassesData,
+      (klass) => (_.set(klass, 'total_paid', paymentAmount))
+    )
+  );
+
+  it('should show rows of payment history information', () => {
+    let klassCount = 3;
+    let paymentAmount = 100;
+    let fakeKlasses = generateFakeKlasses(klassCount);
+    // Set all fake klasses to have payments
+    fakeKlasses = setPaymentValues(fakeKlasses, paymentAmount);
+    fakeKlasses[0].price = 1000;
+    fakeKlasses[1].price = paymentAmount;
+
+    let wrapper = renderPaymentHistory(fakeKlasses);
+    let paymentHistoryTableRows = wrapper.find('tbody tr');
+    assert.equal(paymentHistoryTableRows.length, klassCount);
+    assert.include(paymentHistoryTableRows.at(0).html(), `$${paymentAmount} out of $1,000`);
+    assert.include(paymentHistoryTableRows.at(1).html(), `$${paymentAmount}`);
+  });
+
+  it('should now show payment history information for klasses with no payments', () => {
+    let klassCount = 3;
+    let fakeKlasses = generateFakeKlasses(klassCount);
+    // Set all fake klasses to have payments
+    fakeKlasses = setPaymentValues(fakeKlasses, 100);
+    // Set one of the klasses to have no payment
+    fakeKlasses[1].total_paid = 0;
+
+    let wrapper = renderPaymentHistory(fakeKlasses);
+    let paymentHistoryTableRows = wrapper.find('tbody tr');
+    assert.equal(paymentHistoryTableRows.length, klassCount - 1);
+  });
+});

--- a/static/js/containers/PaymentPage.js
+++ b/static/js/containers/PaymentPage.js
@@ -1,0 +1,164 @@
+// @flow
+/* global SETTINGS: false */
+import React from 'react';
+import { connect } from 'react-redux';
+import type { Dispatch } from 'redux';
+import _ from 'lodash';
+import R from 'ramda';
+
+import {
+  clearUI,
+  setPaymentAmount,
+  setSelectedKlassIndex
+} from '../actions';
+import { actions } from '../rest';
+import { createForm } from '../util/util';
+import Payment from '../components/Payment';
+import PaymentHistory from '../components/PaymentHistory';
+import type { UIState } from '../reducers';
+import type { RestState } from '../rest';
+import type { InputEvent } from '../flow/events';
+
+class PaymentPage extends React.Component {
+  props: {
+    dispatch: Dispatch,
+    ui: UIState,
+    payment: RestState,
+    klasses: RestState,
+    selectedKlass: Object,
+  };
+
+  fetchAPIdata() {
+    this.fetchKlasses();
+  }
+
+  componentDidMount() {
+    this.fetchAPIdata();
+  }
+
+  componentDidUpdate() {
+    this.fetchAPIdata();
+  }
+
+  componentWillUnmount() {
+    const { dispatch } = this.props;
+    dispatch(clearUI());
+  }
+
+  fetchKlasses() {
+    const { dispatch, klasses } = this.props;
+    if (!klasses.fetchStatus) {
+      dispatch(
+        actions.klasses({username: SETTINGS.user.username})
+      );
+    }
+  }
+
+  sendPayment = () => {
+    const {
+      dispatch,
+      ui: { paymentAmount },
+      selectedKlass
+    } = this.props;
+    if (selectedKlass && paymentAmount) {
+      dispatch(
+        actions.payment({
+          paymentAmount: paymentAmount,
+          klassKey: selectedKlass.klass_key
+        })
+      ).then(result => {
+        const {url, payload} = result;
+        const form = createForm(url, payload);
+        const body = document.querySelector("body");
+        body.appendChild(form);
+        form.submit();
+      });
+    }
+  };
+
+  setPaymentAmount = (event: InputEvent) => {
+    const { dispatch } = this.props;
+    dispatch(setPaymentAmount(event.target.value));
+  };
+
+  setSelectedKlassIndex = (event: InputEvent) => {
+    const { dispatch } = this.props;
+    dispatch(setSelectedKlassIndex(parseInt(event.target.value)));
+  };
+
+  hasPastPayments = () => {
+    const { klasses } = this.props;
+
+    if (!klasses.data) return false;
+
+    let totalPaid = R.compose(
+      R.sum,
+      R.map(
+        R.propOr(0, 'total_paid')
+      )
+    )(klasses.data);
+    return totalPaid > 0;
+  };
+
+  render() {
+    const {
+      ui,
+      payment,
+      klasses,
+      selectedKlass
+    } = this.props;
+
+    let renderedPaymentHistory = this.hasPastPayments()
+      ? (
+        <div className="body-row">
+          <PaymentHistory klasses={klasses} />
+        </div>
+      )
+      : null;
+
+    return <div>
+      <div className="body-row top-content-container">
+        <div className="top-content">
+          <Payment
+            ui={ui}
+            payment={payment}
+            klasses={klasses}
+            selectedKlass={selectedKlass}
+            sendPayment={this.sendPayment}
+            setPaymentAmount={this.setPaymentAmount}
+            setSelectedKlassIndex={this.setSelectedKlassIndex}
+          />
+        </div>
+      </div>
+      { renderedPaymentHistory }
+    </div>;
+  }
+}
+
+const deriveSelectedKlass = state => {
+  let {
+    klasses,
+    ui: { selectedKlassIndex }
+  } = state;
+
+  let klassesExist = klasses.data && klasses.data.length > 0;
+  // If there's only one klass available, set selectedKlassIndex such that the one klass
+  // will be set as the selected klass.
+  if (klassesExist && klasses.data.length === 1) {
+    selectedKlassIndex = 0;
+  }
+  return klassesExist && _.isNumber(selectedKlassIndex)
+    ? klasses.data[selectedKlassIndex]
+    : undefined;
+};
+
+const mapStateToProps = state => {
+  return {
+    payment: state.payment,
+    klasses: state.klasses,
+    ui: state.ui,
+    selectedKlass: deriveSelectedKlass(state),
+  };
+};
+
+export default connect(mapStateToProps)(PaymentPage);

--- a/static/js/entry/payment.js
+++ b/static/js/entry/payment.js
@@ -4,14 +4,14 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 import configureStore from '../store/configureStore';
-import Payment from '../containers/Payment';
+import PaymentPage from '../containers/PaymentPage';
 
 const store = configureStore();
 
 const rootEl = document.getElementById("pay");
 ReactDOM.render(
   <Provider store={store}>
-    <Payment />
+    <PaymentPage />
   </Provider>,
   rootEl,
 );

--- a/static/js/factories/index.js
+++ b/static/js/factories/index.js
@@ -1,0 +1,12 @@
+import _ from 'lodash';
+import moment from 'moment';
+
+export const generateFakeKlasses = (numKlasses = 1) => {
+  return _.times(numKlasses, (i) => ({
+    klass_name: `Bootcamp 1 Klass ${i}`,
+    klass_key: i + 1,
+    payment_deadline: moment(),
+    total_paid: 0,
+    price: 1000
+  }));
+};

--- a/static/js/flow/events.js
+++ b/static/js/flow/events.js
@@ -1,0 +1,5 @@
+declare type ElementEventTemplate<E> = {
+  target: E
+} & Event;
+
+export type InputEvent = ElementEventTemplate<HTMLInputElement>;

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -24,3 +24,12 @@ export function createForm(url: string, payload: Object): HTMLFormElement {
 }
 
 export const isNilOrBlank = R.either(R.isNil, R.isEmpty);
+
+export const formatDollarAmount = (amount: ?number): string => {
+  amount = amount || 0;
+  return amount.toLocaleString('en-US', {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0
+  });
+};

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -1,6 +1,10 @@
 import { assert } from 'chai';
 
-import { createForm, isNilOrBlank } from './util';
+import {
+  createForm,
+  isNilOrBlank,
+  formatDollarAmount
+} from './util';
 
 describe('util', () => {
   describe('createForm', () => {
@@ -32,6 +36,16 @@ describe('util', () => {
 
     it('returns false for a non-blank string', () => {
       assert.isFalse(isNilOrBlank('not blank'));
+    });
+  });
+
+  describe('formatDollarAmount', () => {
+    it('returns a properly formatted dollar value', () => {
+      [undefined, null].forEach((nilValue) => {
+        assert.equal(formatDollarAmount(nilValue), '$0');
+      });
+      assert.equal(formatDollarAmount(100), '$100');
+      assert.equal(formatDollarAmount(10000), '$10,000');
     });
   });
 });

--- a/static/scss/_inputs.scss
+++ b/static/scss/_inputs.scss
@@ -1,6 +1,3 @@
-$input-color: #333;
-$input-font-size: 16px;
-
 .btn {
   border: none;
   margin: 0;
@@ -10,22 +7,28 @@ $input-font-size: 16px;
   letter-spacing: normal;
   color: #fff;
   cursor: pointer;
-  display: inline-block;
-  text-decoration: none;
 
   &.large-cta {
-    background-image: linear-gradient(to right, rgb(223, 17, 56) 0%, rgb(217, 71, 32) 100%);
+    background-image: linear-gradient(to right, $red 0%, $red-fade-to 100%);
     border-radius: 3px;
     font-size: 16px;
     height: 60px;
-    line-height: 60px;
     font-weight: 400;
     letter-spacing: 2px;
   }
 
   &:hover {
     text-decoration: none;
-    background: #dc032c;
+    background: $red-hover;
+  }
+}
+
+a.btn {
+  display: inline-block;
+  text-decoration: none;
+
+  &.large-cta {
+    line-height: 60px;
   }
 }
 
@@ -41,8 +44,40 @@ input {
 }
 
 ::placeholder {
-  color: #bbb;
+  color: $placeholder-color;
 }
+
+// Styles for hiding up/down arrows in number-type input
+// sass-lint:disable no-vendor-prefixes
+input[type=number] {
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    cursor: pointer;
+    display: block;
+    width: 8px;
+    color: #333;
+    text-align: center;
+    position: relative;
+  }
+
+  &::-webkit-inner-spin-button:before,
+  &::-webkit-inner-spin-button:after {
+    content: "^";
+    position: absolute;
+    right: 0;
+    font-family: monospace;
+  }
+
+  &::-webkit-inner-spin-button:before {
+    top: 0;
+  }
+
+  &::-webkit-inner-spin-button:after {
+    bottom: 0;
+    -webkit-transform: rotate(180deg);
+  }
+}
+// sass-lint:enable no-vendor-prefixes
 
 // Adapted from http://codepen.io/fil_dev/pen/oZNXzw
 .styled-select-container {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -1,4 +1,14 @@
+$light-gray: #e6e6e6;
 $med-gray: #b1b1b1;
 $med-dark-gray: #707070;
+$dark-gray: #202020;
+$red: rgb(223, 17, 56);
+$red-fade-to: rgb(217, 71, 32);
+$red-hover: #dc032c;
+
+$input-color: #333;
+$placeholder-color: #bbb;
+$input-font-size: 16px;
 
 $artsy-font: PT Serif, "Times New Roman", Helvetica, Arial, sans-serif;
+$sans-serif-font: Lato, sans-serif;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -8,29 +8,19 @@
 body {
   margin: 0;
   padding: 0;
-  background-color: #000;
+  background-color: $dark-gray;
   color: #fff;
   font-family: Roboto, Helvetica, Arial, sans-serif;
+  text-align: center;
 }
 
-.body-row {
-  display: flex;
-}
-
-.body-content {
+.photo-bg {
   /* background-image from background-images.css */
-  flex-direction: column;
-  align-items: center;
-  background-color: #202020;
-  min-height: 800px;
-  width: 100%;
-  margin: 0 auto;
+  min-height: 730px;
+}
 
-  .body-inner-content {
-    width: 90%;
-    margin: 25px auto 0 auto;
-    padding-top: 50px;
-  }
+.top-content-container {
+  padding: 20px 30px 0 30px;
 }
 
 h1 {

--- a/static/scss/login.scss
+++ b/static/scss/login.scss
@@ -1,9 +1,5 @@
-.body-content .body-inner-content#home {
-  padding-top: 26vh;
-}
-
 #home {
-  text-align: center;
+  padding: 26vh 0 25px 0;
 
   p {
     max-width: 725px;
@@ -15,5 +11,3 @@
     width: 265px;
   }
 }
-
-

--- a/static/scss/payment.scss
+++ b/static/scss/payment.scss
@@ -1,9 +1,13 @@
-.body-content .body-inner-content#pay {
-  padding-top: 100px;
-}
-
 #pay {
-  text-align: center;
+  background-color: $dark-gray;
+
+  .payment-section {
+    padding: 100px 0;
+
+    h1 {
+      margin: 10px 0 30px 0;
+    }
+  }
 
   .klass-select-section {
     padding-bottom: 50px;
@@ -20,10 +24,97 @@
     flex-direction: column;
     max-width: 285px;
     margin: 0 auto;
-    padding: 25px 0 75px 0;
+    padding-top: 25px;
 
     input {
       margin-bottom: 25px;
+    }
+  }
+
+  .payment-history-section {
+    background-color: $light-gray;
+    text-align: left;
+
+    .payment-history-block {
+      max-width: 850px;
+      margin: 0 auto;
+      padding: 60px 10px;
+
+      h3 {
+        padding: 0 0 45px 0;
+        margin: 0;
+        color: #000;
+        font-family: $sans-serif-font;
+        font-size: 15px;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+
+        &::after {
+          content: " ";
+          display: inline-block;
+          background-color: $med-gray;
+          margin-left: 15px;
+          height: 1px;
+          width: 70px;
+          position: relative;
+          bottom: 5px;
+        }
+      }
+
+      table {
+        margin: 0;
+        padding: 0;
+        border-collapse: collapse;
+        color: $med-dark-gray;
+        font-family: $artsy-font;
+        font-size: 18px;
+        width: 100%;
+
+        th {
+          font-family: $sans-serif-font;
+          font-size: 13px;
+          font-weight: normal;
+          text-transform: uppercase;
+          padding-bottom: 10px;
+        }
+
+        .col1 {
+          width: 45%;
+        }
+
+        .col2 {
+          width: 33%;
+        }
+
+        .col3 {
+          width: 20%;
+        }
+
+        td {
+          padding-right: 7px;
+        }
+      }
+
+      .statement-column {
+        color: $red;
+        text-transform: uppercase;
+        white-space: nowrap;
+
+        i {
+          position: relative;
+          top: 8px;
+          font-size: 26px;
+        }
+
+        a {
+          color: $red;
+          font-family: $sans-serif-font;
+          font-size: 11px;
+          display: inline-block;
+          text-decoration: none;
+          padding: 0 0 15px 15px;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #58 

#### What's this PR do?
- Adds the payment history component (detailed [here](https://projects.invisionapp.com/share/SFBD1T7DW#/screens/229943705))
- Changes some html/css to make content areas & backgrounds stretch across the length of the screen (discussed with @roberthouse54)
- Splits the payment component into a payment container + 2 child components (Payment and PaymentHistory)

#### How should this be manually tested?
- Navigate to `/pay` with no previous payments, make sure that the history component doesn't show up
- Navigate to `/pay` with no previous payments, make sure history component is visible, amounts are consistent, UI is correct, etc.

#### Where should the reviewer start?
`static/js/components/PaymentHistory.js` and `static/js/containers/PaymentPage.js`

#### Any background context you want to provide?
**The diff is a lot larger than the actual changes due to some movement of code.** `static/js/containers/PaymentPage.js` and `static/js/containers/Payment.js` were split from a single js file. `static/js/containers/Payment.js` has no new logic, and the only logic added in `static/js/containers/PaymentPage.js` is for deciding whether or not the `PaymentHistory` component should be rendered, and the code to actually render it.

#### Screenshots (if appropriate)
![ss 2017-05-04 at 13 49 42](https://cloud.githubusercontent.com/assets/14932219/25717477/926d95b2-30d0-11e7-90ce-54b57adbeb64.png)

