### PR TITLE
Set default test client format

### DIFF
--- a/bootcamp/settings.py
+++ b/bootcamp/settings.py
@@ -269,7 +269,8 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ],
-    'COERCE_DECIMAL_TO_STRING': False
+    'COERCE_DECIMAL_TO_STRING': False,
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 
 # Request files from the webpack dev server


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #152 

#### What's this PR do?
Sets the default test client format to json since pretty much all of our APIs use that format.

#### How should this be manually tested?
Tests should pass