### PR TITLE
Don't post payment to FluidReview until order is saved

### DIFF
--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -115,12 +115,12 @@ class OrderFulfillmentView(APIView):
                     )
         else:
             order.status = Order.FULFILLED
-            try:
-                post_payment(order)
-            except:  # pylint: disable=bare-except
-                log.exception('Error occurred posting payment to FluidReview for order %s', order)
 
         order.save_and_log(acting_user=None)
+        try:
+            post_payment(order)
+        except:  # pylint: disable=bare-except
+            log.exception('Error occurred posting payment to FluidReview for order %s', order)
 
         # The response does not matter to CyberSource
         return Response(status=statuses.HTTP_200_OK)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #176 

#### What's this PR do?
Moves the `post_payment` call after the `Order.save_and_log` call

#### How should this be manually tested?
- Create a `Bootcamp`, `Klass` (`klass_key`=72713), `Installment`, and `Webhook`(`award_id`=72713, `submission_id`=4621059, `user_email`=`staff@example.com`, `user_id`=95292895).  
- Submit a payment while logged in as `staff@example.com` (creating an `Order`)
- Temporarily change the permissions for `ecommerce.views.OrderFulfillmentView` from `IsSignedByCyberSource` to `AllowAny`
- Post a request to `http://<bootcamp_ip>:8099/api/v0/order_fulfillment/` with data:
```
{
	"req_reference_number": "BOOTCAMP-ci-<order_id>",
	"decision": "ACCEPT"
}
```
In a python shell or fluidreview UI, check the submission metadata.  `Amount paid` should be equal to the total amount of payments made.
```
from fluidreview import FluidReviewAPI
api = FluidReviewAPI()
api.get('submissions/4621059/metadata').json()
```
  