### PR TITLE
Case-insensitive email matching for FluidReview-Django users

### DIFF
--- a/fluidreview/api.py
+++ b/fluidreview/api.py
@@ -165,7 +165,10 @@ def process_user(fluid_user):
     Args:
         fluid_user (ReturnDict): Data from a fluidreview.serializers.UserSerializer object
     """
-    user, _ = User.objects.get_or_create(email=fluid_user['email'], defaults={'username': fluid_user['email']})
+    user, _ = User.objects.get_or_create(
+        email__iexact=fluid_user['email'],
+        defaults={'email': fluid_user['email'], 'username': fluid_user['email']}
+    )
     profile, _ = Profile.objects.get_or_create(user=user)
     if not profile.fluidreview_id:
         profile.fluidreview_id = fluid_user['id']

--- a/fluidreview/api_test.py
+++ b/fluidreview/api_test.py
@@ -153,7 +153,7 @@ def test_process_new_profile():
 def test_process_both_exist_no_fluid_id(mocker):
     """Test that no changes are made to an existing user but existing profile is saved with fluid id"""
     ProfileFactory(
-        user=UserFactory(email=fluid_user['email'], username=fluid_user['email']),
+        user=UserFactory(email=fluid_user['email'].upper(), username=fluid_user['email']),
         fluidreview_id=None
     )
     mock_create_user = mocker.patch('fluidreview.api.User.objects.create')
@@ -165,7 +165,7 @@ def test_process_both_exist_no_fluid_id(mocker):
 def test_process_user_both_exist_with_fluid_id(mocker):
     """Test that no changes are made to an existing user and profile with fluidreview id"""
     ProfileFactory(
-        user=UserFactory(email=fluid_user['email'], username=fluid_user['email']),
+        user=UserFactory(email=fluid_user['email'].upper(), username=fluid_user['email']),
         fluidreview_id=1
     )
     mock_create_user = mocker.patch('fluidreview.api.User.objects.create')


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #165

#### What's this PR do?
Makes the lookup for user by email address case-insensitive.

#### How should this be manually tested?
 - Change the email of an existing django user that has not yet been synced with FluidReview to have a mix of uppercase and lowercase letters.
 - Post a WebhookRequest for the user (one that really exists in FluidReview), using all lowercase letters.
- The django user should be synced with the fluidreview user (`Profile` should have the fluidreviewuser_id field populated.)

