### PR TITLE
Changed klass title text in UI

### DIFF
--- a/klasses/api.py
+++ b/klasses/api.py
@@ -32,7 +32,10 @@ def serialize_user_klasses(user):
 
     bootcamp_client = BootcampAdmissionClient(user.email)
     all_klasses_keys = list(set(klass_keys_in_lines).union(set(bootcamp_client.payable_klasses_keys)))
-    klasses_qset = Klass.objects.filter(klass_key__in=all_klasses_keys).order_by('klass_key')
+    klasses_qset = (
+        Klass.objects.filter(klass_key__in=all_klasses_keys)
+        .select_related('bootcamp').order_by('klass_key')
+    )
 
     return [serialize_user_klass(user, klass, bootcamp_client) for klass in klasses_qset]
 
@@ -56,6 +59,7 @@ def serialize_user_klass(user, klass, bootcamp_client=None):
     return {
         "klass_key": klass.klass_key,
         "klass_name": klass.title,
+        "display_title": klass.display_title,
         "start_date": klass.start_date,
         "end_date": klass.end_date,
         "payment_deadline": klass.payment_deadline,

--- a/klasses/api_test.py
+++ b/klasses/api_test.py
@@ -63,6 +63,7 @@ def test_serialize_user_klass_paid(test_data):
     expected_ret = {
         "klass_key": klass_paid.klass_key,
         "klass_name": klass_paid.title,
+        "display_title": klass_paid.display_title,
         "start_date": klass_paid.start_date,
         "end_date": klass_paid.end_date,
         "payment_deadline": klass_paid.payment_deadline,
@@ -85,6 +86,7 @@ def test_serialize_user_klass_not_paid(test_data):
     expected_ret = {
         "klass_key": klass_not_paid.klass_key,
         "klass_name": klass_not_paid.title,
+        "display_title": klass_not_paid.display_title,
         "start_date": klass_not_paid.start_date,
         "end_date": klass_not_paid.end_date,
         "payment_deadline": klass_not_paid.payment_deadline,
@@ -107,6 +109,7 @@ def test_serialize_user_klasses(test_data):
         {
             "klass_key": klass_paid.klass_key,
             "klass_name": klass_paid.title,
+            "display_title": klass_paid.display_title,
             "start_date": klass_paid.start_date,
             "end_date": klass_paid.end_date,
             "payment_deadline": klass_paid.payment_deadline,
@@ -120,6 +123,7 @@ def test_serialize_user_klasses(test_data):
         {
             "klass_key": klass_not_paid.klass_key,
             "klass_name": klass_not_paid.title,
+            "display_title": klass_not_paid.display_title,
             "start_date": klass_not_paid.start_date,
             "end_date": klass_not_paid.end_date,
             "payment_deadline": klass_not_paid.payment_deadline,

--- a/klasses/models.py
+++ b/klasses/models.py
@@ -32,6 +32,50 @@ class Klass(models.Model):
         return self.installment_set.aggregate(price=models.Sum('amount'))['price']
 
     @property
+    def formatted_date_range(self):
+        """
+        Returns a formatted date range.
+
+        Example return values:
+        - Start/end in same month: "May 5 - 10 2017"
+        - Start/end in different months: "May 5 - June 10 2017"
+        - Start/end in different years: "May 5 2017 - May 5 2018"
+        - No end date: "May 5 2017"
+        """
+        month_day_format = '%b %-d'
+        if self.start_date and self.end_date:
+            start_date_month_day = self.start_date.strftime(month_day_format)
+            end_date_month_day = self.end_date.strftime(month_day_format)
+            if self.start_date.year == self.end_date.year:
+                if self.start_date.month == self.end_date.month:
+                    formatted_end_date = self.end_date.day
+                else:
+                    formatted_end_date = end_date_month_day
+                return '{} - {} {}'.format(start_date_month_day, formatted_end_date, self.end_date.year)
+            else:
+                return '{} {} - {} {}'.format(
+                    start_date_month_day,
+                    self.start_date.year,
+                    end_date_month_day,
+                    self.end_date.year
+                )
+        elif self.start_date:
+            return '{} {}'.format(self.start_date.strftime(month_day_format), self.start_date.year)
+        else:
+            return ''
+
+    @property
+    def display_title(self):
+        """
+        Returns a string that will be used to represent the bootcamp/klass in the app
+        """
+        title_parts = [self.bootcamp.title]
+        formatted_date_range = self.formatted_date_range
+        if formatted_date_range:
+            title_parts.append(formatted_date_range)
+        return ', '.join(title_parts)
+
+    @property
     def payment_deadline(self):
         """
         Get the overall payment deadline

--- a/klasses/models_test.py
+++ b/klasses/models_test.py
@@ -40,6 +40,33 @@ def test_klass_payment_deadline():
     assert klass.payment_deadline == installment_2.deadline
 
 
+def test_klass_formatted_date_range():
+    """Test that the formatted_date_range property returns expected values with various start/end dates"""
+    base_date = datetime(year=2017, month=1, day=1)
+    date_same_month = datetime(year=2017, month=1, day=10)
+    date_different_month = datetime(year=2017, month=2, day=1)
+    date_different_year = datetime(year=2018, month=1, day=1)
+    klass = KlassFactory.build(start_date=base_date, end_date=date_same_month)
+    assert klass.formatted_date_range == 'Jan 1 - 10 2017'
+    klass = KlassFactory.build(start_date=base_date, end_date=date_different_month)
+    assert klass.formatted_date_range == 'Jan 1 - Feb 1 2017'
+    klass = KlassFactory.build(start_date=base_date, end_date=date_different_year)
+    assert klass.formatted_date_range == 'Jan 1 2017 - Jan 1 2018'
+    klass = KlassFactory.build(start_date=base_date, end_date=None)
+    assert klass.formatted_date_range == 'Jan 1 2017'
+    klass = KlassFactory.build(start_date=None, end_date=None)
+    assert klass.formatted_date_range == ''
+
+
+def test_klass_display_title():
+    """Test that the display_title property matches expectations"""
+    bootcamp_title = 'Bootcamp 1'
+    klass_with_date = KlassFactory.build(bootcamp__title=bootcamp_title, start_date=datetime.now())
+    assert klass_with_date.display_title == '{}, {}'.format(bootcamp_title, klass_with_date.formatted_date_range)
+    klass_without_dates = KlassFactory.build(bootcamp__title=bootcamp_title, start_date=None, end_date=None)
+    assert klass_without_dates.display_title == bootcamp_title
+
+
 @pytest.fixture()
 def test_data():
     """

--- a/klasses/views_test.py
+++ b/klasses/views_test.py
@@ -28,6 +28,7 @@ KLASS_FIELDS = [
     'installments',
     'payments',
     'klass_name',
+    'display_title',
     'is_user_eligible_to_pay',
     'payment_deadline',
     'price',

--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -29,7 +29,7 @@ export default class Payment extends React.Component {
 
     let options = _.map(
       payableKlassesData,
-      (klass) => (<option value={klass.klass_key} key={klass.klass_key}>{ klass.klass_name }</option>)
+      (klass) => (<option value={klass.klass_key} key={klass.klass_key}>{ klass.display_title }</option>)
     );
     options.unshift(
       <option value="" key="default" disabled style={{display: 'none'}}>Select...</option>
@@ -76,7 +76,7 @@ export default class Payment extends React.Component {
 
     return <div className="klass-display-section">
       <p className="desc">
-        You have been accepted to the {selectedKlass.klass_name} Bootcamp.<br />
+        You have been accepted to {selectedKlass.display_title}.<br />
         You have paid {formatDollarAmount(totalPaid)} out
         of {formatDollarAmount(selectedKlass.price)}.
       </p>

--- a/static/js/components/PaymentHistory.js
+++ b/static/js/components/PaymentHistory.js
@@ -16,7 +16,7 @@ export default class PaymentHistory extends React.Component {
       `${formatDollarAmount(klass.total_paid)}`;
 
     return <tr key={klass.klass_key}>
-      <td>{klass.klass_name}</td>
+      <td>{klass.display_title}</td>
       <td>{paymentAmountMsg}</td>
       <td className="statement-column">
         <i className="material-icons">print</i><a href="#" className="statement-link">View Statement</a>

--- a/static/js/components/PaymentHistory_test.js
+++ b/static/js/components/PaymentHistory_test.js
@@ -31,7 +31,11 @@ describe("PaymentHistory", () => {
     let wrapper = renderPaymentHistory(fakeKlasses);
     let paymentHistoryTableRows = wrapper.find('tbody tr');
     assert.equal(paymentHistoryTableRows.length, klassCount);
-    assert.include(paymentHistoryTableRows.at(0).html(), `$${paymentAmount} out of $1,000`);
-    assert.include(paymentHistoryTableRows.at(1).html(), `$${paymentAmount}`);
+    let firstRowHtml = paymentHistoryTableRows.at(0).html();
+    assert.include(firstRowHtml, fakeKlasses[0].display_title);
+    assert.include(firstRowHtml, `$${paymentAmount} out of $1,000`);
+    let secondRowHtml = paymentHistoryTableRows.at(1).html();
+    assert.include(secondRowHtml, fakeKlasses[1].display_title);
+    assert.include(secondRowHtml, `$${paymentAmount}`);
   });
 });

--- a/static/js/containers/PaymentPage_test.js
+++ b/static/js/containers/PaymentPage_test.js
@@ -113,7 +113,7 @@ describe('Payment container', () => {
 
       return renderFullPaymentPage().then((wrapper) => {
         let title = wrapper.find(klassTitleSelector);
-        assert.include(title.text(), fakeKlasses[0].klass_name);
+        assert.include(title.text(), fakeKlasses[0].display_title);
       });
     });
 

--- a/static/js/factories/index.js
+++ b/static/js/factories/index.js
@@ -3,7 +3,8 @@ import moment from 'moment';
 
 export const generateFakeKlasses = (numKlasses = 1) => {
   return _.times(numKlasses, (i) => ({
-    klass_name: `Bootcamp 1 Klass ${i}`,
+    klass_name: `Klass ${i}`,
+    display_title: `Bootcamp Klass ${i}`,
     klass_key: i + 1,
     payment_deadline: moment(),
     total_paid: 0,


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #78

#### What's this PR do?
Adds a new klass title property to the klasses API, and displays that title value in the UI wherever a full klass title is needed

#### How should this be manually tested?
Look at the `/pay` page and make sure that klasses in the dropdown/page body/payment history component show the klass title as "<Bootcamp.title> - <Klass.title>".

We still have the same issue with the bootcamp test server as discussed in PR #77. The patch link in that description should still work for mocking out results from the external bootcamp API
