### PR TITLE
Hubspot sync updates

### DIFF
--- a/hubspot/management/commands/sync_hubspot.py
+++ b/hubspot/management/commands/sync_hubspot.py
@@ -41,6 +41,13 @@ class Command(BaseCommand):
         sync_messages = [
             make_object_sync_message(obj.id, **kwargs)[0] for obj in objects
         ]
+
+        if object_type == "CONTACT":
+            # Skip sync if message is missing required field
+            sync_messages = [
+                message for message in sync_messages if message.get('propertyNameToValues', {}).get('email')
+            ]
+
         while len(sync_messages) > 0:
             staged_messages = sync_messages[0:200]
             sync_messages = sync_messages[200:]

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -30,6 +30,9 @@ ASSOCIATED_DEAL_RE = re.compile(fr"\[hs_assoc__deal_id: (.+)\]")
 def sync_contact_with_hubspot(profile_id):
     """Send a sync-message to sync a user with a hubspot contact"""
     body = make_contact_sync_message(profile_id)
+    if not body[0].get('propertyNameToValues', {}).get('email'):
+        return  # Skip if message is missing required field
+
     response = send_hubspot_request("CONTACT", HUBSPOT_SYNC_URL, "PUT", body=body)
     response.raise_for_status()
 

--- a/hubspot/tasks_test.py
+++ b/hubspot/tasks_test.py
@@ -33,10 +33,11 @@ def mock_hubspot_request(mocker):
     yield mocker.patch("hubspot.tasks.send_hubspot_request", autospec=True)
 
 
-def test_sync_contact_with_hubspot(mock_hubspot_request):
+def test_sync_contact_with_hubspot(mock_hubspot_request, user_data):
     """Test that send_hubspot_request is called properly for a CONTACT sync"""
     profile = ProfileFactory.create()
     profile.smapply_id = 102132
+    profile.smapply_user_data = user_data
     profile.save()
     sync_contact_with_hubspot(profile.id)
     body = make_contact_sync_message(profile.id)

--- a/smapply/tasks.py
+++ b/smapply/tasks.py
@@ -1,5 +1,6 @@
 """Tasks for smapply"""
 from bootcamp.celery import app
+from hubspot.task_helpers import sync_hubspot_user
 from smapply.serializers import UserSerializer
 from smapply.api import list_users, process_user
 from profiles.models import Profile
@@ -18,3 +19,5 @@ def sync_all_users():
                 user = process_user(serializer.data)
                 user.profile.smapply_user_data = sma_user
                 user.profile.save()
+
+                sync_hubspot_user(user.profile)


### PR DESCRIPTION
#### What are the relevant tickets?
Skip contact sync if message does not include email. Sync contact during smapply sync task

#### What's this PR do?
Skip contact sync if message does not include email. Sync contact during smapply sync task

#### How should this be manually tested?
Attempt to sync profiles without smapply_user_data and check that there are no new hubspot sync errors. Run the smapply task `sync_all_users` and check that new profiles were synced with hubspot.

