### PR TITLE
Ignore 'Accept' header for requests to WebhookView

### DIFF
--- a/bootcamp/negotiations.py
+++ b/bootcamp/negotiations.py
@@ -1,0 +1,34 @@
+""" Custom negotiation classes for REST framework """
+from rest_framework.negotiation import BaseContentNegotiation
+
+
+class IgnoreClientContentNegotiation(BaseContentNegotiation):
+    """
+    Ignore whatever a request's 'Accept' header is if any.
+    """
+    def select_parser(self, request, parsers):
+        """
+        Select the first parser in the `.parser_classes` list.
+
+        Args:
+            request(Request): The request to process
+            parsers(list): list of parsers
+
+        Returns:
+            Parser: the parser to use (first in list)
+        """
+        return parsers[0]
+
+    def select_renderer(self, request, renderers, format_suffix=None):
+        """
+        Select the first renderer in the `.renderer_classes` list.
+
+        Args:
+            request(Request): The request to process
+            renderers(list): list of renderers
+            format_suffix(string): not used
+
+        Returns:
+            Renderer: the renderer class to use (first in list)
+        """
+        return renderers[0], renderers[0].media_type

--- a/fluidreview/views.py
+++ b/fluidreview/views.py
@@ -2,6 +2,7 @@
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from bootcamp.negotiations import IgnoreClientContentNegotiation
 from fluidreview.permissions import WebhookPermission
 from fluidreview.models import WebhookRequest
 
@@ -12,6 +13,7 @@ class WebhookView(APIView):
     """
     permission_classes = (WebhookPermission,)
     authentication_classes = ()
+    content_negotiation_class = IgnoreClientContentNegotiation
 
     def post(self, request):
         """Store webhook request for later processing"""


### PR DESCRIPTION
#### What are the relevant tickets?
#186 

#### What's this PR do?
Creates a new `IgnoreClientContentNegotiation` class that is used by `WebhookView` to ignore whatever `Accept` header is sent to it.

#### How should this be manually tested?
Send requests to `WebhookView` with the `Accept` header set to `text/plain`, `video/mp4`, and any other values you'd like to try.  As long as the rest of the request is valid, a successful response should be returned.