### PR TITLE
Upgrade redux-asserts for security alert for lodash-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-test-renderer": "^15.5.0-rc.2",
     "redux": "^4.0.4",
     "redux-actions": "^2.6.5",
-    "redux-asserts": "^0.0.10",
+    "redux-asserts": "^0.0.12",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "sass-lint": "^1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4435,10 +4435,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.2.1:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
-
 lodash.assignin@^4.0.9:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
@@ -4541,7 +4537,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5836,7 +5832,7 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.1:
+prop-types@^15.6.1, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6161,12 +6157,14 @@ redux-actions@^2.6.5:
     reduce-reducers "^0.4.3"
     to-camel-case "^1.0.0"
 
-redux-asserts@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/redux-asserts/-/redux-asserts-0.0.10.tgz#d955958c56e8482c6289c5208da7303b9e1171b5"
+redux-asserts@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/redux-asserts/-/redux-asserts-0.0.12.tgz#dc376781950a28de9ca4ad0558b2b5d79350915b"
+  integrity sha512-pAfT6uuoFEW9vso48lHeGsXhNU2KqO6zXfL1cWlny/WUpL5zQe3pI9TDP0IWwEBv06G8giLNfkp739R8spao0A==
   dependencies:
-    lodash "^4.6.1"
-    redux "^3.3.1"
+    lodash "^4.17.15"
+    prop-types "^15.7.2"
+    redux "^4.0.4"
     redux-thunk "^2.0.1"
 
 redux-logger@^3.0.6:
@@ -6178,15 +6176,6 @@ redux-logger@^3.0.6:
 redux-thunk@^2.0.1, redux-thunk@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
-
-redux@^3.3.1:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
-  dependencies:
-    lodash "^4.2.1"
-    lodash-es "^4.2.1"
-    loose-envify "^1.1.0"
-    symbol-observable "^1.0.3"
 
 redux@^4.0.4:
   version "4.0.4"
@@ -7064,10 +7053,6 @@ svgo@^0.7.0:
     mkdirp "~0.5.1"
     sax "~1.2.1"
     whet.extend "~0.9.9"
-
-symbol-observable@^1.0.3:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
 
 symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
#### What are the relevant tickets?
Security alert ag/upgrade_redux

#### What's this PR do?
Upgrade redux-asserts

#### How should this be manually tested?
Nothing should break