### PR TITLE
Only create profiles from userdata containing verified email addresses.

### DIFF
--- a/smapply/tasks.py
+++ b/smapply/tasks.py
@@ -14,6 +14,10 @@ def sync_all_users():
     """
     profiles_to_sync = []
     for sma_user in list_users():
+        # Only create Profile and User data for SMApply accounts with verified email addresses
+        if not sma_user.get('email_verified'):
+            continue
+
         profile = Profile.objects.filter(smapply_id=sma_user['id']).first()
         if not profile:
             serializer = UserSerializer(data=sma_user)

--- a/smapply/tasks_test.py
+++ b/smapply/tasks_test.py
@@ -8,7 +8,7 @@ from smapply.tasks import sync_all_users
 pytestmark = pytest.mark.django_db
 
 test_user_data = [
-    {'id': 12345678, 'first_name': 'first_name', 'last_name': 'last_name',
+    {'id': 12345678, 'first_name': 'first_name', 'last_name': 'last_name', 'email_verified': True,
      'email': 'test1@test.co', 'last_login': '2019-08-04T08:27:55', 'date_joined': '2012-10-21T17:37:03',
      'timezone': 'Europe/Berlin', 'groups': [], 'teams': [], 'member_of': [], 'submissions': [], 'status': 0,
      'status_pretty': 'Active', 'roles': 'Applicant', 'role_ids': [1], 'assignments_total': 0,
@@ -16,7 +16,7 @@ test_user_data = [
      'last_login_pretty': 'Aug 4 2019', 'date_joined_pretty': 'Oct 21 2012', 'team_names': '',
      'custom_fields': {'43316': ''}, 'signup_source': '-', 'verified': 'True', 'organizations': [], 'sso_id': [],
      'applicants_conflicted': 0, 'applications_with_awarded_money_count': 0},
-    {'id': 87654321, 'first_name': 'testy', 'last_name': 'testname',
+    {'id': 87654321, 'first_name': 'testy', 'last_name': 'testname', 'email_verified': True,
      'email': 'tester@test.co', 'last_login': '2019-08-04T08:27:55', 'date_joined': '2012-10-21T17:37:03',
      'timezone': 'Europe/Berlin', 'groups': [], 'teams': [], 'member_of': [], 'submissions': [], 'status': 0,
      'status_pretty': 'Active', 'roles': 'Applicant', 'role_ids': [1], 'assignments_total': 0,
@@ -52,6 +52,20 @@ def test_sync_all_users_bad_data(mocker):
     Test that sync_all_users properly skips bad data
     """
     test_user_data[0].pop('email')
+    mocker.patch(
+        'smapply.tasks.list_users',
+        return_value=test_user_data,
+    )
+    mocker.patch('smapply.tasks.sync_bulk_with_hubspot')
+    sync_all_users()
+    assert Profile.objects.count() == 1
+
+
+def test_sync_all_users_unverified_email(mocker):
+    """
+    Test that sync_all_users properly skips users that haven't verified their email address
+    """
+    test_user_data[0]['email_verified'] = False
     mocker.patch(
         'smapply.tasks.list_users',
         return_value=test_user_data,


### PR DESCRIPTION
#### What are the relevant tickets?
closes #325 

#### What's this PR do?
This PR adds code that skips creating Profile and User objects for SMApply users that have not yet verified their email addresses.

#### How should this be manually tested?
Create a new account but dont verify your email address. Wait for the `sync_all_users` task to run or run it manually. Check that the database does not have a new Profile object for your account.
