### PR TITLE
create klass title with award name instead of description

### DIFF
--- a/smapply/api.py
+++ b/smapply/api.py
@@ -256,7 +256,7 @@ def parse_webhook_user(webhook):
             klass = Klass.objects.create(
                 bootcamp=bootcamp,
                 source=ApplicationSource.SMAPPLY,
-                title=klass_info['description'],
+                title=klass_info['name'],
                 klass_key=klass_info['id'])
             try:
                 MailgunClient().send_individual_email(

--- a/smapply/api_test.py
+++ b/smapply/api_test.py
@@ -231,7 +231,7 @@ def test_parse_webhook_user(mocker, price, sends_email):
     parse_webhook(hook)
     if sends_email:
         assert hook.status == WebhookParseStatus.SUCCEEDED
-        assert Klass.objects.filter(klass_key=award_id).exists()
+        assert Klass.objects.filter(title=award_name).exists()
         assert Bootcamp.objects.filter(title=award_name).exists()
         assert PersonalPrice.objects.filter(
             klass__klass_key=award_id,


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #255 

#### What's this PR do?
Update parse webhook method to created klass using award name instead of description.
