### PR TITLE
Prevent users from making a payment if forbidden from paying for a klass

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -24,6 +24,7 @@ from ecommerce.models import (
     Line,
     Order,
 )
+from klasses.bootcamp_admissions_client import BootcampAdmissionClient
 from klasses.models import Klass
 
 
@@ -71,6 +72,11 @@ def create_unfulfilled_order(user, klass_key, payment_amount):
     except Klass.DoesNotExist:
         # In the near future we should do other checking here based on information from Bootcamp REST API
         raise ValidationError("Incorrect klass key {}".format(klass_key))
+
+    bootcamp_client = BootcampAdmissionClient(user.email)
+    if not bootcamp_client.can_pay_klass(klass_key):
+        raise ValidationError("User is unable to pay for klass {}".format(klass_key))
+
     if payment_amount <= 0:
         raise ValidationError("Payment is less than or equal to zero")
 

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -13,11 +13,11 @@ from django.test import (
 import faker
 from rest_framework import status as statuses
 
-from ecommerce.api import (
-    create_unfulfilled_order,
-    make_reference_id,
+from ecommerce.api import make_reference_id
+from ecommerce.api_test import (
+    create_purchasable_klass,
+    create_test_order,
 )
-from ecommerce.api_test import create_purchasable_klass
 from ecommerce.exceptions import EcommerceException
 from ecommerce.models import (
     Order,
@@ -108,7 +108,7 @@ class OrderFulfillmentViewTests(TestCase):
         Test the happy case
         """
         klass, user = create_purchasable_klass()
-        order = create_unfulfilled_order(user, klass.klass_key, 123)
+        order = create_test_order(user, klass.klass_key, 123)
         data_before = order.to_dict()
 
         data = {}
@@ -170,7 +170,7 @@ class OrderFulfillmentViewTests(TestCase):
         If the decision is not ACCEPT then the order should be marked as failed
         """
         klass, user = create_purchasable_klass()
-        order = create_unfulfilled_order(user, klass.klass_key, 123)
+        order = create_test_order(user, klass.klass_key, 123)
 
         data = {
             'req_reference_number': make_reference_id(order),
@@ -204,7 +204,7 @@ class OrderFulfillmentViewTests(TestCase):
         If the decision is CANCEL and we already have a duplicate failed order, don't change anything.
         """
         klass, user = create_purchasable_klass()
-        order = create_unfulfilled_order(user, klass.klass_key, 123)
+        order = create_test_order(user, klass.klass_key, 123)
         order.status = Order.FAILED
         order.save()
 
@@ -231,7 +231,7 @@ class OrderFulfillmentViewTests(TestCase):
     def test_error_on_duplicate_order(self, order_status, decision):
         """If there is a duplicate message (except for CANCEL), raise an exception"""
         klass, user = create_purchasable_klass()
-        order = create_unfulfilled_order(user, klass.klass_key, 123)
+        order = create_test_order(user, klass.klass_key, 123)
         order.status = order_status
         order.save()
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #64 

#### What's this PR do?
Adds a validation check if the user is not eligible to pay

#### How should this be manually tested?
If we're already hiding the UI to purchase for non-eligible klasses I don't think we can manually test this