### PR TITLE
Make MAILGUN_SENDER_DOMAIN not required

### DIFF
--- a/app.json
+++ b/app.json
@@ -306,7 +306,7 @@
     },
     "MAILGUN_SENDER_DOMAIN": {
       "description": "The domain to send mailgun email through",
-      "required": true
+      "required": false
     },
     "MAILGUN_URL": {
       "description": "The API url for mailfun",

--- a/main/settings.py
+++ b/main/settings.py
@@ -475,7 +475,6 @@ MAILGUN_SENDER_DOMAIN = get_string(
     "MAILGUN_SENDER_DOMAIN",
     None,
     description="The domain to send mailgun email through",
-    required=True,
 )
 
 BOOTCAMP_REPLY_TO_ADDRESS = get_string(


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Makes a setting not required so that it doesn't block deployments of PR builds

#### How should this be manually tested?
N/A
