### PR TITLE
Sync contacts in bulk and add a retry to handle too many requests errors

### DIFF
--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -11,6 +11,7 @@ import requests
 from django.conf import settings
 from django.utils import timezone
 
+from hubspot.decorators import try_again
 from hubspot.serializers import HubspotContactSerializer, HubspotProductSerializer, \
     HubspotDealSerializer, HubspotLineSerializer
 from klasses.models import Bootcamp, PersonalPrice
@@ -60,6 +61,7 @@ def parse_hubspot_id(hubspot_id):
     return int(match.group(1)) if match else None
 
 
+@try_again
 def send_hubspot_request(
     endpoint, api_url, method, body=None, query_params=None, **kwargs
 ):

--- a/hubspot/api_test.py
+++ b/hubspot/api_test.py
@@ -3,6 +3,7 @@ Hubspot API tests
 """
 # pylint: disable=redefined-outer-name
 import abc
+from unittest.mock import Mock
 from urllib.parse import urlencode
 
 import pytest
@@ -92,6 +93,17 @@ def test_send_hubspot_request(mocker, request_method, endpoint, api_url, expecte
             endpoint, api_url, request_method, query_params=query_params, body=body
         )
         mock_request.assert_called_once_with(url=url, json=body)
+
+
+def test_send_hubspot_request_try_again(mocker):
+    """Test the try again decorator"""
+    mock_request = mocker.patch(f"hubspot.api.requests.get", return_value=Mock(
+        raise_for_status=Mock(side_effect=HTTPError())))
+
+    api.send_hubspot_request(
+        "sync-errors", "/extensions/ecomm/v1", "GET"
+    )
+    assert mock_request.call_count == 3
 
 
 @pytest.mark.parametrize(

--- a/hubspot/decorators.py
+++ b/hubspot/decorators.py
@@ -1,0 +1,34 @@
+"""
+Decorators for hubspot module
+"""
+import functools
+from time import sleep
+
+from requests import HTTPError
+
+
+def try_again(func):
+    """
+    Wrapper for sending requests to hubspot. Attempts to send requests multiple times.
+    Hubspot does not seem to return 429 errors so any error is considered a too many requests error for the purposes
+    of try again.
+
+    The wrapped function should return a requests response object.
+    """
+    @functools.wraps(func)
+    def wrapper_try_again(*args, **kwargs):
+        max_attempts = 3
+        for i in range(max_attempts):
+            resp = func(*args, **kwargs)
+            try:
+                # If response does not raise an error, return it
+                resp.raise_for_status()
+                return resp
+            except HTTPError:
+                if i + 1 == max_attempts:
+                    # If we have already tried three times, return response and let the code handle it as normal
+                    return resp
+                # Wait 2 seconds in between attempts
+                sleep(2)
+
+    return wrapper_try_again

--- a/smapply/tasks.py
+++ b/smapply/tasks.py
@@ -1,8 +1,9 @@
 """Tasks for smapply"""
 from bootcamp.celery import app
-from hubspot.task_helpers import sync_hubspot_user
+from hubspot.api import make_contact_sync_message
+from hubspot.tasks import sync_bulk_with_hubspot
 from smapply.serializers import UserSerializer
-from smapply.api import list_users, process_user
+from smapply.api import list_users, process_user, SMApplyTaskCache
 from profiles.models import Profile
 
 
@@ -11,6 +12,7 @@ def sync_all_users():
     """
     Pulls user data from SMApply and creates or conditionally updates local User and Profile objects
     """
+    profiles_to_sync = []
     for sma_user in list_users():
         profile = Profile.objects.filter(smapply_id=sma_user['id']).first()
         if not profile:
@@ -20,8 +22,8 @@ def sync_all_users():
                 user.profile.smapply_user_data = sma_user
                 user.profile.save()
 
-                sync_hubspot_user(user.profile)
-        else:
-            profile.smapply_user_data = sma_user
-            profile.save()
-            sync_hubspot_user(profile)
+                profiles_to_sync.append(user.profile)
+
+    if profiles_to_sync:
+        task_cache = SMApplyTaskCache()
+        sync_bulk_with_hubspot(profiles_to_sync, make_contact_sync_message, "CONTACT", task_cache=task_cache)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes Hubspot 500 errors

#### What's this PR do?
This PR adds try again functionality to hubspot requests. It also uses bulk sync on `smapply.tasks.sync_all_users` and reduces how many users get synced each time the task runs.

#### How should this be manually tested?
Delete some or all Profiles from your local database and run `sync_all_users`. Check that there are no errors. When deployed to RC watch for errors. Also make sure that new Profiles are successfully synced to hubspot.
