### PR TITLE
Redirect user to detail form if no legal address

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,4 @@ repos:
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
-        exclude: .*_test.*|yarn\.lock
+        exclude: .*_test.*|conftest.py|yarn\.lock

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -15,7 +15,6 @@ from applications.factories import (
 from ecommerce.factories import OrderFactory
 from ecommerce.models import Order
 from klasses.factories import BootcampRunFactory
-from profiles.constants import FEMALE
 from profiles.factories import ProfileFactory, UserFactory
 from main.utils import now_in_utc
 
@@ -37,7 +36,7 @@ def test_derive_application_state():
     )
     assert derive_application_state(app) == AppStates.AWAITING_PROFILE_COMPLETION.value
 
-    ProfileFactory.create(user=app.user, company="MIT", gender=FEMALE, birth_year=2000, job_title="Engineer")
+    ProfileFactory.create(user=app.user)
     app.refresh_from_db()
     assert derive_application_state(app) == AppStates.AWAITING_RESUME.value
 

--- a/authentication/pipeline/compliance.py
+++ b/authentication/pipeline/compliance.py
@@ -27,6 +27,9 @@ def verify_exports_compliance(
         backend (social_core.backends.base.BaseAuth): the backend being used to authenticate
         user (User): the current user
     """
+    if not strategy.is_api_enabled():
+        return {}
+
     if not api.is_exports_verification_enabled():
         log.warning("Export compliance checks are disabled")
         return {}

--- a/authentication/pipeline/compliance_test.py
+++ b/authentication/pipeline/compliance_test.py
@@ -13,12 +13,29 @@ from compliance.factories import ExportsInquiryLogFactory
 pytestmark = pytest.mark.django_db
 
 
-def test_verify_exports_compliance_disabled(mocker):
+@pytest.fixture(autouse=True)
+def social_auth_settings(settings):
+    """ Enable social auth API by default """
+    settings.FEATURES["SOCIAL_AUTH_API"] = True
+
+
+def test_verify_exports_compliance_disabled(mocker, mock_create_user_strategy):
     """Assert that nothing is done when the api is disabled"""
     mock_api = mocker.patch("authentication.pipeline.compliance.api")
     mock_api.is_exports_verification_enabled.return_value = False
 
-    assert compliance.verify_exports_compliance(None, None) == {}
+    assert compliance.verify_exports_compliance(mock_create_user_strategy, None) == {}
+    mock_api.is_exports_verification_enabled.assert_called_once()
+
+
+def test_verify_api_disabled_no_compliance_check(mocker, mock_create_user_strategy):
+    """Assert that nothing is done when the social auth api is disabled"""
+    mock_create_user_strategy.is_api_enabled.return_value = False
+    mock_api = mocker.patch("authentication.pipeline.compliance.api")
+    mock_api.is_exports_verification_enabled.return_value = False
+
+    assert compliance.verify_exports_compliance(mock_create_user_strategy, None) == {}
+    mock_api.is_exports_verification_enabled.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -31,7 +48,7 @@ def test_verify_exports_compliance_disabled(mocker):
     ],
 )
 def test_verify_exports_compliance_user_active(
-    mailoutbox, mocker, user, is_active, inquiry_exists, should_verify
+    mailoutbox, mocker, mock_create_user_strategy, user, is_active, inquiry_exists, should_verify
 ):  # pylint: disable=too-many-arguments
     """Assert that the user is verified only if they already haven't been"""
     user.is_active = is_active
@@ -43,39 +60,39 @@ def test_verify_exports_compliance_user_active(
         is_denied=False, is_unknown=False
     )
 
-    assert compliance.verify_exports_compliance(None, None, user=user) == {}
+    assert compliance.verify_exports_compliance(mock_create_user_strategy, None, user=user) == {}
 
     if should_verify:
         mock_api.verify_user_with_exports.assert_called_once_with(user)
     assert len(mailoutbox) == 0
 
 
-def test_verify_exports_compliance_no_record(mocker, user):
+def test_verify_exports_compliance_no_record(mocker, mock_create_user_strategy, user):
     """Assert that an error to try again later is raised if no ExportsInquiryLog is created"""
 
     mock_api = mocker.patch("authentication.pipeline.compliance.api")
     mock_api.verify_user_with_exports.return_value = None
 
     with pytest.raises(UserTryAgainLaterException):
-        compliance.verify_exports_compliance(None, None, user=user)
+        compliance.verify_exports_compliance(mock_create_user_strategy, None, user=user)
 
     mock_api.verify_user_with_exports.assert_called_once_with(user)
 
 
-def test_verify_exports_compliance_api_raises_exception(mocker, user):
+def test_verify_exports_compliance_api_raises_exception(mocker, mock_create_user_strategy, user):
     """Assert that an error to try again later is raised if the export api raises an exception"""
 
     mock_api = mocker.patch("authentication.pipeline.compliance.api")
     mock_api.verify_user_with_exports.side_effect = Exception("error")
 
     with pytest.raises(UserTryAgainLaterException):
-        compliance.verify_exports_compliance(None, None, user=user)
+        compliance.verify_exports_compliance(mock_create_user_strategy, None, user=user)
 
     mock_api.verify_user_with_exports.assert_called_once_with(user)
 
 
 @pytest.mark.parametrize("email_fails", [True, False])
-def test_verify_exports_compliance_denied(mailoutbox, mocker, user, email_fails):
+def test_verify_exports_compliance_denied(mailoutbox, mocker, mock_create_user_strategy, user, email_fails):
     """Assert that a UserExportBlockedException is raised if the inquiry result is denied"""
     reason_code = 100
     mock_api = mocker.patch("authentication.pipeline.compliance.api")
@@ -91,7 +108,7 @@ def test_verify_exports_compliance_denied(mailoutbox, mocker, user, email_fails)
         )
 
     with pytest.raises(UserExportBlockedException) as exc:
