### PR TITLE
Added message for users with no payment-eligible klasses

### DIFF
--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -150,7 +150,7 @@ export default class Payment extends React.Component {
       null;
     let renderedKlassDropdown = (payableKlassesData.length > 1) ?
       this.renderKlassDropdown() :
-      null;
+      <p className="desc">No payment is required at this time.</p>;
     let renderedSelectedKlass = selectedKlass ?
       this.renderSelectedKlass() :
       null;

--- a/static/js/components/Payment_test.js
+++ b/static/js/components/Payment_test.js
@@ -16,13 +16,14 @@ import {
 } from '../util/util';
 
 describe("Payment", () => {
-  const deadlineMsgSelector = '.deadline-message';
+  const deadlineMsgSelector = '.deadline-message',
+    klassDropdownSelector = 'select.klass-select';
 
   let defaultProps = {
     ui: {},
     payment: {},
     payableKlassesData: [],
-    selectedKlass: {},
+    selectedKlass: undefined,
     now: moment(),
     sendPayment: () => {},
     setPaymentAmount: () => {},
@@ -34,6 +35,24 @@ describe("Payment", () => {
       <Payment {...defaultProps} {...props} />
     );
   };
+
+  it('should show the user a message when no klasses are eligible for payment', () => {
+    let wrapper = renderPayment({payableKlassesData: []});
+    assert.include(wrapper.html(), 'No payment is required at this time.');
+  });
+
+  describe('klass dropdown', () => {
+    [
+      [1, false],
+      [2, true]
+    ].forEach(([numKlasses, shouldShowDropdown]) => {
+      it(`should${shouldShowDropdown ? '' : ' not'} be shown when ${numKlasses} klasses available`, () => {
+        let fakeKlasses = generateFakeKlasses(numKlasses);
+        let wrapper = renderPayment({payableKlassesData: fakeKlasses});
+        assert.equal(wrapper.find(klassDropdownSelector).exists(), shouldShowDropdown);
+      });
+    });
+  });
 
   describe('deadline message', () => {
     it('should show the final payment deadline date and no installment deadline with one installment', () => {

--- a/static/js/containers/PaymentPage_test.js
+++ b/static/js/containers/PaymentPage_test.js
@@ -37,7 +37,6 @@ const RECEIVE_KLASSES_SUCCESS = makeReceiveSuccessActionType('klasses');
 
 describe('PaymentPage', () => {
   const klassTitleSelector = '.klass-display-section .desc',
-    klassDropdownSelector = 'select.klass-select',
     welcomeMsgSelector = 'h1.greeting',
     paymentInputSelector = 'input[id="payment-amount"]',
     paymentBtnSelector = 'button.large-cta',
@@ -102,6 +101,17 @@ describe('PaymentPage', () => {
     });
   });
 
+  it('only passes payable klasses to the Payment component', () => {
+    let fakeKlasses = generateFakeKlasses(3);
+    fakeKlasses[1].is_user_eligible_to_pay = false;
+    klassesStub = fetchStub.withArgs(klassesUrl)
+      .returns(Promise.resolve(fakeKlasses));
+
+    return renderFullPaymentPage().then((wrapper) => {
+      assert.lengthOf(wrapper.find('Payment').prop('payableKlassesData'), 2);
+    });
+  });
+
   describe('UI', () => {
     it('shows the name of the user in a welcome message', () => {
       let fakeKlasses = generateFakeKlasses();
@@ -133,32 +143,6 @@ describe('PaymentPage', () => {
         .returns(Promise.resolve(generateFakeKlasses(1)));
       return renderFullPaymentPage().then((wrapper) => {
         assert.isFalse(wrapper.find(welcomeMsgSelector).exists());
-      });
-    });
-
-    [
-      [1, false],
-      [2, true]
-    ].forEach(([numKlasses, shouldShowDropdown]) => {
-      it(`should ${shouldShowDropdown ? '' : 'not'} show dropdown when ${numKlasses} klasses available`, () => {
-        let fakeKlasses = generateFakeKlasses(numKlasses);
-        klassesStub = fetchStub.withArgs(klassesUrl)
-          .returns(Promise.resolve(fakeKlasses));
-
-        return renderFullPaymentPage().then((wrapper) => {
-          assert.equal(wrapper.find(klassDropdownSelector).exists(), shouldShowDropdown);
-        });
-      });
-    });
-
-    it('only shows payable klasses in the klass dropdown', () => {
-      let fakeKlasses = generateFakeKlasses(3);
-      fakeKlasses[1].is_user_eligible_to_pay = false;
-      klassesStub = fetchStub.withArgs(klassesUrl)
-        .returns(Promise.resolve(fakeKlasses));
-
-      return renderFullPaymentPage().then((wrapper) => {
-        assert.lengthOf(wrapper.find('Payment').prop('payableKlassesData'), 2);
       });
     });
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #67 

#### What's this PR do?
Adds message for users with no payment-eligible klasses

#### How should this be manually tested?
Check out `/pay` with no payment-eligible klasses (this should be the default for pretty much all of us)

#### Any background context you want to provide?
I moved a couple js tests from `static/js/containers/PaymentPage_test.js` to `static/js/containers/Payment_test.js`. They were originally there because `PaymentPage` was the only component we had

#### Screenshots (if appropriate)
![ss 2017-05-19 at 17 13 03](https://cloud.githubusercontent.com/assets/14932219/26268033/400dc192-3cbb-11e7-909a-55f2ba4f75cb.png)
