### PR TITLE
Remove py-call-osafterfork setting from uwsgi.ini

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,7 +1,6 @@
 [uwsgi]
 strict = true
 need-app = true
-py-call-osafterfork = true
 auto-procname = true
 if-env = DEV_ENV
 socket = :$(PORT)


### PR DESCRIPTION

#### What are the relevant tickets?

https://trello.com/c/upfutK0A/44-update-all-uwsgi-configs-with-recommendations-from-bloomberg-article

#### What's this PR do?

It removes a uWSGI parameter that is going to be deprecated, and which causes an exception when uWSGI starts up; on some versions of Python 3. The server would still run, but it would raise this exception.

See
https://github.com/mitodl/micromasters/pull/4569#issuecomment-611130601
and the other comments in that thread.


#### How should this be manually tested?

```
docker-compose build
docker-compose up -d
docker logs -f bootcamp-ecommerce_web_1
```
... You should see output like the following, with no exception saying "cannot release un-acquired lock."

```
spawned uWSGI master process (pid: 1)
spawned uWSGI worker 1 (pid: 19, cores: 100)
spawned 2 offload threads for uWSGI worker 1
spawned uWSGI worker 2 (pid: 22, cores: 100)
running "exec:touch /tmp/app-initialized" (accepting1)...
spawned 2 offload threads for uWSGI worker 2
Python auto-reloader enabled
```