### PR TITLE
Fixed bug with 'no payment' message

### DIFF
--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -148,16 +148,19 @@ export default class Payment extends React.Component {
     let welcomeMessage = !isNilOrBlank(SETTINGS.user.full_name) ?
       <h1 className="greeting">Hi {SETTINGS.user.full_name}!</h1> :
       null;
-    let renderedKlassDropdown = (payableKlassesData.length > 1) ?
-      this.renderKlassDropdown() :
-      <p className="desc">No payment is required at this time.</p>;
+    let renderedKlassChoice;
+    if (payableKlassesData.length > 1) {
+      renderedKlassChoice = this.renderKlassDropdown();
+    } else if (payableKlassesData.length === 0) {
+      renderedKlassChoice = <p className="desc">No payment is required at this time.</p>;
+    }
     let renderedSelectedKlass = selectedKlass ?
       this.renderSelectedKlass() :
       null;
 
     return <div className="payment-section">
       {welcomeMessage}
-      {renderedKlassDropdown}
+      {renderedKlassChoice}
       {renderedSelectedKlass}
     </div>;
   }

--- a/static/js/components/Payment_test.js
+++ b/static/js/components/Payment_test.js
@@ -16,7 +16,8 @@ import {
 } from '../util/util';
 
 describe("Payment", () => {
-  const deadlineMsgSelector = '.deadline-message',
+  const paymentSectionSelector = '.payment-section',
+    deadlineMsgSelector = '.deadline-message',
     klassDropdownSelector = 'select.klass-select';
 
   let defaultProps = {
@@ -53,6 +54,22 @@ describe("Payment", () => {
       });
     });
   });
+
+  describe('"No payments required" message', () => {
+    let noPaymentMsg = "No payment is required at this time";
+    [
+      [0, true],
+      [1, false],
+      [2, false]
+    ].forEach(([numKlasses, shouldShowMessage]) => {
+      it(`should${shouldShowMessage ? '' : ' not'} be shown when ${numKlasses} klasses available`, () => {
+        let fakeKlasses = generateFakeKlasses(numKlasses);
+        let wrapper = renderPayment({payableKlassesData: fakeKlasses});
+        assert.equal(wrapper.find(paymentSectionSelector).html().indexOf(noPaymentMsg) >= 0, shouldShowMessage);
+      });
+    });
+  });
+
 
   describe('deadline message', () => {
     it('should show the final payment deadline date and no installment deadline with one installment', () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #106 

#### What's this PR do?
Fixes bug where 'no payment' message was displaying even with a payment-eligible klass

#### How should this be manually tested?
Navigate to `/pay` with 1 payment-eligible klass

#### What image best describes this PR or how it makes you feel?
![](http://i.imgur.com/uQoHgUV.png)
