### PR TITLE
Use award_cost as personal price if amount_to_pay is blank

### DIFF
--- a/fluidreview/api.py
+++ b/fluidreview/api.py
@@ -234,11 +234,12 @@ def parse_webhook_user(webhook):
     else:
         user = profile.user
     if webhook.award_id is not None:
+        personal_price = webhook.award_cost if webhook.amount_to_pay is None else webhook.amount_to_pay
         klass = Klass.objects.get(klass_key=webhook.award_id)
-        if webhook.amount_to_pay is not None:
+        if personal_price is not None:
             user.klass_prices.update_or_create(
                 klass=klass,
-                defaults={'price': webhook.amount_to_pay}
+                defaults={'price': personal_price}
             )
         else:
             user.klass_prices.filter(klass=klass).delete()


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #200 

#### What's this PR do?
Creates/updates a `PersonalPrice` with the value of `award_cost` if `amount_to_pay` is blank in a `WebhookRequest`.

#### How should this be manually tested?
- Send a webhook request for your bootcamp user with `{amount_to_pay: '', 'award_cost: '100'}`, and verify that the total amount owed on the payment page is equal to $100.
- Send a webhook request for your bootcamp user with `{amount_to_pay: '50', 'award_cost: '100'}`, and verify that the total amount owed on the payment page is equal to $50.
- Send a webhook request for your bootcamp user with `{amount_to_pay: '', 'award_cost: ''}`, and verify that the total amount owed on the payment page is equal to the installment price for that class.