-        compliance.verify_exports_compliance(None, None, user=user)
+        compliance.verify_exports_compliance(mock_create_user_strategy, None, user=user)
 
     assert exc.value.reason_code == reason_code
 
@@ -99,7 +116,7 @@ def test_verify_exports_compliance_denied(mailoutbox, mocker, user, email_fails)
     assert len(mailoutbox) == (0 if email_fails else 1)
 
 
-def test_verify_exports_compliance_unknown(mailoutbox, mocker, user):
+def test_verify_exports_compliance_unknown(mailoutbox, mocker, mock_create_user_strategy, user):
     """Assert that a UserExportBlockedException is raised if the inquiry result is unknown"""
     mock_api = mocker.patch("authentication.pipeline.compliance.api")
     mock_api.verify_user_with_exports.return_value = mocker.Mock(
@@ -107,7 +124,7 @@ def test_verify_exports_compliance_unknown(mailoutbox, mocker, user):
     )
 
     with pytest.raises(AuthException):
-        compliance.verify_exports_compliance(None, None, user=user)
+        compliance.verify_exports_compliance(mock_create_user_strategy, None, user=user)
 
     mock_api.verify_user_with_exports.assert_called_once_with(user)
     assert len(mailoutbox) == 0

--- a/authentication/pipeline/conftest.py
+++ b/authentication/pipeline/conftest.py
@@ -1,0 +1,24 @@
+"""
+Fixtures for pipeline tests
+"""
+import pytest
+
+@pytest.fixture
+def mock_create_user_strategy(mocker):
+    """Fixture that returns a valid strategy for create_user_via_email"""
+    strategy = mocker.Mock()
+    strategy.request_data.return_value = {
+        "profile": {"name": "Jane Doe"},
+        "password": "password1",
+        "legal_address": {
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "street_address_1": "1 Main st",
+            "city": "Boston",
+            "state_or_territory": "US-MA",
+            "country": "US",
+            "postal_code": "02101",
+        },
+    }
+    strategy.is_api_enabled = mocker.Mock(return_value=True)
+    return strategy

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -114,12 +114,12 @@ def create_user_via_email(
         )
 
     data["email"] = kwargs.get("email", kwargs.get("details", {}).get("email"))
-    username = usernameify(data["profile"]["name"], email=data["email"])
-    data["username"] = username
 
     is_new = user is None
 
     if is_new:
