### PR TITLE
Completely disabled overpayment error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 .hypothesis/
 coverage/
 .nyc_output/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -80,18 +80,6 @@ def create_unfulfilled_order(user, klass_key, payment_amount):
     if payment_amount <= 0:
         raise ValidationError("Payment is less than or equal to zero")
 
-    already_paid = get_total_paid(user, klass_key)
-    if payment_amount + already_paid > klass.price:
-        raise ValidationError(
-            "Payment of ${payment_amount} plus already paid ${already_paid} for {klass} would be"
-            " greater than total price of ${klass_price}".format(
-                payment_amount=payment_amount,
-                klass=klass.title,
-                already_paid=already_paid,
-                klass_price=klass.price,
-            )
-        )
-
     order = Order.objects.create(
         status=Order.CREATED,
         total_price_paid=payment_amount,

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -33,7 +33,6 @@ from ecommerce.exceptions import (
     EcommerceException,
     ParseException,
 )
-from ecommerce.factories import LineFactory
 from ecommerce.models import (
     Order,
     OrderAudit,
@@ -80,33 +79,6 @@ class PurchasableTests(TestCase):
         super().setUpTestData()
 
         cls.klass, cls.user = create_purchasable_klass()
-
-    def test_too_much(self):
-        """
-        An order cannot exceed the total amount for the klass
-        """
-        LineFactory.create(
-            order__status=Order.FULFILLED,
-            order__user=self.user,
-            klass_key=self.klass.klass_key,
-            order__total_price_paid=self.klass.price - 10
-        )
-
-        with self.assertRaises(ValidationError) as ex:
-            # payment is $15 here but there is only $10 left to pay
-            payment_amount = 15
-            create_test_order(self.user, self.klass.klass_key, payment_amount)
-
-        message = (
-            "Payment of ${payment_amount} plus already paid ${already_paid} for {klass} would be"
-            " greater than total price of ${klass_price}".format(
-                payment_amount=payment_amount,
-                already_paid=self.klass.price - 10,
-                klass=self.klass.title,
-                klass_price=self.klass.price,
-            )
-        )
-        assert ex.exception.args[0] == message
 
     @ddt.data(0, -1.23)
     def test_less_or_equal_to_zero(self, payment_amount):

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -70,7 +70,7 @@ class OrderFulfillmentView(APIView):
     authentication_classes = ()
     permission_classes = (IsSignedByCyberSource, )
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """
         Confirmation from CyberSource which fulfills an existing Order.
         """


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #207 

#### What's this PR do?
Removes the overpayment error in the ecommerce API

#### How should this be manually tested?
Enter an amount into the payment field that is greater than the amount you owe for the klass and click "Pay Now". You should be sent to cybersource instead of, well, going nowhere and seeing an error in the developer console

#### Any background context you want to provide?
This is a temporary fix. https://github.com/mitodl/bootcamp-ecommerce/issues/208 covers the work to fix this in earnest
