### PR TITLE
Pin potsgres version 9.6 -> 9.6.16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   db:
-    image: postgres:9.6
+    image: postgres:9.6.16
     ports:
       - "5432"
 


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Pins postgres images to the previous 9.6.x patch version as the current one seems broken.

#### How should this be manually tested?
Travis tests should pass