### PR TITLE
Upgrade minimist

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jsdom-global": "^3.0.2",
     "keycode": "^2.1.9",
     "lodash": "^4.17.14",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.5",
     "mocha": "^4.0.1",
     "moment": "^2.20.1",
     "node-sass": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4810,6 +4810,11 @@ minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 mixin-object@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"


### PR DESCRIPTION
#### What are the relevant tickets?
Security Alert https://github.com/mitodl/bootcamp-ecommerce/network/alert/yarn.lock/minimist/open

#### What's this PR do?
Upgrade minimist to 1.2.5

#### How should this be manually tested?
Nothing should break

┆Attachments: <a href="https://github.com/mitodl/bootcamp-ecommerce/pull/354">bootcamp-ecommerce #354 Bump minimist from 1.2.0 to 1.2.2</a> | <a href="https://github.com/mitodl/bootcamp-ecommerce/pull/359">https:&#x2F;&#x2F;github.com&#x2F;mitodl&#x2F;bootcamp-ecommerce&#x2F;pull&#x2F;359</a>
