### PR TITLE
Handle missing installments on payment page

### DIFF
--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -51,10 +51,10 @@ export default class Payment extends React.Component<*, void> {
 
     const installments = selectedKlass.installments
     let installmentDeadlineText = ""
-    const deadlineDates = getInstallmentDeadlineDates(installments)
-    const finalInstallmentDeadline = formatReadableDate(R.last(deadlineDates))
 
-    if (installments.length > 1) {
+    if (installments.length > 0) {
+      const deadlineDates = getInstallmentDeadlineDates(installments)
+      const finalInstallmentDeadline = formatReadableDate(R.last(deadlineDates))
       const nextInstallmentIndex = R.findIndex(R.lt(now), deadlineDates),
         lastInstallmentIndex = installments.length - 1
       if (nextInstallmentIndex !== lastInstallmentIndex) {
@@ -70,12 +70,10 @@ export default class Payment extends React.Component<*, void> {
       if (this.hasMissedPreviousInstallment(nextInstallmentIndex)) {
         installmentDeadlineText = `You missed the previous payment deadline. ${installmentDeadlineText}`
       }
+      installmentDeadlineText += ` Full payment must be complete by ${finalInstallmentDeadline}.`
     }
 
-    return (
-      `${installmentDeadlineText} ` +
-      `Full payment must be complete by ${finalInstallmentDeadline}.`
-    )
+    return installmentDeadlineText
   }
 
   renderKlassDropdown = () => {

--- a/static/js/components/Payment_test.js
+++ b/static/js/components/Payment_test.js
@@ -271,6 +271,13 @@ describe("Payment", () => {
         const deadlineMsgHtml = wrapper.find(deadlineMsgSelector).html()
         assert.notInclude(deadlineMsgHtml, "A deposit of ")
       })
+
+      it("should not show an installment deadline message if there are no installments", () => {
+        fakeKlass.installments = []
+        const wrapper = renderPayment({ selectedKlass: fakeKlass })
+        const deadlineMsgHtml = wrapper.find(deadlineMsgSelector).text()
+        assert.equal(deadlineMsgHtml, "")
+      })
     })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
- Closes #193 

#### What's this PR do?
- Modifies the React `Payment` component to properly handle cases where no installments exist for a klass.

#### How should this be manually tested?
- You'll need a `Bootcamp` (legacy or not), `Klass`, and a `User` enrolled in that `Klass`
- Don't create any installments for the `Klass`; or delete the ones that already exist.
- Log in as that user.  The `/pay` URL should load and display the usual text that you are enrolled, and the amount owed should be $0 or the `PersonalPrice` if this is a non-legacy `Bootcamp` and there is a `WebhookRequest` specifying an `amount_to_pay` for this user.  There should be no message indicating when a next installment is due.
- Create an installment for the klass and reload the page.  The amount owed should not be $0 and there should be a message about when payment is due.
