### PR TITLE
Change expected HTTP_AUTHORIZATION for smapply from OAuth to Basic

### DIFF
--- a/smapply/permissions.py
+++ b/smapply/permissions.py
@@ -17,5 +17,5 @@ class WebhookPermission(BasePermission):
             token = request.META['HTTP_AUTHORIZATION']
         except KeyError:
             return False
-        expected = 'OAuth {}'.format(settings.SMAPPLY_WEBHOOK_AUTH_TOKEN)
+        expected = 'Basic {}'.format(settings.SMAPPLY_WEBHOOK_AUTH_TOKEN)
         return constant_time_compare(token, expected)

--- a/smapply/views_test.py
+++ b/smapply/views_test.py
@@ -25,7 +25,7 @@ def test_webhook(data, client, settings, mocker):  # pylint: disable=unused-argu
     token = 'zxvbnm'
     settings.SMAPPLY_WEBHOOK_AUTH_TOKEN = token
     url = reverse('smapply-webhook')
-    resp = client.post(url, data=data, HTTP_AUTHORIZATION='OAuth {}'.format(token), content_type='text/plain')
+    resp = client.post(url, data=data, HTTP_AUTHORIZATION='Basic {}'.format(token), content_type='text/plain')
     assert resp.status_code == status.HTTP_200_OK
     assert WebhookRequestSMA.objects.count() == 1
     assert WebhookRequestSMA.objects.first().body == data
@@ -40,7 +40,7 @@ def test_webhook_fail_auth(client, settings, token_missing, mocker):  # pylint: 
     headers = {}
     settings.SMAPPLY_WEBHOOK_AUTH_TOKEN = 'xyz'
     if not token_missing:
-        headers['HTTP_AUTHORIZATION'] = 'OAuth abc'
+        headers['HTTP_AUTHORIZATION'] = 'Basic abc'
 
     url = reverse('smapply-webhook')
     with pytest.raises(SMApplyException) as exc:
@@ -57,7 +57,7 @@ def test_webhook_with_accept_header(client, settings, mocker, accept):  # pylint
     mocker.patch('smapply.api.SMApplyAPI')
     settings.SMAPPLY_WEBHOOK_AUTH_TOKEN = 'xyz'
     headers = {
-        'HTTP_AUTHORIZATION': 'OAuth xyz'
+        'HTTP_AUTHORIZATION': 'Basic xyz'
     }
     if accept is not None:
         headers['HTTP_ACCEPT'] = accept
@@ -109,7 +109,7 @@ def test_webhook_parse_success(email, smapply_id, should_update, settings, clien
     token = 'zxvbnm'
     settings.SMAPPLY_WEBHOOK_AUTH_TOKEN = token
     url = reverse('smapply-webhook')
-    resp = client.post(url, data=body, HTTP_AUTHORIZATION='OAuth {}'.format(token), content_type='text/plain')
+    resp = client.post(url, data=body, HTTP_AUTHORIZATION='Basic {}'.format(token), content_type='text/plain')
     assert resp.status_code == status.HTTP_200_OK
 
     webhook = WebhookRequestSMA.objects.filter(body=body).first()


### PR DESCRIPTION
#### What are the relevant tickets?
#261 

#### What's this PR do?
Changes expected HTTP_AUTHORIZATION header from "OAuth" to "Basic"

#### How should this be manually tested?
Using Postman or equivalent, send a request to http://localhost:8099/api/v0/smapply_webhook/ with HTTP_AUTHORIZATION header "Basic <SMAPPLY_WEBHOOK_AUTH_TOKEN>" and a valid body, content-type, etc.  The webhook should be saved in the database and you should not get a permission denied error.
