### PR TITLE
Removed integer keys from async_cache_admissions task

### DIFF
--- a/klasses/bootcamp_admissions_client.py
+++ b/klasses/bootcamp_admissions_client.py
@@ -20,14 +20,14 @@ class BootcampAdmissionClient:
     """
 
     admissions = {}
-    payable_klasses = {}
+    payable_klasses = []
     payable_klasses_keys = []
 
     def __init__(self, user_email):
         self.user_email = user_email
         self.admissions = self._get_admissions()
         self.payable_klasses = self._get_payable_klasses()
-        self.payable_klasses_keys = list(self.payable_klasses.keys())
+        self.payable_klasses_keys = [klass['klass_id'] for klass in self.payable_klasses]
         # trigger the async task to cache the info
         if self.payable_klasses:
             async_cache_admissions.delay(self.user_email, self.payable_klasses)
@@ -94,11 +94,11 @@ class BootcampAdmissionClient:
         """
         Returns a list of the payable klasses.
         """
-        adm_klasses = {}
+        adm_klasses = []
         for bootcamp in self.admissions.get("bootcamps", []):
             for klass in bootcamp.get("klasses", []):
                 if klass.get("is_user_eligible_to_pay") is True:
-                    adm_klasses[klass["klass_id"]] = klass
+                    adm_klasses.append(klass)
         return adm_klasses
 
     def can_pay_klass(self, klass_key):

--- a/klasses/bootcamp_admissions_client_test.py
+++ b/klasses/bootcamp_admissions_client_test.py
@@ -103,14 +103,14 @@ def test_happy_path(test_data, mocked_get_200, mocked_update_cache):
     boot_client = BootcampAdmissionClient(user_email)
     mocked_get_200.request.assert_called_once_with(url)
     assert boot_client.admissions == JSON_RESP_OBJ
-    expected_payable_klasses = {
-        16: {
+    expected_payable_klasses = [
+        {
             "klass_id": 16,
             "klass_name": "Class 1",
             "status": "scholarship_not_awarded",
             "is_user_eligible_to_pay": True
         }
-    }
+    ]
     assert boot_client.payable_klasses == expected_payable_klasses
     assert boot_client.payable_klasses_keys == [16]
     mocked_update_cache.assert_called_once_with(user_email, expected_payable_klasses)
@@ -126,7 +126,7 @@ def test_get_raises(test_data, mocked_get_200, mocked_update_cache):
     boot_client = BootcampAdmissionClient(user_email)
     mocked_get_200.request.assert_called_once_with(url)
     assert boot_client.admissions == {}
-    assert boot_client.payable_klasses == {}
+    assert boot_client.payable_klasses == []
     assert boot_client.payable_klasses_keys == []
     assert mocked_update_cache.call_count == 0
 
@@ -140,7 +140,7 @@ def test_status_code_not_200(test_data, mocked_get_400, mocked_update_cache):
     boot_client = BootcampAdmissionClient(user_email)
     mocked_get_400.request.assert_called_once_with(url)
     assert boot_client.admissions == {}
-    assert boot_client.payable_klasses == {}
+    assert boot_client.payable_klasses == []
     assert boot_client.payable_klasses_keys == []
     assert mocked_update_cache.call_count == 0
 
@@ -156,7 +156,7 @@ def test_json_raises(test_data, mocked_get_200, mocked_update_cache):
     boot_client = BootcampAdmissionClient(user_email)
     mocked_get_200.request.assert_called_once_with(url)
     assert boot_client.admissions == {}
-    assert boot_client.payable_klasses == {}
+    assert boot_client.payable_klasses == []
     assert boot_client.payable_klasses_keys == []
     assert mocked_update_cache.call_count == 0
 

--- a/klasses/tasks.py
+++ b/klasses/tasks.py
@@ -25,8 +25,8 @@ def _cache_admissions(user_email, payable_klasses):
         log.exception('User with email %s does not exists', user_email)
         return
 
-    payable_klasses_keys = [klass['klass_id'] for klass in payable_klasses]
     payable_klasses_lookup = {klass['klass_id']: klass for klass in payable_klasses}
+    payable_klasses_keys = list(payable_klasses_lookup.keys())
     local_klasses = Klass.objects.filter(klass_key__in=payable_klasses_keys)
 
     for klass in local_klasses:


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #93 

#### What's this PR do?
Changes format of admissions data passed to `async_cache_admissions` to no longer use integer keys

#### How should this be manually tested?
- Delete all `BootcampAdmissionsCache` objects for some user
- Open a shell and run `BootcampAdmissionsClient(email)` where email is the email address of that user
- Check that the task populated `BootcampAdmissionsCache` objects for that user
