### PR TITLE
Hubspot contact serializer allow missing fields

### DIFF
--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -87,12 +87,6 @@ class HubspotContactSerializer(serializers.ModelSerializer):
                 else:
                     response = responses[field_key]['response']
                 demographics_data[mapping] = response
-
-        # If any fields aren't present then the associated program has a typo, or is otherwise missing data
-        missing_fields = set(demo_sync_fields.values()) - set(demographics_data.keys())
-        if missing_fields:
-            log.error("Missing fields while syncing data for Profile with SMApply Id %s. Fields: %s",
-                      instance.smapply_id, missing_fields)
         return demographics_data
 
     def to_representation(self, instance):

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -39,7 +39,7 @@ def test_profile_serializer_no_task(mocker, user_data):
 
 
 def test_profile_serializer_missing_task_responses(mocker, demographics_data, task_data, serialized_data):
-    """Test that HubspotProfileSerializer properly logs an error when demographics data is missing"""
+    """Test that HubspotProfileSerializer does not log error when demographics data is missing"""
     logger = mocker.patch('logging.Logger.error')
     profile = ProfileFactory.create(smapply_id=123456)
     demographics_data['data'].pop('8JgmHI7gTA')
@@ -49,13 +49,13 @@ def test_profile_serializer_missing_task_responses(mocker, demographics_data, ta
     mock_api().get.return_value.json.return_value = task_data
 
     data = HubspotContactSerializer(instance=profile).data
-    logger.assert_called_once()
+    logger.assert_not_called()
     serialized_data.pop('industry')
     assert data == serialized_data
 
 
 def test_profile_serializer_missing_task_fields(mocker, demographics_data, task_data, serialized_data):
-    """Test that HubspotProfileSerializer properly logs an error when demographics data is missing"""
+    """Test that HubspotProfileSerializer does not log error when demographics data is missing"""
     logger = mocker.patch('logging.Logger.error')
     profile = ProfileFactory.create(smapply_id=123456)
     demographics_data['data'].pop('8JgmHI7gTA')
@@ -66,7 +66,7 @@ def test_profile_serializer_missing_task_fields(mocker, demographics_data, task_
     mock_api().get.return_value.json.return_value = task_data
 
     data = HubspotContactSerializer(instance=profile).data
-    logger.assert_called_once()
+    logger.assert_not_called()
     serialized_data.pop('industry')
     assert data == serialized_data
 

--- a/smapply/api.py
+++ b/smapply/api.py
@@ -232,7 +232,6 @@ def process_user(sma_user):
     Returns:
         User: user modified or created by the function
     """
-
     serializer = UserSerializer(data=sma_user)
     serializer.is_valid(raise_exception=True)
 

--- a/smapply/api.py
+++ b/smapply/api.py
@@ -221,8 +221,7 @@ class SMApplyTaskCache:
             self.task_cache[task_id] = task_data
             return copy.deepcopy(task_data)
 
-
-def process_user(sma_user):
+def process_user(sma_user, require_validation=True):
     """
     Create/update User and Profile model objects based on SMApply user info
 
@@ -232,8 +231,9 @@ def process_user(sma_user):
     Returns:
         User: user modified or created by the function
     """
-    serializer = UserSerializer(data=sma_user)
-    serializer.is_valid(raise_exception=True)
+    if require_validation:
+        serializer = UserSerializer(data=sma_user)
+        serializer.is_valid(raise_exception=True)
 
     user, _ = User.objects.get_or_create(
         email__iexact=sma_user['email'],

--- a/smapply/api.py
+++ b/smapply/api.py
@@ -221,12 +221,14 @@ class SMApplyTaskCache:
             self.task_cache[task_id] = task_data
             return copy.deepcopy(task_data)
 
+
 def process_user(sma_user, require_validation=True):
     """
     Create/update User and Profile model objects based on SMApply user info
 
     Args:
         sma_user (ReturnDict): Data from a smapply.serializers.UserSerializer object
+        require_validation (bool): if the user data should be validated or not
 
     Returns:
         User: user modified or created by the function

--- a/smapply/api_test.py
+++ b/smapply/api_test.py
@@ -218,6 +218,7 @@ def test_process_new_profile():
     process_user(sma_user)
     assert User.objects.filter(email=sma_user['email']).count() == 1
     assert Profile.objects.filter(smapply_id=sma_user['id']).count() == 1
+    assert Profile.objects.get(smapply_id=sma_user['id']).smapply_user_data == sma_user
 
 
 def test_process_both_exist_no_smapply_id(mocker):

--- a/smapply/tasks.py
+++ b/smapply/tasks.py
@@ -1,10 +1,12 @@
 """Tasks for smapply"""
+import logging
 from bootcamp.celery import app
 from hubspot.api import make_contact_sync_message
 from hubspot.tasks import sync_bulk_with_hubspot
-from smapply.serializers import UserSerializer
 from smapply.api import list_users, process_user, SMApplyTaskCache
 from profiles.models import Profile
+
+log = logging.getLogger(__name__)
 
 
 @app.task
@@ -20,11 +22,11 @@ def sync_all_users():
 
         profile = Profile.objects.filter(smapply_id=sma_user['id']).first()
         if not profile:
-            serializer = UserSerializer(data=sma_user)
-            if serializer.is_valid():
+            try:
                 user = process_user(sma_user)
-
                 profiles_to_sync.append(user.profile)
+            except:  # pylint: disable=bare-except
+                log.exception('Syncing profile for SMA user %s failed', sma_user['id'])
 
     if profiles_to_sync:
         task_cache = SMApplyTaskCache()

--- a/smapply/tasks.py
+++ b/smapply/tasks.py
@@ -22,9 +22,7 @@ def sync_all_users():
         if not profile:
             serializer = UserSerializer(data=sma_user)
             if serializer.is_valid():
-                user = process_user(serializer.data)
-                user.profile.smapply_user_data = sma_user
-                user.profile.save()
+                user = process_user(sma_user)
 
                 profiles_to_sync.append(user.profile)
 

--- a/smapply/tasks.py
+++ b/smapply/tasks.py
@@ -7,7 +7,6 @@ from smapply.api import list_users, process_user, SMApplyTaskCache
 from profiles.models import Profile
 
 
-
 @app.task
 def sync_all_users():
     """


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #332

#### What's this PR do?
For programs that have webhook setup for firing on application creation, this allows for the contact to successfully sync with hubspot, given that they haven't filled out the application yet, and the demographic data is still missing.

1) Hubspot requires only one field for contact creation: `email`.
The email is found in `Profile.smapply_user_data`. I updated the code to fill out this data in `process_user` procedure, instead of `sync_all_users` scheduled task.

2) Removed the check for missing fields when syncing user data

#### How should this be manually tested?
Setup a webhook for your program. It is already setup for "Test Program".
Create a new application in SMApply for a user that does not have a profile in your local Bootcamp and Hubspot.
If the webhook succeeds then a contact should get created in Hubspot for your user.