### PR TITLE
Added terms and conditions

### DIFF
--- a/bootcamp/templates/bootcamp/tac.html
+++ b/bootcamp/templates/bootcamp/tac.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}MIT Bootcamps - Terms and Conditions{% endblock %}
+
+{% block content %}
+{% include "navbar.html" %}
+<div id="tos" class="text-info-page">
+  <h2>TERMS AND CONDITIONS FOR OPEN ENROLLMENT</h2>
+  <strong>Fees</strong>
+  <p>
+  The fee includes tuition, meals during the program, and course materials. The fee does not include accommodation,
+  incidental costs of the attendees, or travel costs to and from the course site, unless stated otherwise. A deposit fee as
+  set in the admission letter must be paid within 14 days of the date of acceptance (date of admissions letter). The
+  balance of the fee ([fee-deposit fee] minus any scholarships received from MIT Bootcamps) must be fully paid one
+  month before the start of the program. In the event that there is a difference between the payment due dates
+  specified above and the admissions letter, we will follow the payment due date as indicated on the admissions letter.
+  </p>
+ <strong>Cancellation and Deferral Policies</strong>
+ <p>
+     All registrations made under this agreement will be subject to MIT Bootcamp’s standard cancellation and deferral policies, including:
+ </p>
+ <ol>
+    <li>
+      All cancellations must be made in writing to bootcamp@mit.edu. Cancellation fees are as follows:
+      <ol type="a" class="ol-sub-lists">
+          <li>56 days or more prior to the program start date: $250 administrative fee</li>
+          <li>55-22 days prior to the program start date: 50% cancellation fee</li>
+          <li>21 days or less prior to the program start date: 100% cancellation fee</li>
+      </ol>
+      <br/>
+    </li>
+    <li>
+      All enrollment deferrals must be requested in writing to bootcamp@mit.edu. Deferral fees, as a percentage of published tuition rates, are as follows:
+      <ol type="a" class="ol-sub-lists">
+          <li>56 days or more prior to the program start date: No fee</li>
+          <li>55-22 days prior to the program start date: 25% fee</li>
+          <li>21-7 days prior to the program start date: 50% fee</li>
+          <li>7 days to program start date: 100% fee</li>
+      </ol>
+      <br/>
+      Any fees incurred will be deducted from the initial payment received.
+      <br/> <br/>
+      Please note that there may be an increase in tuition for future sessions. If admission is deferred to a future
+      program session, the participant must attend that session or all funds will be forfeited for that program
+      registration. Only one deferral per registration is allowed and the new session must occur within one year of
+      the original session date. There is no cancellation allowed on deferred admissions.
+    </li>
+ </ol>
+ <strong>Ownership of Program Materials</strong>
+ <p>
+  MIT Bootcamps or other material contributors to the open enrollment programs solely own all the intellectual property
+  or have obtained the necessary rights relating to the materials used for the open enrollment programs. Title to and the
+  right to determine the disposition of any copyrightable materials first produced under the terms of Agreement solely
+  by faculty or staff of MIT shall remain with MIT and will be governed by the MIT intellectual property policies. You
+  must not copy, reproduce, republish,disassemble, decompile, reverse engineer, download, post, broadcast, transmit,
+  make available to the public, or otherwise use MIT Bootcamp content in any way except for your own personal,
+  non-commercial use. You also agree not to adapt, alter or create a derivative work from any MIT Bootcamp content
+  except for your own personal, non-commercial use. Any other use of MIT Bootcamp content requires the prior
+  written permission of the MIT Technology Licensing Office.
+ </p>
+ <p>
+  MIT DISCLAIMS ALL REPRESENTATIONS AND WARRANTIES, WHETHER EXPRESS OR IMPLIED, RELATING
+  TO THE BOOTCAMP, INCLUDING, WITHOUT LIMITATION, IMPLIED WARRANTIES OF MERCHANTABILITY,
+  NONINFRINGEMENT, FITNESS FOR A PARTICULAR PURPOSE AND THE ABSENCE OF LATENT OR OTHER
+  DEFECTS, WHETHER OR NOT DISCOVERABLE.
+ </p>
+ <strong>Governing Law</strong>
+ <p>
+   These terms and conditions will be governed by the laws of the Commonwealth of Massachusetts and the federal
+   laws of the United States of America, without regard to any applicable conflict of laws principles.
+ </p>
+ <br/>
+</div>
+{% include "footer.html" %}
+{% endblock %}

--- a/bootcamp/templates/bootcamp/tac.html
+++ b/bootcamp/templates/bootcamp/tac.html
@@ -18,11 +18,11 @@
   </p>
  <strong>Cancellation and Deferral Policies</strong>
  <p>
-     All registrations made under this agreement will be subject to MIT Bootcamp’s standard cancellation and deferral policies, including:
+     All registrations made under this agreement will be subject to MIT Bootcamps' standard cancellation and deferral policies, including:
  </p>
  <ol>
     <li>
-      All cancellations must be made in writing to bootcamp@mit.edu. Cancellation fees are as follows:
+      All cancellations must be made in writing to <a href="mailto:bootcamp@mit.edu">bootcamp@mit.edu</a>. Cancellation fees are as follows:
       <ol type="a" class="ol-sub-lists">
           <li>56 days or more prior to the program start date: $250 administrative fee</li>
           <li>55-22 days prior to the program start date: 50% cancellation fee</li>
@@ -31,7 +31,8 @@
       <br/>
     </li>
     <li>
