### PR TITLE
add basic drawer component

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/node_modules/fbjs/.*
+.*/node_modules/immer/.*
 .*.git/.*
 .*/staticfiles/.*
 .*/static/bundles/.*

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-flow": "^7.9.0",
     "@babel/preset-react": "^7.9.4",
     "@babel/register": "^7.9.0",
+    "@reduxjs/toolkit": "^1.3.5",
     "@sentry/browser": "^5.15.5",
     "@trust/webcrypto": "^0.9.2",
     "autoprefixer": "^9.7.6",

--- a/static/js/Router.js
+++ b/static/js/Router.js
@@ -2,10 +2,13 @@
 import React from "react"
 import { Provider } from "react-redux"
 import { Route, Router as ReactRouter } from "react-router-dom"
+import { Provider as ReduxQueryProvider } from "redux-query-react"
 
 import ScrollToTop from "./components/ScrollToTop"
 import App from "./pages/App"
 import withTracker from "./util/withTracker"
+
+import { getQueries } from "./lib/redux_query"
 
 import type { Store } from "redux"
 
@@ -15,18 +18,18 @@ type Props = {
   children: React$Element<*>
 }
 
-export default class Router extends React.Component<Props> {
-  render() {
-    const { children, history, store } = this.props
+export default function Router(props: Props) {
+  const { children, history, store } = props
 
-    return (
-      <Provider store={store}>
+  return (
+    <Provider store={store}>
+      <ReduxQueryProvider queriesSelector={getQueries}>
         <ReactRouter history={history}>
           <ScrollToTop>{children}</ScrollToTop>
         </ReactRouter>
-      </Provider>
-    )
-  }
+      </ReduxQueryProvider>
+    </Provider>
+  )
 }
 
 export const routes = <Route url="/" component={withTracker(App)} />

--- a/static/js/components/Drawer.js
+++ b/static/js/components/Drawer.js
@@ -1,0 +1,36 @@
+// @flow
+import { useCallback } from "react"
+import * as React from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { Drawer as RMWCDrawer, DrawerContent } from "@rmwc/drawer"
+import { Theme } from "@rmwc/theme"
+import { createSelector } from "reselect"
+
+import { toggleDrawer } from "../reducers/drawer"
+
+const drawerSelector = createSelector(
+  state => state.drawer,
+  drawer => drawer
+)
+
+type Props = {
+  children?: React.Node
+}
+
+export default function Drawer(props: Props) {
+  const { children } = props
+  const { showDrawer } = useSelector(drawerSelector)
+
+  const dispatch = useDispatch()
+  const closeDrawer = useCallback(() => {
+    dispatch(toggleDrawer())
+  }, [dispatch])
+
+  return (
+    <Theme>
+      <RMWCDrawer open={showDrawer} onClose={closeDrawer} dir="rtl" modal>
+        <DrawerContent dir="ltr">{children}</DrawerContent>
+      </RMWCDrawer>
+    </Theme>
+  )
+}

--- a/static/js/components/Drawer_test.js
+++ b/static/js/components/Drawer_test.js
@@ -1,0 +1,44 @@
+// @flow
+import React from "react"
+import { assert } from "chai"
+import { Drawer as RMWCDrawer } from "@rmwc/drawer"
+
+import Drawer from "./Drawer"
+
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { toggleDrawer } from "../reducers/drawer"
+
+describe("Drawer", () => {
+  let helper, render
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    render = helper.configureReduxQueryRenderer(Drawer)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render a drawer component with children", async () => {
+    const { wrapper } = await render(
+      {
+        children: <div className="testtesttest">test</div>
+      },
+      [toggleDrawer()]
+    )
+    assert.ok(wrapper.find(RMWCDrawer).exists())
+    assert.equal(wrapper.find(".testtesttest").text(), "test")
+  })
+
+  it("should have the drawer open if action is dispatch", async () => {
+    const { wrapper } = await render({}, [toggleDrawer()])
+    assert.isTrue(wrapper.find(RMWCDrawer).prop("open"))
+  })
+
+  it("should pass down a close function to drawer", async () => {
+    const { wrapper, store } = await render({}, [toggleDrawer()])
+    wrapper.find(RMWCDrawer).prop("onClose")()
+    assert.isFalse(store.getState().drawer.showDrawer)
+  })
+})

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -1,10 +1,10 @@
 // @flow
 import React from "react"
