### PR TITLE
Add back SecurityMiddleware

### DIFF
--- a/bootcamp/settings.py
+++ b/bootcamp/settings.py
@@ -136,6 +136,7 @@ if not DISABLE_WEBPACK_LOADER_STATS:
 
 
 MIDDLEWARE = (
+    'django.middleware.security.SecurityMiddleware',
     'raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #362 

#### What's this PR do?
Adds back `SecurityMiddleware` which handles SSL redirects. I think it was probably confused with `SessionMiddleware` in #356, and `SessionMiddleware` is deprecated since its functionality is automatic in newer versions of Django

#### How should this be manually tested?
Will need to test on RC


#### Any background context you want to provide?
Should we be doing SSL redirects in nginx instead?