### PR TITLE
Fixed bug w/ 'no klasses' message being shown while API results were …

### DIFF
--- a/static/js/containers/PaymentPage.js
+++ b/static/js/containers/PaymentPage.js
@@ -14,6 +14,7 @@ import {
   setSelectedKlassKey,
   setTimeoutActive,
   setToastMessage,
+  FETCH_SUCCESS,
 } from '../actions';
 import {
   TOAST_SUCCESS,
@@ -229,18 +230,11 @@ class PaymentPage extends React.Component {
       selectedKlass
     } = this.props;
 
-    let klassDataWithPayments = this.getKlassDataWithPayments(klasses.data || []);
-    let renderedPaymentHistory = klassDataWithPayments.length > 0
-      ? (
-        <div className="body-row">
-          <PaymentHistory klassDataWithPayments={klassDataWithPayments} />
-        </div>
-      )
-      : null;
+    let renderedPayment = null,
+      renderedPaymentHistory = null;
 
-    return <div>
-      <div className="body-row top-content-container">
-        {this.renderToast()}
+    if (klasses.fetchStatus === FETCH_SUCCESS) {
+      renderedPayment = (
         <Payment
           ui={ui}
           payment={payment}
@@ -251,8 +245,24 @@ class PaymentPage extends React.Component {
           setPaymentAmount={this.setPaymentAmount}
           setSelectedKlassKey={this.setSelectedKlassKey}
         />
+      );
+
+      let klassDataWithPayments = this.getKlassDataWithPayments(klasses.data || []);
+      renderedPaymentHistory = klassDataWithPayments.length > 0
+        ? (
+          <div className="body-row">
+            <PaymentHistory klassDataWithPayments={klassDataWithPayments}/>
+          </div>
+        )
+        : null;
+    }
+
+    return <div>
+      <div className="body-row top-content-container">
+        {this.renderToast()}
+        {renderedPayment}
       </div>
-      { renderedPaymentHistory }
+      {renderedPaymentHistory}
     </div>;
   }
 }

--- a/static/scss/payment.scss
+++ b/static/scss/payment.scss
@@ -5,7 +5,7 @@
     padding: 100px 0;
 
     h1 {
-      margin: 10px 0 30px 0;
+      margin: 0 0 30px 0;
     }
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #109 

#### What's this PR do?
Fixes bug where 'no payments required' message was being shown while API results were still pending.

#### How should this be manually tested?
Load the `/pay` page with an enrollable klass configured on the admissions server. Make sure you don't see the 'No payments required` message flash before the results are loaded.

#### Any background context you want to provide?
We could get fancier with loading spinners, et al, but this is an incremental improvement on the message flashing
