### PR TITLE
Upgraded docker-compose version and added Jupyter notebook config

### DIFF
--- a/Dockerfile-nb
+++ b/Dockerfile-nb
@@ -1,0 +1,10 @@
+FROM bootcamp-ecommerce_web
+
+USER root
+
+WORKDIR /tmp
+
+RUN pip install --force-reinstall jupyter
+
+USER mitodl
+WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -180,3 +180,43 @@ Custom fields can be found at `<SMAPPLY_BASE_URL>/admin/settings/metadata/`
           "user": "Student Name"
         }
         ```
+
+## Running the app in a notebook
+
+This repo includes a config for running a [Jupyter notebook](https://jupyter.org/) in a
+Docker container. This enables you to do in a Jupyter notebook anything you might
+otherwise do in a Django shell. To get started:
+
+- Copy the example file
+    ```bash
+    # Choose any name for the resulting .ipynb file
+    cp localdev/app.ipynb.example localdev/app.ipynb
+    ```
+- Build the `notebook` container _(for first time use, or when requirements change)_
+    ```bash
+    docker-compose -f docker-compose-notebook.yml build
+    ```
+- Run all the standard containers (`docker-compose up`)
+- In another terminal window, run the `notebook` container
+    ```bash
+    docker-compose -f docker-compose-notebook.yml run --rm --service-ports notebook
+    ```
+- Visit the running notebook server in your browser. The `notebook` container log output will
+  indicate the URL and `token` param with some output that looks like this:
+    ```
+    notebook_1  |     To access the notebook, open this file in a browser:
+    notebook_1  |         file:///home/mitodl/.local/share/jupyter/runtime/nbserver-8-open.html
+    notebook_1  |     Or copy and paste one of these URLs:
+    notebook_1  |         http://(2c19429d04d0 or 127.0.0.1):8080/?token=2566e5cbcd723e47bdb1b058398d6bb9fbf7a31397e752ea
+    ```
+  Here is a one-line command that will produce a browser-ready URL from that output. Run this in a separate terminal:
+    ```bash
+    APP_HOST="boot.odl.local"; docker logs $(docker ps --format '{{.Names}}' | grep "_notebook_run_") | grep -E "http://(.*):8080[^ ]+\w" | tail -1 | sed -e 's/^[[:space:]]*//' | sed -e "s/(.*)/$APP_HOST/"
+    ```
+  OSX users can pipe that output to `xargs open` to open a browser window directly with the URL from that command.
+- Navigate to the `.ipynb` file that you created and click it to run the notebook
+- Execute the first block to confirm it's working properly (click inside the block
+  and press Shift+Enter)
+
+From there, you should be able to run code snippets with a live Django app just like you
+would in a Django shell.

--- a/docker-compose-notebook.yml
+++ b/docker-compose-notebook.yml
@@ -1,0 +1,35 @@
+version: '3.6'
+
+x-environment:
+  &py-environment
+  DEBUG: 'False'
+  DEV_ENV: 'True'  # necessary to have nginx connect to web container
+  NODE_ENV: 'production'
+  PORT: 8097
+  COVERAGE_DIR: htmlcov
+  DATABASE_URL: postgres://postgres@db:5432/postgres
+  BOOTCAMP_SECURE_SSL_REDIRECT: 'False'
+  BOOTCAMP_DB_DISABLE_SSL: 'True'
+  CELERY_TASK_ALWAYS_EAGER: 'False'
+  CELERY_BROKER_URL: redis://redis:6379/4
+  CELERY_RESULT_BACKEND: redis://redis:6379/4
+  DOCKER_HOST: ${DOCKER_HOST:-missing}
+  WEBPACK_DEV_SERVER_HOST: ${WEBPACK_DEV_SERVER_HOST:-localhost}
+
+services:
+  notebook:
+    build:
+      context: .
+      dockerfile: Dockerfile-nb
+    volumes:
+      - .:/src
+    environment:
+      << : *py-environment
+      BASE_DJANGO_APP_NAME: main
+    env_file: .env
+    command: >
+      /bin/bash -c '
+      sleep 3 &&
+      jupyter notebook --no-browser --ip=0.0.0.0 --port=8080'
+    ports:
+      - "8080:8080"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,14 +1,6 @@
-version: '2.1'
-services:
-  python:
-    volumes:
-      - .:/src
-      - django_media:/var/media
-    environment:
-      DEBUG: 'True'
-      NODE_ENV: 'development'
-      BOOTCAMP_USE_WEBPACK_DEV_SERVER: 'True'
+version: '3.6'
 
+services:
   web:
     volumes:
       - .:/src

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -1,10 +1,5 @@
-version: '2.1'
+version: '3.6'
 services:
-  python:
-    build:
-      context: .
-      dockerfile: ./travis/Dockerfile-travis-web
-
   web:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
-version: '2.1'
+version: '3.6'
+
+x-environment:
+  &py-environment
+  DEBUG: 'False'
+  DEV_ENV: 'True'  # necessary to have nginx connect to web container
+  NODE_ENV: 'production'
+  COVERAGE_DIR: htmlcov
+  DATABASE_URL: postgres://postgres@db:5432/postgres
+  BOOTCAMP_SECURE_SSL_REDIRECT: 'False'
+  BOOTCAMP_DB_DISABLE_SSL: 'True'
+  CELERY_TASK_ALWAYS_EAGER: 'False'
+  CELERY_BROKER_URL: redis://redis:6379/4
+  CELERY_RESULT_BACKEND: redis://redis:6379/4
+  DOCKER_HOST: ${DOCKER_HOST:-missing}
+  WEBPACK_DEV_SERVER_HOST: ${WEBPACK_DEV_SERVER_HOST:-localhost}
+
 services:
   db:
     image: postgres:9.6.16
@@ -17,39 +33,24 @@ services:
     links:
       - web
 
-  python:
+  web:
     build:
       context: .
       dockerfile: Dockerfile
-    command: /bin/true
-    environment:
-      DEBUG: 'False'
-      DEV_ENV: 'True'  # necessary to have nginx connect to web container
-      NODE_ENV: 'production'
-      PORT: 8097
-      COVERAGE_DIR: htmlcov
-      DATABASE_URL: postgres://postgres@db:5432/postgres
-      BOOTCAMP_SECURE_SSL_REDIRECT: 'False'
-      BOOTCAMP_DB_DISABLE_SSL: 'True'
-      CELERY_TASK_ALWAYS_EAGER: 'False'
-      CELERY_BROKER_URL: redis://redis:6379/4
-      CELERY_RESULT_BACKEND: redis://redis:6379/4
-      DOCKER_HOST: ${DOCKER_HOST:-missing}
-      WEBPACK_DEV_SERVER_HOST: ${WEBPACK_DEV_SERVER_HOST:-localhost}
-    env_file: .env
-
-  web:
-    image: bootcamp_python
-    extends:
-      service: python
     command: >
       /bin/bash -c '
       sleep 3 &&
       python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --no-input &&
-      uwsgi uwsgi.ini'
+      uwsgi uwsgi.ini --honour-stdin'
+    stdin_open: true
+    tty: true
     ports:
       - "8097:8097"
+    environment:
+      <<: *py-environment
+      PORT: 8097
+    env_file: .env
     links:
       - db
       - redis
@@ -70,9 +71,11 @@ services:
     env_file: .env
 
   celery:
-    image: bootcamp_python
-    extends:
-      service: python
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment: *py-environment
+    env_file: .env
     command: >
       /bin/bash -c '
       sleep 3;

--- a/localdev/app.ipynb.example
+++ b/localdev/app.ipynb.example
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import django\n",
+    "from django.contrib.auth import get_user_model\n",
+    "\n",
+    "ABS_PROJECT_ROOT_PATH = \"/src\"\n",
+    "BASE_DJANGO_APP_NAME = os.environ.get(\"BASE_DJANGO_APP_NAME\")\n",
+    "\n",
+    "if not ABS_PROJECT_ROOT_PATH in sys.path:\n",
+    "    sys.path.insert(0, ABS_PROJECT_ROOT_PATH)\n",
+    "os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{}.settings'.format(BASE_DJANGO_APP_NAME))\n",
+    "django.setup()\n",
+    "\n",
+    "User = get_user_model()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
- Upgrades the docker-compose version from 2.1 to 3.6
- Adds config for running the app in a Jupyter Notebook like we have in other apps

#### How should this be manually tested?
1. Build and run the containers. Make sure the app loads.
2. Follow the notebook instructions in the readme and confirm that the notebook runs

#### Any background context you want to provide?
I've been doing a bunch of data seeding/manipulation to test the Klass rename (#425), and I find that type of stuff much easier in a notebook. We've made these changes in other repos so it was easy enough to apply the same changes here
