### PR TITLE
Fix duplicate color variable

### DIFF
--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -1,6 +1,6 @@
 $static-path: '/static';
 $primary: #a31f34;
-$light-gray: #e6e6e6;
+$medium-soft-light-gray: #e6e6e6;
 $med-gray: #b1b1b1;
 $med-dark-gray: #707070;
 $dark-gray: #202020;
@@ -17,7 +17,6 @@ $link-blue: #126f9a;
 $light-blue: #15729b;
 $cornflower-blue: #579cf9;
 $tab-color: #c2c0bf;
-$primary: #a31f34;
 
 $default-text-color: #fff;
 $default-subtext-color: rgba(255, 255, 255, 0.9);

--- a/static/scss/payment.scss
+++ b/static/scss/payment.scss
@@ -54,7 +54,7 @@
   }
 
   .payment-history-section {
-    background-color: $light-gray;
+    background-color: $medium-soft-light-gray;
     text-align: left;
 
     .payment-history-block {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #504 

#### What's this PR do?
There was a duplicate variable name which overrode a previous variable name. This PR renames one of the variables so the two colors have different names.

#### How should this be manually tested?
If you have payment history, it should look like the correct screenshot in the linked issue.
