### PR TITLE
add validation for klass and bootcamp title

### DIFF
--- a/bootcamp/utils.py
+++ b/bootcamp/utils.py
@@ -3,6 +3,7 @@ General bootcamp utility functions
 """
 import json
 import logging
+import re
 from itertools import islice
 
 from django.conf import settings
@@ -76,3 +77,9 @@ def chunks(iterable, chunk_size=20):
     while len(chunk) > 0:
         yield chunk
         chunk = list(islice(iterable, chunk_size))
+
+
+def remove_html_tags(text):
+    """Remove html tags from a string"""
+    clean = re.compile('<.*?>')
+    return re.sub(clean, '', text)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #246 and #251 

#### What's this PR do?

- Strip HTML tags from klass and bootcamp titles,
- Validate that titles are not empty

#### How should this be manually tested?
(Required)
