### PR TITLE
Fix Jobma webhook permissions check

### DIFF
--- a/jobma/permissions.py
+++ b/jobma/permissions.py
@@ -17,8 +17,8 @@ class JobmaWebhookPermission(BasePermission):
             log.error("JOBMA_WEBHOOK_ACCESS_TOKEN not set")
             return False
         header = request.headers.get("authorization", "")
-        if header.startswith("Token "):
-            token = header[len("Token "):]
+        if header.startswith("Bearer "):
+            token = header[len("Bearer "):]
 
             return token == settings.JOBMA_WEBHOOK_ACCESS_TOKEN
         return False

--- a/jobma/permissions_test.py
+++ b/jobma/permissions_test.py
@@ -7,7 +7,7 @@ def test_webhook_auth(settings, mocker):
     """The permission check should pass if the auth token matches"""
     token = "asdfghjk"
     settings.JOBMA_WEBHOOK_ACCESS_TOKEN = token
-    request = mocker.Mock(headers=HttpHeaders({"HTTP_AUTHORIZATION": f"Token {token}"}))
+    request = mocker.Mock(headers=HttpHeaders({"HTTP_AUTHORIZATION": f"Bearer {token}"}))
     assert JobmaWebhookPermission().has_permission(request, mocker.Mock()) is True
 
 
@@ -15,7 +15,7 @@ def test_webhook_auth_incorrect(settings, mocker):
     """If the token doesn't match, it should not have permission"""
     token = "asdfghjk"
     settings.JOBMA_WEBHOOK_ACCESS_TOKEN = token
-    request = mocker.Mock(headers=HttpHeaders({"HTTP_AUTHORIZATION": "Token someothertoken"}))
+    request = mocker.Mock(headers=HttpHeaders({"HTTP_AUTHORIZATION": "Bearer someothertoken"}))
     assert JobmaWebhookPermission().has_permission(request, mocker.Mock()) is False
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #431 

#### What's this PR do?
Fixes the authorization header check. I used the DRF docs instead of the Jobma docs to took at what was expected here.

#### How should this be manually tested?
There isn't a full workflow to test with yet so it would be cumbersome to set up locally.