### PR TITLE
Look up admissions in WebhookRequest

### DIFF
--- a/fluidreview/api_test.py
+++ b/fluidreview/api_test.py
@@ -177,7 +177,9 @@ def test_process_user_both_exist_with_fluid_id(mocker):
 
 def test_parse_success(mocker):
     """Test that a webhookrequest body is successfully parsed into individual fields"""
-    mocker.patch('fluidreview.signals.FluidReviewAPI')
+    mocker.patch('fluidreview.api.FluidReviewAPI')
+    mocker.patch('fluidreview.api.UserSerializer')
+    mocker.patch('fluidreview.api.process_user')
     data = {
         'date_of_birth': '',
         'user_email': 'veteran-grants-9463shC',

--- a/fluidreview/factories.py
+++ b/fluidreview/factories.py
@@ -2,7 +2,7 @@
 Factories for backend models
 """
 from factory.django import DjangoModelFactory
-from factory.fuzzy import FuzzyText
+from factory.fuzzy import FuzzyText, FuzzyInteger, FuzzyDecimal
 
 from fluidreview import models
 
@@ -14,3 +14,18 @@ class OAuthTokenFactory(DjangoModelFactory):
 
     class Meta:
         model = models.OAuthToken
+
+
+class WebhookRequestFactory(DjangoModelFactory):
+    """Factory for WebhookRequest"""
+    body = FuzzyText()
+    user_email = FuzzyText()
+    user_id = FuzzyInteger(low=1)
+    submission_id = FuzzyInteger(low=1)
+    award_id = FuzzyInteger(low=1)
+    award_name = FuzzyText()
+    award_cost = FuzzyDecimal(low=0.00)
+    amount_to_pay = FuzzyDecimal(low=0.00)
+
+    class Meta:
+        model = models.WebhookRequest

--- a/fluidreview/models.py
+++ b/fluidreview/models.py
@@ -57,4 +57,4 @@ class WebhookRequest(TimestampedModel):
     amount_to_pay = DecimalField(null=True, blank=True, max_digits=20, decimal_places=2)
 
     def __str__(self):
-        return '<WebhookRequest created_on={} >'.format(self.created_on)
+        return '<WebhookRequest created_on={} status={} >'.format(self.created_on, self.status)

--- a/fluidreview/views_test.py
+++ b/fluidreview/views_test.py
@@ -19,7 +19,7 @@ def test_webhook(data, client, settings, mocker):  # pylint: disable=unused-argu
     """
     The fluidreview webhook should store its data in the WebhookRequest model, no matter what the data is
     """
-    mocker.patch('fluidreview.signals.FluidReviewAPI')
+    mocker.patch('fluidreview.api.FluidReviewAPI')
     token = 'zxvbnm'
     settings.FLUIDREVIEW_WEBHOOK_AUTH_TOKEN = token
     url = reverse('fluidreview-webhook')
@@ -34,7 +34,7 @@ def test_webhook_fail_auth(client, settings, token_missing, mocker):  # pylint: 
     """
     If the token doesn't match we should return a 403 and not record the webhook
     """
-    mocker.patch('fluidreview.signals.FluidReviewAPI')
+    mocker.patch('fluidreview.api.FluidReviewAPI')
     headers = {}
     settings.FLUIDREVIEW_WEBHOOK_AUTH_TOKEN = 'xyz'
     if not token_missing:
@@ -69,7 +69,7 @@ def test_webhook_parse_success(email, fluid_id, should_update, settings, client,
         'submissions': [],
         'teams': [],
     }
-    mock_api = mocker.patch('fluidreview.signals.FluidReviewAPI')
+    mock_api = mocker.patch('fluidreview.api.FluidReviewAPI')
     mock_api().get.return_value.json.return_value = user_data
 
     existing_user = 'old@mit.edx'

--- a/klasses/api_test.py
+++ b/klasses/api_test.py
@@ -17,7 +17,7 @@ from klasses.bootcamp_admissions_client import BootcampAdmissionClient
 from klasses.conftest import patch_get_admissions
 from klasses.factories import KlassFactory, InstallmentFactory
 from klasses.serializers import InstallmentSerializer
-from profiles.factories import UserFactory
+from profiles.factories import ProfileFactory
 
 # pylint: disable=missing-docstring,redefined-outer-name,unused-argument
 
@@ -29,19 +29,19 @@ def test_data(mocker):
     """
     Sets up the data for all the tests in this module
     """
-    user = UserFactory.create()
+    profile = ProfileFactory.create()
     klass_paid = KlassFactory.create()
     klass_not_paid = KlassFactory.create()
 
     InstallmentFactory.create(klass=klass_paid)
     InstallmentFactory.create(klass=klass_not_paid)
 
-    order = OrderFactory.create(user=user, status=Order.FULFILLED)
+    order = OrderFactory.create(user=profile.user, status=Order.FULFILLED)
     LineFactory.create(order=order, klass_key=klass_paid.klass_key, price=627.34)
 
-    patch_get_admissions(mocker, user)
+    patch_get_admissions(mocker, profile.user)
 
-    return user, klass_paid, klass_not_paid
+    return profile.user, klass_paid, klass_not_paid
 
 
 def test_serialize_user_klass_bootclient_equivalent(test_data):


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #151

#### What's this PR do?
Modifies the `BootcampAdmissionsClient` to get both a user's legacy klasses and FluidReview klasses.

#### How should this be manually tested?
- Create a `Bootcamp` with a `Klass` (`klass_key=72713`) and `Installment`.
- Create another `Bootcamp` with a `Klass` (`klass_key=13`)  and `Installment`.
- Send a `WebhookRequest` to your bootcamp instance at `../api/v0/fluidreview_webhook/` with this data:
```json
{
  "date_of_birth": "",
  "user_email": "staff@example.com",
  "amount_to_pay": "",
  "user_id": 95292895,
  "submission_id": 999999,
  "award_id": 72713,
  "award_cost": "1000",
  "award_name": "TEST CAMP"
}
```
- Log in to bootcamp via edx as `staff@example.com`.
- It should show a select field: `Which bootcamp do you want to pay for?`, with the two bootcamps as options.
- Click each one and verify that it shows the correct information for that bootcamp (dates, amounts paid/owed, titles).
- Make a payment for each (use admin console if necessary to change the `Order` status to `Fulfilled`).
- The 'You have paid $X out of $Y' amounts should now be updated for each bootcamp.