+        username = usernameify(data["profile"]["name"], email=data["email"])
+        data["username"] = username
         serializer = UserSerializer(data=data)
     else:
         serializer = UserSerializer(user, data=data)

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -89,7 +89,7 @@ def create_user_via_email(
     if not strategy.is_api_enabled():
         return {}
 
-    # if the user has data for all the fields this step
+    # if the user has data for all the fields, skip this step
     if (
         user and
         user.password and

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -86,7 +86,16 @@ def create_user_via_email(
     Raises:
         RequirePasswordAndPersonalInfoException: if the user hasn't set password or name
     """
-    if user or not strategy.is_api_enabled():
+    if not strategy.is_api_enabled():
+        return {}
+
+    # if the user has data for all the fields this step
+    if (
+        user and
+        user.password and
+        user.profile.name and
+        user.legal_address.is_complete
+    ):
         return {}
 
     if not strategy.is_api_request():
@@ -107,23 +116,31 @@ def create_user_via_email(
     data["email"] = kwargs.get("email", kwargs.get("details", {}).get("email"))
     username = usernameify(data["profile"]["name"], email=data["email"])
     data["username"] = username
-    serializer = UserSerializer(data=data)
+
+    is_new = user is None
+
+    if is_new:
+        serializer = UserSerializer(data=data)
+    else:
+        serializer = UserSerializer(user, data=data)
 
     if not serializer.is_valid():
         raise RequirePasswordAndPersonalInfoException(
             backend, current_partial, errors=serializer.errors
         )
 
-    try:
-        created_user = create_user_with_generated_username(serializer, username)
-        if created_user is None:
-            raise IntegrityError(
-                "Failed to create User with generated username ({})".format(username)
-            )
-    except Exception as exc:
-        raise UserCreationFailedException(backend, current_partial) from exc
-
-    return {"is_new": True, "user": created_user, "username": created_user.username}
+    if is_new:
+        try:
+            user = create_user_with_generated_username(serializer, username)
+            if user is None:
+                raise IntegrityError(
+                    "Failed to create User with generated username ({})".format(username)
+                )
+        except Exception as exc:
+            raise UserCreationFailedException(backend, current_partial) from exc
+    else:
+        user = serializer.save()
+    return {"is_new": is_new, "user": user, "username": user.username}
 
 
 @partial

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -238,7 +238,7 @@ def activate_user(
         backend (social_core.backends.base.BaseAuth): the backend being used to authenticate
         user (User): the current user
     """
-    if user.is_active:
+    if user.is_active or not strategy.is_api_enabled():
         return {}
 
     export_inquiry = compliance_api.get_latest_exports_inquiry(user)

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -257,10 +257,10 @@ def test_create_user_via_email(mocker, mock_email_backend, mock_create_user_stra
         "is_new": is_new,
     }
     request_data = mock_create_user_strategy.request_data()
-    patched_usernameify.assert_called_once_with(
-        request_data["profile"]["name"], email=user.email
-    )
     if is_new:
+        patched_usernameify.assert_called_once_with(
+            request_data["profile"]["name"], email=user.email
+        )
         patched_create_user.assert_called_once()
         # Confirm that a UserSerializer object was passed to create_user_with_generated_username, and
         # that it was instantiated with the data we expect.
@@ -271,6 +271,7 @@ def test_create_user_via_email(mocker, mock_email_backend, mock_create_user_stra
         assert serializer.initial_data["password"] == request_data["password"]
     else:
         patched_create_user.assert_not_called()
+        patched_usernameify.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/profiles/constants.py
+++ b/profiles/constants.py
@@ -1,4 +1,7 @@
 """User constants"""
+import pycountry
+
+
 USERNAME_MAX_LEN = 30
 
 
@@ -48,4 +51,9 @@ HIGHEST_EDUCATION_CHOICES = (
     ("Elementary/primary school", "Elementary/primary school"),
     ("No formal education", "No formal education"),
     ("Other education", "Other education"),
+)
+
+COUNTRIES_REQUIRING_POSTAL_CODE = (
+    pycountry.countries.get(alpha_2='US'),
+    pycountry.countries.get(alpha_2='CA')
 )

--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -58,6 +58,9 @@ class LegalAddressFactory(DjangoModelFactory):
     class Meta:
         model = LegalAddress
 
+    class Params:
+        incomplete = Trait(first_name="", country="", city="")
+
 
 class ProfileFactory(DjangoModelFactory):
     """Factory for Profile"""

--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -10,6 +10,9 @@ from social_django.models import UserSocialAuth
 
 from profiles.constants import (
     GENDER_CHOICES,
+    COMPANY_SIZE_CHOICES,
+    YRS_EXPERIENCE_CHOICES,
+    HIGHEST_EDUCATION_CHOICES,
 )
 from profiles.models import Profile, LegalAddress
 
@@ -66,6 +69,12 @@ class ProfileFactory(DjangoModelFactory):
     birth_year = Faker("year")
     company = Faker("company")
     job_title = Faker("word")
+    industry = Faker("word")
+    job_function = Faker("word")
+
+    company_size = FuzzyChoice(choices=[size[0] for size in COMPANY_SIZE_CHOICES if size[0]])
+    years_experience = FuzzyChoice(choices=[exp[0] for exp in YRS_EXPERIENCE_CHOICES if exp[0]])
+    highest_education = FuzzyChoice(choices=[ed[0] for ed in HIGHEST_EDUCATION_CHOICES if ed[0]])
 
     class Meta:
         model = Profile

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -19,6 +19,7 @@ from profiles.constants import (
     COMPANY_SIZE_CHOICES,
     YRS_EXPERIENCE_CHOICES,
     HIGHEST_EDUCATION_CHOICES,
+    COUNTRIES_REQUIRING_POSTAL_CODE,
 )
 
 
@@ -132,6 +133,22 @@ class LegalAddress(TimestampedModel):
             if line
         ]
 
+    @property
+    def is_complete(self):
+        """Returns True if the profile is complete"""
+        country = pycountry.countries.get(alpha_2=self.country)
+        return all(
+            (
+                self.first_name,
+                self.last_name,
+                self.street_address,
+                self.city,
+                self.country,
+                self.state_or_territory or country not in COUNTRIES_REQUIRING_POSTAL_CODE,
+                self.postal_code or country not in COUNTRIES_REQUIRING_POSTAL_CODE,
+            )
+        )
+
 
 class Profile(TimestampedModel):
     """Used to store information about the User"""
@@ -168,7 +185,19 @@ class Profile(TimestampedModel):
     @property
     def is_complete(self):
         """Returns True if the profile is complete"""
-        return all((self.gender, self.birth_year, self.company, self.job_title))
+        return all(
+            (
+                self.gender,
+                self.birth_year,
+                self.company,
+                self.job_title,
+                self.industry,
+                self.job_function,
+                self.company_size,
+                self.years_experience,
+                self.highest_education,
+            )
+        )
 
     def __str__(self):
         return "Profile for user {}".format(self.user)

--- a/profiles/models_test.py
+++ b/profiles/models_test.py
@@ -1,0 +1,36 @@
+"""
+Tests for profiles.models
+"""
+from builtins import setattr
+
+import pytest
+
+from profiles.factories import LegalAddressFactory, ProfileFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize("empty_field", [
+    "first_name", "last_name", "street_address_1", "city", "country", "state_or_territory", None
+])
+def test_legal_address_is_complete(empty_field):
+    """Test that LegalAddress.is_complete returns expected result"""
+    address = LegalAddressFactory.create(country="US")
+    if empty_field:
+        setattr(address, empty_field, '')
+        assert address.is_complete is False
+    else:
+        assert address.is_complete is True
+
+
+@pytest.mark.parametrize("empty_field", [
+    "birth_year", "gender", "job_title", "company", "industry", "job_function", "company_size", "years_experience", "highest_education", None
+])
+def test_profile_is_complete(empty_field):
+    """Test that Profile.is_complete returns expected result"""
+    profile = ProfileFactory.create()
+    if empty_field:
+        setattr(profile, empty_field, '')
+        assert profile.is_complete is False
+    else:
+        assert profile.is_complete is True


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Prevents OFAC errors when logging in via edx under various conditions

#### How should this be manually tested?
Copy over the CYBERSOURCE_ and MAILGUN_ env values from CI to enable compliance checks and verification emails.

Go through the following steps with `FEATURE_SOCIAL_AUTH_API=False`:
- Log in via edx as an existing user who already has a bootcamp account
- Log in via edx as a user who exists in edx but not bootcamp
- Log in via edx as a new user who does not exist on edx or bootcamp

You should be redirected to `./pay` after login for all the above.  

Repeat the above steps with `FEATURE_SOCIAL_AUTH_API=True`:
- You should be redirected to `./create-account/details` for all the above
- Complete the registration forms and then you should be redirected to `./pay`

Log out.

Go to `../create-account` and submit the form, wait for the verification email, click the link, step through the registration forms.  You should be redirected to `../pay` at the end.
