### PR TITLE
Added django-hijack for user masquerading

### DIFF
--- a/bootcamp/settings.py
+++ b/bootcamp/settings.py
@@ -110,6 +110,11 @@ INSTALLED_APPS = (
     'server_status',
     'social_django',
 
+    # Hijack
+    'hijack',
+    'compat',
+    'hijack_admin',
+
     # other third party APPS
     'raven.contrib.django.raven_compat',
 
@@ -214,6 +219,9 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'bootcamp.wsgi.application'
 
+# Hijack
+HIJACK_ALLOW_GET_REQUESTS = True
+HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'
 
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases

--- a/bootcamp/templates/base.html
+++ b/bootcamp/templates/base.html
@@ -3,6 +3,7 @@
   <head>
     {% spaceless %}
     {% load static %}
+    {% load hijack_tags %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% load raven %}
@@ -24,6 +25,7 @@
     {% endspaceless %}
   </head>
   <body>
+    {% hijack_notification %}
     {% include "gtm_body.html" %}
     {% block content %}
     {% endblock %}

--- a/bootcamp/templates/base.html
+++ b/bootcamp/templates/base.html
@@ -11,6 +11,7 @@
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" type="text/css" href="{% url 'background-images-css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
     <script type="text/javascript">
     var SETTINGS = {{ js_settings_json|safe }};
     </script>

--- a/bootcamp/urls.py
+++ b/bootcamp/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     url(r'^terms_and_conditions/$', TemplateView.as_view(template_name='bootcamp/tac.html'), name='bootcamp-tac'),
     url(r'^status/', include('server_status.urls')),
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^hijack/', include('hijack.urls', namespace='hijack')),
     url('', include('ecommerce.urls')),
     url('', include('fluidreview.urls')),
     url('', include('social_django.urls', namespace='social')),

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,9 @@ Django==1.10.5
 PyYAML==3.11
 celery==4.0.2
 dj-database-url==0.3.0
+django-compat==1.0.15
+django-hijack==2.1.7
+django-hijack-admin==2.1.7
 dj-static==0.0.6
 django-redis==4.7.0
 django-server-status==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,9 @@ contextlib2==0.5.5        # via raven
 decorator==4.0.11         # via ipython, traitlets
 defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.3.0
+django-compat==1.0.15
+django-hijack==2.1.7
+django-hijack-admin==2.1.7
 dj-static==0.0.6
 django-redis==4.7.0
 django-server-status==0.3.2


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/bootcamp-ecommerce/issues/212

#### What's this PR do?
Add django hijack so that you can masquerade login user with you super admin credentials

#### How should this be manually tested?
- login to admin site
- go and http://192.168.99.101:8099/admin/auth/user/
- perform view as

@pdpinch 
#### Screenshots (if appropriate)
<img width="1276" alt="screen shot 2018-06-04 at 9 02 11 pm" src="https://user-images.githubusercontent.com/10431250/40928393-b5dbe98e-683a-11e8-920a-8c016182ccd3.png">

<img width="655" alt="screen shot 2018-06-04 at 9 02 40 pm" src="https://user-images.githubusercontent.com/10431250/40928395-b625dc7e-683a-11e8-9cee-1b8dce6756b9.png">