-      All enrollment deferrals must be requested in writing to bootcamp@mit.edu. Deferral fees, as a percentage of published tuition rates, are as follows:
+      All enrollment deferrals must be requested in writing to <a href="mailto:bootcamp@mit.edu">bootcamp@mit.edu</a>. Deferral fees,
+        as a percentage of published tuition rates, are as follows:
       <ol type="a" class="ol-sub-lists">
           <li>56 days or more prior to the program start date: No fee</li>
           <li>55-22 days prior to the program start date: 25% fee</li>
@@ -54,9 +55,9 @@
   right to determine the disposition of any copyrightable materials first produced under the terms of Agreement solely
   by faculty or staff of MIT shall remain with MIT and will be governed by the MIT intellectual property policies. You
   must not copy, reproduce, republish,disassemble, decompile, reverse engineer, download, post, broadcast, transmit,
-  make available to the public, or otherwise use MIT Bootcamp content in any way except for your own personal,
-  non-commercial use. You also agree not to adapt, alter or create a derivative work from any MIT Bootcamp content
-  except for your own personal, non-commercial use. Any other use of MIT Bootcamp content requires the prior
+  make available to the public, or otherwise use MIT Bootcamps content in any way except for your own personal,
+  non-commercial use. You also agree not to adapt, alter or create a derivative work from any MIT Bootcamps content
+  except for your own personal, non-commercial use. Any other use of MIT Bootcamps content requires the prior
   written permission of the MIT Technology Licensing Office.
  </p>
  <p>

--- a/bootcamp/urls.py
+++ b/bootcamp/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     url(r'^$', index, name='bootcamp-index'),
     url(r'^pay/$', pay, name='pay'),
     url(r'^terms_of_service/$', TemplateView.as_view(template_name='bootcamp/tos.html'), name='bootcamp-tos'),
+    url(r'^terms_and_conditions/$', TemplateView.as_view(template_name='bootcamp/tac.html'), name='bootcamp-tac'),
     url(r'^status/', include('server_status.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url('', include('ecommerce.urls')),

--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -138,6 +138,13 @@ export default class Payment extends React.Component {
         <button className="btn large-cta" onClick={sendPayment} disabled={processing}>
           Pay Now
         </button>
+        <br/>
+        <p className="tac">
+          By making a payment I certify that I agree with the <a href="/terms_and_conditions/" target="_blank"
+            className="tac-link">
+            MIT Bootcamps Terms and Conditions
+          </a>
+        </p>
       </div>
     </div>;
   };

--- a/static/js/components/Payment_test.js
+++ b/static/js/components/Payment_test.js
@@ -81,6 +81,19 @@ describe("Payment", () => {
     });
   });
 
+  it('should show terms and conditions message', () => {
+    const fakeKlass = generateFakeKlasses(1, {hasInstallment: true})[0];
+    const wrapper = renderPayment({selectedKlass: fakeKlass});
+    const termsText = wrapper.find(".tac").text();
+    const termsLink = wrapper.find(".tac-link");
+
+    assert.include(
+      termsText,
+      'By making a payment I certify that I agree with the MIT Bootcamps Terms and Conditions'
+    );
+    assert.equal(termsLink.prop('href'), '/terms_and_conditions/');
+  });
+
   describe('klass dropdown', () => {
     [
       [1, false],

--- a/static/scss/_shared.scss
+++ b/static/scss/_shared.scss
@@ -44,7 +44,7 @@ h3.section-header {
     margin-top: $text-page-margin;
   }
 
-  ol-sub-lists {
+  .ol-sub-lists {
     margin-top: 10px;
   }
 }

--- a/static/scss/_shared.scss
+++ b/static/scss/_shared.scss
@@ -43,4 +43,8 @@ h3.section-header {
   li ul {
     margin-top: $text-page-margin;
   }
+
+  ol-sub-lists {
+    margin-top: 10px;
+  }
 }

--- a/static/scss/payment.scss
+++ b/static/scss/payment.scss
@@ -19,6 +19,26 @@
     padding-top: 15px;
   }
 
+  .tac {
+    color: rgba(255, 255, 255, .7);
+
+    a {
+      color: rgba(255, 255, 255, .7);
+
+      &:visited {
+        color: rgba(255, 255, 255, .7);
+      }
+
+      &:hover {
+        color: rgba(255, 250, 255, .7);
+      }
+
+      &:active {
+        color: rgba(255, 255, 255,.7);
+      }
+    }
+  }
+
   .payment {
     display: flex;
     flex-direction: column;

--- a/static/scss/payment.scss
+++ b/static/scss/payment.scss
@@ -14,27 +14,27 @@
   }
 
   .deadline-message {
-    color: rgba(255,255,255,.7);
+    color: $default-subtext-color;
     font-size: 16px;
     padding-top: 15px;
   }
 
   .tac {
-    color: rgba(255, 255, 255, .7);
+    color: $default-subtext-color;
 
     a {
-      color: rgba(255, 255, 255, .7);
+      color: $default-subtext-color;
 
       &:visited {
-        color: rgba(255, 255, 255, .7);
+        color: $default-subtext-color;
       }
 
       &:hover {
-        color: rgba(255, 250, 255, .7);
+        color: $default-subtext-color;
       }
 
       &:active {
-        color: rgba(255, 255, 255,.7);
+        color: $default-subtext-color;
       }
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/bootcamp-ecommerce/issues/127

#### What's this PR do?
Add terms and condition page in bootcamp

#### How should this be manually tested?
go to payment page and click on `MIT Bootcamps Terms and Conditions`

@pdpinch 

#### Screenshots (if appropriate)
<img width="1224" alt="screen shot 2017-10-09 at 5 51 10 pm" src="https://user-images.githubusercontent.com/10431250/31338903-7a4dfd20-ad1a-11e7-958d-8e5c682944cc.png">
