### PR TITLE
Add name and url to email

### DIFF
--- a/bootcamp/settings.py
+++ b/bootcamp/settings.py
@@ -304,8 +304,8 @@ MAILGUN_URL = get_var('MAILGUN_URL', 'https://api.mailgun.net/v3/micromasters.od
 MAILGUN_KEY = get_var('MAILGUN_KEY', None)
 MAILGUN_BATCH_CHUNK_SIZE = get_var('MAILGUN_BATCH_CHUNK_SIZE', 1000)
 MAILGUN_RECIPIENT_OVERRIDE = get_var('MAILGUN_RECIPIENT_OVERRIDE', None)
-MAILGUN_FROM_EMAIL = get_var('MAILGUN_FROM_EMAIL', 'no-reply@micromasters.mit.edu')
-MAILGUN_BCC_TO_EMAIL = get_var('MAILGUN_BCC_TO_EMAIL', 'no-reply@micromasters.mit.edu')
+MAILGUN_FROM_EMAIL = get_var('MAILGUN_FROM_EMAIL', 'no-reply@bootcamp.mit.edu')
+MAILGUN_BCC_TO_EMAIL = get_var('MAILGUN_BCC_TO_EMAIL', 'no-reply@bootcamp.mit.edu')
 
 # e-mail configurable admins
 ADMIN_EMAIL = get_var('BOOTCAMP_ADMIN_EMAIL', '')

--- a/smapply/api.py
+++ b/smapply/api.py
@@ -268,7 +268,8 @@ def parse_webhook_user(webhook):
                         name=klass_info['name'],
                         base_url=settings.BOOTCAMP_ECOMMERCE_BASE_URL
                     ),
-                    settings.EMAIL_SUPPORT
+                    settings.EMAIL_SUPPORT,
+                    sender_address=settings.MAILGUN_FROM_EMAIL
                 )
             except:  # pylint: disable=bare-except
                 log.exception(

--- a/smapply/api.py
+++ b/smapply/api.py
@@ -260,11 +260,13 @@ def parse_webhook_user(webhook):
                 klass_key=klass_info['id'])
             try:
                 MailgunClient().send_individual_email(
-                    "Klass and Bootcamp created, for klass_key {klass_key}".format(
-                        klass_key=klass_info['id']
+                    "Klass and Bootcamp {name} was created".format(
+                        name=klass_info['name'],
                     ),
-                    "Klass and Bootcamp created, for klass_key {klass_key}".format(
-                        klass_key=klass_info['id']
+                    "Klass and Bootcamp {name} was created, for klass_key {klass_key} at {base_url}".format(
+                        klass_key=klass_info['id'],
+                        name=klass_info['name'],
+                        base_url=settings.BOOTCAMP_ECOMMERCE_BASE_URL
                     ),
                     settings.EMAIL_SUPPORT
                 )

--- a/smapply/api_test.py
+++ b/smapply/api_test.py
@@ -7,6 +7,7 @@ import json
 import pytest
 from django.contrib.auth.models import User
 from django.test import override_settings
+from django.conf import settings
 from requests import HTTPError
 
 from ecommerce.factories import OrderFactory, LineFactory
@@ -238,8 +239,12 @@ def test_parse_webhook_user(mocker, price, sends_email):
         ).exists()
         assert send_email.call_count == 1
         assert send_email.call_args[0] == (
-            "Klass and Bootcamp created, for klass_key {klass_key}".format(klass_key=award_id),
-            "Klass and Bootcamp created, for klass_key {klass_key}".format(klass_key=award_id),
+            "Klass and Bootcamp {award_name} was created".format(award_name=award_name),
+            "Klass and Bootcamp {award_name} was created, for klass_key {klass_key} at {url}".format(
+                award_name=award_name,
+                klass_key=award_id,
+                url=settings.BOOTCAMP_ECOMMERCE_BASE_URL
+            ),
             'support@example.com',
         )
     else:


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
When new bootcamp is created the email notifies about the creation with name and base url.

#### How should this be manually tested?
Try creating a new bootcamp

