### PR TITLE
Fix hubspot sync issues, update tests

### DIFF
--- a/hubspot/conftest.py
+++ b/hubspot/conftest.py
@@ -230,7 +230,7 @@ smapply_serialized_data = {
     'phone': '1234567890', 'jobtitle': 'Fake Job', 'participant_license_release': 'I Agree',
     'mit_honor_code': 'I Agree', 'occupation': 'Retired', 'confidentiality': 'I Agree',
     'referral_information': 'some kind of response', 'hear_about_bootcamp': 'MIT or Bootcamp alumni',
-    'country': 'United States', 'gender': '', 'company': 'Fake Name',
+    'country': 'United States', 'gender': 'Male', 'company': 'Fake Name',
     'highest_education': "Other advanced degree beyond a Master's degree",
     'linkedin_profile': 'https://www.linkedin.com', 'liability_release': 'I Agree'}
 

--- a/hubspot/management/commands/configure_hubspot_bridge.py
+++ b/hubspot/management/commands/configure_hubspot_bridge.py
@@ -255,12 +255,12 @@ HUBSPOT_ECOMMERCE_SETTINGS = {
             },
             {
                 "propertyName": "first_name",
-                "targetHubspotProperty": "first_name",
+                "targetHubspotProperty": "firstname",
                 "dataType": "STRING",
             },
             {
                 "propertyName": "last_name",
-                "targetHubspotProperty": "last_name",
+                "targetHubspotProperty": "lastname",
                 "dataType": "STRING",
             },
             {

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -76,7 +76,7 @@ class HubspotContactSerializer(serializers.ModelSerializer):
                 if 'choices' in task_definition[field_name]:
                     # Lookup the response choice in the task definition dict of choices
                     response_id = responses[field_key]['response']
-                    if response_id:
+                    if response_id is not None:
                         if isinstance(response_id, list):
                             # Some responses are lists but only allow a single answer.
                             # I think this has to do with the questions using checkboxes, not radio buttons.

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -76,7 +76,7 @@ class HubspotContactSerializer(serializers.ModelSerializer):
                 if 'choices' in task_definition[field_name]:
                     # Lookup the response choice in the task definition dict of choices
                     response_id = responses[field_key]['response']
-                    if response_id is not None:
+                    if response_id is not None and response_id != []:
                         if isinstance(response_id, list):
                             # Some responses are lists but only allow a single answer.
                             # I think this has to do with the questions using checkboxes, not radio buttons.

--- a/smapply/tasks.py
+++ b/smapply/tasks.py
@@ -21,3 +21,7 @@ def sync_all_users():
                 user.profile.save()
 
                 sync_hubspot_user(user.profile)
+        elif not profile.smapply_user_data:
+            profile.smapply_user_data = sma_user
+            profile.save()
+            sync_hubspot_user(profile)

--- a/smapply/tasks.py
+++ b/smapply/tasks.py
@@ -21,7 +21,7 @@ def sync_all_users():
                 user.profile.save()
 
                 sync_hubspot_user(user.profile)
-        elif not profile.smapply_user_data:
+        else:
             profile.smapply_user_data = sma_user
             profile.save()
             sync_hubspot_user(profile)

--- a/smapply/tasks_test.py
+++ b/smapply/tasks_test.py
@@ -56,23 +56,6 @@ def test_sync_all_users_bad_data(mocker):
     assert Profile.objects.count() == 1
 
 
-def test_sync_existing_user_lacking_data(mocker):
-    """
-    Test that an already existing profile without smapply_user_data has that data populated during sync_all_users.
-    """
-    profile = ProfileFactory.create(smapply_id=12345678)
-
-    mocker.patch(
-        'smapply.tasks.list_users',
-        return_value=test_user_data,
-    )
-    sync_all_users()
-    assert Profile.objects.count() == 2
-
-    profile.refresh_from_db()
-    assert profile.smapply_user_data
-
-
 @pytest.mark.parametrize("sma_data", [None, {"foo": "bar"}])
 def test_sync_existing_user_data(mocker, sma_data):
     """

--- a/smapply/tasks_test.py
+++ b/smapply/tasks_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from profiles.factories import ProfileFactory
 from profiles.models import Profile
 from smapply.tasks import sync_all_users
 
@@ -53,3 +54,20 @@ def test_sync_all_users_bad_data(mocker):
     )
     sync_all_users()
     assert Profile.objects.count() == 1
+
+
+def test_sync_existing_user_lacking_data(mocker):
+    """
+    Test that an already existing profile without smapply_user_data has that data populated during sync_all_users.
+    """
+    profile = ProfileFactory.create(smapply_id=12345678)
+
+    mocker.patch(
+        'smapply.tasks.list_users',
+        return_value=test_user_data,
+    )
+    sync_all_users()
+    assert Profile.objects.count() == 2
+
+    profile.refresh_from_db()
+    assert profile.smapply_user_data

--- a/smapply/tasks_test.py
+++ b/smapply/tasks_test.py
@@ -71,3 +71,20 @@ def test_sync_existing_user_lacking_data(mocker):
 
     profile.refresh_from_db()
     assert profile.smapply_user_data
+
+
+@pytest.mark.parametrize("sma_data", [None, {"foo": "bar"}])
+def test_sync_existing_user_data(mocker, sma_data):
+    """
+    Test that an existing profile with and without smapply_user_data has data populated during sync_all_users.
+    """
+    profile = ProfileFactory.create(smapply_id=12345678, smapply_user_data=sma_data)
+
+    mocker.patch(
+        'smapply.tasks.list_users',
+        return_value=test_user_data,
+    )
+    sync_all_users()
+
+    profile.refresh_from_db()
+    assert profile.smapply_user_data == test_user_data[0]


### PR DESCRIPTION
This PR deals with fixing hubspot sync issues. The hubspot bridge will need to be configured again on production by running the management command `configure_hubspot_bridge`. Since some data is missing it may also make sense to sync/resync all contacts again by running the management command `sync_hubspot --contacts`.

#### What are the relevant tickets?
closes #317 

#### What's this PR do?
This PR fixes hubspot sync to properly handle first name, last name, and all multiple choice fields.

#### How should this be manually tested?
Load the shell and manually try syncing any profile that was missing information.
