### PR TITLE
Redirect to pay page after purchase

### DIFF
--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -59,7 +59,7 @@ class PaymentView(CreateAPIView):
         # Sync order data with hubspot
         sync_hubspot_deal_from_order(order)
 
-        redirect_url = self.request.build_absolute_uri(reverse('bootcamp-index'))
+        redirect_url = self.request.build_absolute_uri(reverse('pay'))
 
         return Response({
             'payload': generate_cybersource_sa_payload(order, redirect_url),

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -91,7 +91,7 @@ class PaymentTests(TestCase):
             'url': CYBERSOURCE_SECURE_ACCEPTANCE_URL,
         }
         assert generate_cybersource_sa_payload_mock.call_count == 1
-        generate_cybersource_sa_payload_mock.assert_any_call(fake_order, "http://testserver/")
+        generate_cybersource_sa_payload_mock.assert_any_call(fake_order, "http://testserver/pay/")
         assert create_unfulfilled_order_mock.call_count == 1
         create_unfulfilled_order_mock.assert_any_call(user, klass.klass_key, klass.price)
 

--- a/klasses/bootcamp_admissions_client.py
+++ b/klasses/bootcamp_admissions_client.py
@@ -59,7 +59,7 @@ class BootcampAdmissionClient:
             user (User): A user
         """
         self._klass_keys = fetch_fluidreview_klass_keys(user.profile.fluidreview_id) + \
-            fetch_smapply_klass_keys(user.profile.smapply_id)
+            fetch_smapply_klass_keys(user.profile.smapply_id) + [12345]
 
     @property
     def payable_klasses_keys(self):

--- a/klasses/bootcamp_admissions_client.py
+++ b/klasses/bootcamp_admissions_client.py
@@ -59,7 +59,7 @@ class BootcampAdmissionClient:
             user (User): A user
         """
         self._klass_keys = fetch_fluidreview_klass_keys(user.profile.fluidreview_id) + \
-            fetch_smapply_klass_keys(user.profile.smapply_id) + [12345]
+            fetch_smapply_klass_keys(user.profile.smapply_id)
 
     @property
     def payable_klasses_keys(self):

--- a/main/views.py
+++ b/main/views.py
@@ -43,6 +43,7 @@ def index(request):
 
 
 @login_required
+@csrf_exempt
 def react(request):
     """
     View for pages served by react

--- a/static/js/containers/PaymentPage.js
+++ b/static/js/containers/PaymentPage.js
@@ -119,10 +119,15 @@ export class PaymentPage extends React.Component<Props> {
 
   handleOrderStatus = (): void => {
     const { klasses, klassesFinished } = this.props
-    const query = new URI().query(true)
+    let query = new URI().query(true)
     if (!klassesFinished) {
       // wait until we have access to the klasses
       return
+    }
+
+    // hacky workaround to handle redirect from Cybersource while keeping query parameters
+    if (query.next) {
+      query = new URI(query.next).query(true)
     }
 
     const status = query.status

--- a/static/js/containers/PaymentPage_test.js
+++ b/static/js/containers/PaymentPage_test.js
@@ -225,21 +225,36 @@ describe("PaymentPage", () => {
       orderId = fakeKlasses[0].payments[0].order.id
     })
 
-    it("shows the order status toast when the query param is set for a cancellation", async () => {
-      window.location = "/pay/?status=cancel"
-      const { store } = await renderPage()
-      assert.deepEqual(store.getState().ui.toastMessage, {
-        message: "Order was cancelled",
-        icon:    TOAST_FAILURE
-      })
-    })
+    //
+    ;[true, false].forEach(isNext => {
+      describe(`when next ${isNext ? "is" : "is not"} specified`, () => {
+        it("shows the order status toast when the query param is set for a cancellation", async () => {
+          let uri = "/pay/?status=cancel"
+          if (isNext) {
+            uri = `/pay/?next=${encodeURIComponent(uri)}`
+          }
 
-    it("shows the order status toast when query param is set for a success", async () => {
-      window.location = `/pay?status=receipt&order=${orderId}`
-      const { store } = await renderPage()
-      assert.deepEqual(store.getState().ui.toastMessage, {
-        title: "Payment Complete!",
-        icon:  TOAST_SUCCESS
+          window.location = uri
+          const { store } = await renderPage()
+          assert.deepEqual(store.getState().ui.toastMessage, {
+            message: "Order was cancelled",
+            icon:    TOAST_FAILURE
+          })
+        })
+
+        it("shows the order status toast when query param is set for a success", async () => {
+          let uri = `/pay?status=receipt&order=${orderId}`
+          if (isNext) {
+            uri = `/pay/?next=${encodeURIComponent(uri)}`
+          }
+
+          window.location = uri
+          const { store } = await renderPage()
+          assert.deepEqual(store.getState().ui.toastMessage, {
+            title: "Payment Complete!",
+            icon:  TOAST_SUCCESS
+          })
+        })
       })
     })
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #416 

#### What's this PR do?
Redirects to `/pay/` instead of `/` after purchase. I think there used to be an automatic redirect from `/` to `/pay/` for people who are logged in, but this should fix the issue too.

#### How should this be manually tested?
It's probably easiest to just test this on RC
