### PR TITLE
Add bootcamp name to deal

### DIFF
--- a/hubspot/management/commands/configure_hubspot_bridge.py
+++ b/hubspot/management/commands/configure_hubspot_bridge.py
@@ -39,6 +39,14 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
                 'name': 'application_stage',
                 'type': 'string'
             },
+            {
+                'description': 'The associated bootcamp name',
+                'fieldType': 'text',
+                'groupName': 'dealinformation',
+                'label': 'Bootcamp Name',
+                'name': 'bootcamp_name',
+                'type': 'string'
+            },
         ]
     },
     "contacts": {
@@ -223,6 +231,11 @@ HUBSPOT_ECOMMERCE_SETTINGS = {
             {
                 "propertyName": "application_stage",
                 "targetHubspotProperty": "application_stage",
+                "dataType": "STRING",
+            },
+            {
+                "propertyName": "bootcamp_name",
+                "targetHubspotProperty": "bootcamp_name",
                 "dataType": "STRING",
             },
         ]

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -123,6 +123,7 @@ class HubspotDealSerializer(serializers.ModelSerializer):
     name = serializers.SerializerMethodField()
     purchaser = serializers.SerializerMethodField()
     price = serializers.SerializerMethodField()
+    bootcamp_name = serializers.SerializerMethodField()
 
     def get_name(self, instance):
         """Get a formatted name for the deal"""
@@ -136,6 +137,10 @@ class HubspotDealSerializer(serializers.ModelSerializer):
     def get_price(self, instance):
         """Get a string of the price"""
         return instance.price.to_eng_string()
+
+    def get_bootcamp_name(self, instance):
+        """Get a string of the price"""
+        return instance.klass.bootcamp.title
 
     def to_representation(self, instance):
         # Populate order data
@@ -162,7 +167,7 @@ class HubspotDealSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PersonalPrice
-        fields = ['name', 'application_stage', 'price', 'purchaser']
+        fields = ['name', 'application_stage', 'price', 'purchaser', 'bootcamp_name']
 
 
 class HubspotLineSerializer(serializers.ModelSerializer):

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -139,7 +139,7 @@ class HubspotDealSerializer(serializers.ModelSerializer):
         return instance.price.to_eng_string()
 
     def get_bootcamp_name(self, instance):
-        """Get a string of the price"""
+        """Get the name of the bootcamp"""
         return instance.klass.bootcamp.title
 
     def to_representation(self, instance):

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -86,6 +86,7 @@ def test_deal_serializer():
     personal_price.user.profile = profile
 
     serialized_data = {'application_stage': '',
+                       'bootcamp_name': personal_price.klass.bootcamp.title,
                        'price': personal_price.price.to_eng_string(),
                        'purchaser': format_hubspot_id(personal_price.user.profile.id),
                        'name': f'Bootcamp-application-{personal_price.id}',


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #331

#### What's this PR do?
Adds a field to deal object. Filtering users by bootcamp name and application stage.

![Screen Shot 2020-03-04 at 2 11 39 PM](https://user-images.githubusercontent.com/7574259/75914843-73ed0180-5e23-11ea-8524-e1693bb0ddc1.png)


#### How should this be manually tested?
Create a user application for a test bootcamp, without filling it out. Make sure the program has a webhook automation set up to fire on application creation. Also make sure that the user that is starting the application is not already synced with bootcamp and hubspot.
When the user starts the application contact and deal should get synced to hubspot.
