### PR TITLE
Fixed display for numbers with decimal points

### DIFF
--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -30,6 +30,7 @@ export const formatDollarAmount = (amount: ?number): string => {
   return amount.toLocaleString('en-US', {
     style: "currency",
     currency: "USD",
-    maximumFractionDigits: 0
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2
   });
 };

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -46,6 +46,7 @@ describe('util', () => {
       });
       assert.equal(formatDollarAmount(100), '$100');
       assert.equal(formatDollarAmount(10000), '$10,000');
+      assert.equal(formatDollarAmount(100.12), '$100.12');
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
Fixes a bug having to do with displaying numbers w/ decimal points in certain browsers

#### How should this be manually tested?
Set an `Installment.amount` or any `Line.price` to have a value with non-zero decimal places. Make sure it shows up in the payment history or the main payment section correctly
