### PR TITLE
Fix accidental removal of pylint from pytest.ini

### DIFF
--- a/backends/utils_test.py
+++ b/backends/utils_test.py
@@ -32,9 +32,11 @@ def update_social_extra_data(user, data):
 
 @pytest.fixture
 def mock_refresh(mocker, social_extra_data):
+    """Mock refresh_token"""
     yield mocker.patch('backends.edxorg.EdxOrgOAuth2.refresh_token', return_value=social_extra_data, autospec=True)
 
 
+# pylint: disable=redefined-outer-name
 def test_refresh(mock_refresh, now, user):
     """The refresh needs to be called"""
 

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -39,6 +39,7 @@ from profiles.factories import UserFactory, ProfileFactory
 pytestmark = pytest.mark.django_db
 
 
+# pylint: disable=redefined-outer-name, unused-argument
 def create_purchasable_bootcamp_run():
     """Create a purchasable bootcamp run, and a user to be associated with it"""
     profile = ProfileFactory.create()

--- a/ecommerce/models_test.py
+++ b/ecommerce/models_test.py
@@ -102,6 +102,7 @@ def test_run_title():
 
 @pytest.fixture
 def lines_fulfilled():
+    """Create fulfilled orders and lines"""
     order_fulfilled_1 = OrderFactory.create(status=Order.FULFILLED)
     line_fulfilled_1 = LineFactory.create(order=order_fulfilled_1)
     user = order_fulfilled_1.user
@@ -109,11 +110,12 @@ def lines_fulfilled():
     order_fulfilled_2 = OrderFactory.create(user=user, status=Order.FULFILLED)
     line_fulfilled_2 = LineFactory.create(order=order_fulfilled_2)
     order_created = OrderFactory.create(user=user, status=Order.CREATED)
-    line_created = LineFactory.create(order=order_created, run_key=run_key)
+    LineFactory.create(order=order_created, run_key=run_key)
 
     yield line_fulfilled_1, line_fulfilled_2, user, run_key
 
 
+# pylint: disable=redefined-outer-name
 def test_fulfilled_for_user(lines_fulfilled):
     """
     Test for the fulfilled_for_user classmethod

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -32,6 +32,7 @@ def line():
     yield LineFactory.create()
 
 
+# pylint: disable=redefined-outer-name
 def test_orderpartial_serializer(line):
     """
     Test order partial serializer result

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -33,6 +33,7 @@ batch_recipient_arg = [('a@example.com', None), ('b@example.com', {"name": "B"})
 individual_recipient_arg = 'a@example.com'
 
 
+# pylint: disable=redefined-outer-name
 @pytest.fixture
 def mock_post(mocker, mocked_json):
     """Mock post with successful json response"""

--- a/mail/api_test.py
+++ b/mail/api_test.py
@@ -35,6 +35,7 @@ individual_recipient_arg = 'a@example.com'
 
 @pytest.fixture
 def mock_post(mocker, mocked_json):
+    """Mock post with successful json response"""
     mocked = mocker.patch('requests.post', autospec=True, return_value=mocker.Mock(
         spec=Response,
         status_code=HTTP_200_OK,
@@ -43,6 +44,7 @@ def mock_post(mocker, mocked_json):
     yield mocked
 
 
+# pylint: disable=redefined-outer-name
 @pytest.mark.parametrize("sender_name", [None, 'Tester'])
 def test_send_batch(settings, sender_name, mock_post):
     """
@@ -181,7 +183,7 @@ def test_send_batch_400_no_raise(settings, mocker, mock_post, mocked_json):
     chunk_size = 10
     recipient_tuples = [("{0}@example.com".format(letter), None) for letter in string.ascii_letters]
     assert len(recipient_tuples) == 52
-    settings.MAILGUN_RECIPIENT_OVERRIDE=None
+    settings.MAILGUN_RECIPIENT_OVERRIDE = None
     resp_list = MailgunClient.send_batch(
         'email subject', 'email body', recipient_tuples, chunk_size=chunk_size, raise_for_status=False
     )

--- a/main/serializers_test.py
+++ b/main/serializers_test.py
@@ -14,7 +14,7 @@ def profile():
     yield ProfileFactory.create(name='Full Name')
 
 
-# pylint: disable=redefined-outer-names,unused-argument
+# pylint: disable=redefined-outer-name,unused-argument
 def test_serialize_maybe_user(mocker, profile):
     """Test that a user is correctly serialized"""
     mocker.patch('main.serializers.get_social_username', return_value='abc')

--- a/main/serializers_test.py
+++ b/main/serializers_test.py
@@ -14,6 +14,7 @@ def profile():
     yield ProfileFactory.create(name='Full Name')
 
 
+# pylint: disable=redefined-outer-names,unused-argument
 def test_serialize_maybe_user(mocker, profile):
     """Test that a user is correctly serialized"""
     mocker.patch('main.serializers.get_social_username', return_value='abc')

--- a/main/templatetags_test.py
+++ b/main/templatetags_test.py
@@ -3,10 +3,11 @@ Tests for templatetags in the main Django app
 """
 # NOTE: This file is located here and not in main/templatetags/ because Django attempts to load
 # all files in the 'templatetags' directory as template tags, even '_test.py' files.
-import pytest
 from datetime import datetime
-from pytz import utc
+
 from django.test.client import RequestFactory
+import pytest
+from pytz import utc
 
 from main.utils import webpack_dev_server_url
 from main.templatetags.render_bundle import render_bundle, public_path

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --cov . --cov-report term --cov-report html --ds=main.settings --reuse-db
+addopts = --pylint --cov . --cov-report term --cov-report html --ds=main.settings --reuse-db
 norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg selenium_tests

--- a/smapply/api_test.py
+++ b/smapply/api_test.py
@@ -164,8 +164,8 @@ def test_save_token_update():
     ['get', '/users?testing=true', '{}users?testing=true', {}],
     ['put', 'installments/2', '{}installments/2', {'data': {'transaction': 1}}],
     ['post', 'transactions', '{}transactions', {'data': {'application': 3}}]
-])
-def test_oauth_requests(settings, mocker, method, url, full_url, kwargs):  # pylint: disable=too-many-arguments
+])  # pylint: disable=too-many-arguments
+def test_oauth_requests(settings, mocker, method, url, full_url, kwargs):
     """Test that OAuth2Session calls the correct request method with correct arguments"""
     settings.SMAPPLY_BASE_URL = "http://test.bootcamp.zzz"
 

--- a/smapply/api_test.py
+++ b/smapply/api_test.py
@@ -165,7 +165,7 @@ def test_save_token_update():
     ['put', 'installments/2', '{}installments/2', {'data': {'transaction': 1}}],
     ['post', 'transactions', '{}transactions', {'data': {'application': 3}}]
 ])
-def test_oauth_requests(settings, mocker, method, url, full_url, kwargs):
+def test_oauth_requests(settings, mocker, method, url, full_url, kwargs):  # pylint: disable=too-many-arguments
     """Test that OAuth2Session calls the correct request method with correct arguments"""
     settings.SMAPPLY_BASE_URL = "http://test.bootcamp.zzz"
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
The `--pylint` flag was removed from `pytest.ini` accidentally. This adds it back.

#### How should this be manually tested?
Tests should pass