-
+import { useSelector } from "react-redux"
 import { Switch, Route } from "react-router"
 import urljoin from "url-join"
 
-import { routes } from "../lib/urls"
+import { useRequest } from "redux-query-react"
 
 import PrivateRoute from "../components/PrivateRoute"
 import ProfilePages from "./profile/ProfilePages"
@@ -14,74 +14,59 @@ import PaymentPage from "./PaymentPage"
 import EmailConfirmPage from "./settings/EmailConfirmPage"
 import AccountSettingsPage from "./settings/AccountSettingsPage"
 
-import { compose } from "redux"
-import { connect } from "react-redux"
-import { createStructuredSelector } from "reselect"
 import users, { currentUserSelector } from "../lib/queries/users"
-import { connectRequest } from "redux-query-react"
+import { routes } from "../lib/urls"
 
 import type { Match } from "react-router"
-import type { Store } from "redux"
-import type { CurrentUser } from "../flow/authTypes"
 
 type Props = {
-  match: Match,
-  currentUser: ?CurrentUser,
-  store: Store<*, *>
+  match: Match
 }
 
-export class App extends React.Component<Props, void> {
-  render() {
-    const { match, currentUser } = this.props
-    if (!currentUser) {
-      // application is still loading
-      return <div className="app" />
-    }
-    return (
-      <div className="app">
-        <Switch>
-          <Route path={`${match.url}pay/`} component={PaymentPage} />
-          <Route
-            path={urljoin(match.url, String(routes.profile))}
-            component={ProfilePages}
-          />
-          <Route
-            path={urljoin(match.url, String(routes.login))}
-            component={LoginPages}
-          />
-          <Route
-            path={urljoin(match.url, String(routes.register))}
-            component={RegisterPages}
-          />
-          <Route
-            path={urljoin(match.url, String(routes.login))}
-            component={LoginPages}
-          />
-          <Route
-            path={urljoin(match.url, String(routes.register))}
-            component={RegisterPages}
-          />
-          <Route
-            path={urljoin(match.url, String(routes.account.confirmEmail))}
-            component={EmailConfirmPage}
-          />
-          <PrivateRoute
-            path={urljoin(match.url, String(routes.accountSettings))}
-            component={AccountSettingsPage}
-          />
-        </Switch>
-      </div>
-    )
+export default function App(props: Props) {
+  const { match } = props
+
+  const currentUser = useSelector(currentUserSelector)
+  useRequest(users.currentUserQuery())
+
+  if (!currentUser) {
+    // application is still loading
+    return <div className="app" />
   }
+
+  return (
+    <div className="app">
+      <Switch>
+        <Route path={`${match.url}pay/`} component={PaymentPage} />
+        <Route
+          path={urljoin(match.url, String(routes.profile))}
+          component={ProfilePages}
+        />
+        <Route
+          path={urljoin(match.url, String(routes.login))}
+          component={LoginPages}
+        />
+        <Route
+          path={urljoin(match.url, String(routes.register))}
+          component={RegisterPages}
+        />
+        <Route
+          path={urljoin(match.url, String(routes.login))}
+          component={LoginPages}
+        />
+        <Route
+          path={urljoin(match.url, String(routes.register))}
+          component={RegisterPages}
+        />
+        <Route
+          path={urljoin(match.url, String(routes.account.confirmEmail))}
+          component={EmailConfirmPage}
+        />
+        <PrivateRoute
+          path={urljoin(match.url, String(routes.accountSettings))}
+          component={AccountSettingsPage}
+        />
+      </Switch>
+    </div>
+  )
 }
-
-const mapStateToProps = createStructuredSelector({
-  currentUser: currentUserSelector
-})
-
-const mapPropsToConfig = () => [users.currentUserQuery()]
-
-export default compose(
-  connect(mapStateToProps),
-  connectRequest(mapPropsToConfig)
-)(App)

--- a/static/js/reducers/drawer.js
+++ b/static/js/reducers/drawer.js
@@ -1,0 +1,13 @@
+// @Flow
+import { createAction, createReducer } from "@reduxjs/toolkit"
+
+export const toggleDrawer = createAction("TOGGLE_DRAWER")
+
+export const drawer = createReducer(
+  { showDrawer: false },
+  {
+    [toggleDrawer]: state => {
+      state.showDrawer = !state.showDrawer
+    }
+  }
+)

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -4,10 +4,12 @@ import { entitiesReducer, queriesReducer } from "redux-query"
 
 import ui from "./ui"
 import userNotifications from "./notifications"
+import { drawer } from "./drawer"
 
 export default combineReducers<*, *>({
   entities: entitiesReducer,
   queries:  queriesReducer,
   ui,
-  userNotifications
+  userNotifications,
+  drawer
 })

--- a/static/js/util/withTracker.js
+++ b/static/js/util/withTracker.js
@@ -5,7 +5,9 @@
 import React from "react"
 import ga from "react-ga"
 
-const withTracker = (WrappedComponent: Class<React.Component<*, *>>) => {
+const withTracker = (
+  WrappedComponent: Class<React.Component<*, *>> | Function
+) => {
   const debug = SETTINGS.reactGaDebug === "true"
 
   if (SETTINGS.gaTrackingID) {

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -1,0 +1,3 @@
+.mdc-drawer {
+  top: 0;
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -1,4 +1,5 @@
 @import "node_modules/@material/dialog/dist/mdc.dialog";
+@import "node_modules/@material/drawer/dist/mdc.drawer";
 @import "node_modules/bootstrap/scss/bootstrap";
 @import "variables";
 @import "breakpoints";
@@ -13,6 +14,7 @@
 @import "auth";
 @import "user-menu";
 @import "cms/product";
+@import "drawer";
 
 body {
   margin: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,6 +1671,16 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@reduxjs/toolkit@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.3.5.tgz#37c1ab6de9aa66f95bab25a8e9bd9d8ec3b7b80c"
+  integrity sha512-QVqI2T6kwT/3CVdCa6KjUDdEz9YY1eCLQVcRZamiaOAcKI7kkJSh2P0GjaaKXTjIFy0u9sWCXjzifPJNGoXjlw==
+  dependencies:
+    immer "^6.0.1"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@rmwc/avatar@^5.7.2":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/@rmwc/avatar/-/avatar-5.7.2.tgz#e8d4de62bf01bae9b2121d4d41a1caf50892af42"
@@ -6093,6 +6103,11 @@ ignore@^5.1.2:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
+immer@^6.0.1:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-6.0.5.tgz#77187d13b71c6cee40dde3b8e87a50a7a636d630"
+  integrity sha512-Q2wd90qrgFieIpLzAO2q9NLEdmyp/sr76Ml4Vm5peUKgyTa2CQa3ey8zuzwSKOlKH7grCeGBGUcLLVCVW1aguA==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -9167,12 +9182,12 @@ redux-query@^3.3.1:
     invariant "^2.2.0"
     json-stable-stringify "^1.0.0"
 
-redux-thunk@^2.0.1:
+redux-thunk@^2.0.1, redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
-redux@^4.0.4, redux@^4.0.5:
+redux@^4.0.0, redux@^4.0.4, redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==


### PR DESCRIPTION
#### What are the relevant tickets?

part of #483

#### What's this PR do?

this adds a drawer component, ported over mainly from what we do in open-discussions. right now it isn't used for anything, this is just putting the component itself in place for when we need / want it later.

#### How should this be manually tested?

you can check out this branch and revert `d58d99db9fae10e8e044feaaaaa31948ba152513`. then the drawer component will be mounted on the home page, and there will be a sort of crude 'open drawer' button. you should then be able to open the drawer, and clicking outside of it should cause it to close.

other than that I guess the code should look straightforward, and hopefully I didn't break anything.
