### PR TITLE
pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: git@github.com:Yelp/detect-secrets
+    rev: v0.13.1
+    hooks:
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: .*_test.*|yarn\.lock

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,77 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-04-27T20:22:32Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "d821063cb2fa7fee23506a4a075cac83c9699e50",
+        "is_verified": false,
+        "line_number": 101,
+        "type": "Secret Keyword"
+      }
+    ],
+    "tox.ini": [
+      {
+        "hashed_secret": "a91d15f236494c30183c34d79e945cb243e214db",
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Base64 High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/README.md
+++ b/README.md
@@ -220,3 +220,18 @@ otherwise do in a Django shell. To get started:
 
 From there, you should be able to run code snippets with a live Django app just like you
 would in a Django shell.
+
+
+## Commits
+
+To ensure commits to github are safe, you should install the following first:
+```
+pip install pre_commit
+pre-commit install
+```
+
+To automatically install precommit hooks when cloning a repo, you can run this:
+```
+git config --global init.templateDir ~/.git-template
+pre-commit init-templatedir ~/.git-template
+```    


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #421

#### What's this PR do?
Install config files to run the `detect-secrets` hook via `pre-commit`

#### What's this PR do?
- Installs a pre-commit hook during `docker-compose build` that will run before every commit

#### How should this be manually tested?
- run `pip install pre_commit detect-secrets`
- run `pre-commit install`
- `git add` an `.env`-like file with fake (but realistic) AWS credentials in it
- `git commit -a -m 'test' ` should generate an error list of bad things it finds in the added file, and the commit should be aborted.
- Replace the contents of the file with safe random text, then run `git commit -a -m 'test'` again, it should work. 
