### PR TITLE
Fix environment variable for USE_S3, and remove reference to removed OverwriteStorage

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,6 +28,22 @@
       "default": "['*']",
       "description": "Array of allowed hostnames"
     },
+    "AWS_ACCESS_KEY_ID": {
+      "description": "AWS Access Key for S3 storage.",
+      "required": false
+    },
+    "AWS_QUERYSTRING_AUTH": {
+      "description": null,
+      "required": false
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+      "description": "AWS Secret Key for S3 storage.",
+      "required": false
+    },
+    "AWS_STORAGE_BUCKET_NAME": {
+      "description": "S3 Bucket name.",
+      "required": false
+    },
     "CYBERSOURCE_ACCESS_KEY": {
       "description": "CyberSource Access Key"
     },

--- a/main/settings.py
+++ b/main/settings.py
@@ -470,7 +470,7 @@ WAGTAIL_SITE_NAME = "MIT Bootcamp-Ecommerce"
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
-BOOTCAMP_ECOMMERCE_USE_S3 = get_bool('MICROMASTERS_USE_S3', False)
+BOOTCAMP_ECOMMERCE_USE_S3 = get_bool('BOOTCAMP_USE_S3', False)
 AWS_ACCESS_KEY_ID = get_string('AWS_ACCESS_KEY_ID', False)
 AWS_SECRET_ACCESS_KEY = get_string('AWS_SECRET_ACCESS_KEY', False)
 AWS_STORAGE_BUCKET_NAME = get_string('AWS_STORAGE_BUCKET_NAME', False)
@@ -490,10 +490,6 @@ if (
     )
 if BOOTCAMP_ECOMMERCE_USE_S3:
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
-else:
-    # by default use django.core.files.storage.FileSystemStorage with
-    # overwrite feature
-    DEFAULT_FILE_STORAGE = 'storages.backends.overwrite.OverwriteStorage'
 
 # Celery
 CELERY_BROKER_URL = get_var(


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes a couple of bugs:
 - `OverwriteStorage` was removed so this goes with the default option which is `FileSystemStorage` instead. Since this only affects local instances it shouldn't make much of a difference.
 - Rename `MICROMASTERS_USE_S3` to `BOOTCAMP_USE_S3`

#### How should this be manually tested?
N/A, this should not affect anything. I don't know that we use django-storages yet in Bootcamp.

