### PR TITLE
Fix support links

### DIFF
--- a/app.json
+++ b/app.json
@@ -124,6 +124,10 @@
       "description": "Email address listed for customer support",
       "required": false
     },
+    "BOOTCAMP_SUPPORT_URL": {
+      "description": "URL for customer support",
+      "required": false
+    },
     "BOOTCAMP_USE_S3": {
       "description": "Use S3 for storage backend (required on Heroku)",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -184,6 +184,11 @@ BOOTCAMP_ECOMMERCE_BASE_URL = get_string(
     required=True,
 )
 SITE_BASE_URL = BOOTCAMP_ECOMMERCE_BASE_URL
+SUPPORT_URL = get_string(
+    "BOOTCAMP_SUPPORT_URL", "https://mitbootcamps.zendesk.com/hc/en-us/requests/new",
+    description="URL for customer support",
+    required=False
+)
 
 EDXORG_BASE_URL = get_string(
     "EDXORG_BASE_URL",

--- a/main/templates/404.html
+++ b/main/templates/404.html
@@ -12,7 +12,7 @@
         <h1>Page not found</h1>
         <p class="desc">
           Whatever you were looking for isn't here. <br/>
-          Please <a href="mailto:{{ support_email }}">contact us</a> if you need support.
+          Please <a href="{{ support_url }}" target="_blank" rel="noopener noreferrer">contact us</a> if you need support.
         </p>
       </div>
     </div>

--- a/main/templates/500.html
+++ b/main/templates/500.html
@@ -10,7 +10,7 @@
     <div class="photo-bg photo-2 top-content-container">
       <div id="error" class="text-info-page">
         <h1>There has been an error (500).</h1>
-        <p class="desc">Please <a href="mailto:{{ support_email }}">contact us</a> if this continues to happen</p>
+        <p class="desc">Please <a href="{{ support_url }}" target="_blank" rel="noopener noreferrer">contact us</a> if this continues to happen</p>
       </div>
     </div>
   </div>

--- a/main/views.py
+++ b/main/views.py
@@ -26,6 +26,7 @@ def _serialize_js_settings(request):  # pylint: disable=missing-docstring
             "help_widget_key": settings.ZENDESK_CONFIG.get("HELP_WIDGET_KEY"),
         },
         "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
+        "support_url": settings.SUPPORT_URL,
     }
 
 
@@ -77,7 +78,7 @@ def standard_error_page(request, status_code, template_filename):
         template_filename,
         context={
             "js_settings_json": json.dumps(_serialize_js_settings(request)),
-            "support_email": settings.EMAIL_SUPPORT,
+            "support_url": settings.SUPPORT_URL,
             "authenticated": authenticated,
         }
     )

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -29,6 +29,7 @@ class TestViews(TestCase):
         environment = FuzzyText().fuzz()
         version = '0.0.1'
         recaptcha_key = "abc"
+        support_url = "http://test.edu/form"
         with self.settings(
             WEBPACK_DEV_SERVER_HOST=host,
             VERSION=version,
@@ -37,7 +38,8 @@ class TestViews(TestCase):
                 "HELP_WIDGET_ENABLED": False,
                 "HELP_WIDGET_KEY": "fake_key",
             },
-            RECAPTCHA_SITE_KEY=recaptcha_key
+            RECAPTCHA_SITE_KEY=recaptcha_key,
+            SUPPORT_URL=support_url
         ), patch('main.templatetags.render_bundle._get_bundle') as get_bundle:
             resp = self.client.get('/')
         self.assertContains(
@@ -60,8 +62,8 @@ class TestViews(TestCase):
             'public_path': '/static/bundles/',
             'user': None,
             'zendesk_config': {"help_widget_enabled": False, "help_widget_key": "fake_key"},
-
             "recaptchaKey": recaptcha_key,
+            "support_url": support_url,
         }
 
     def test_index_logged_in(self):
@@ -90,6 +92,7 @@ class TestViews(TestCase):
         environment = FuzzyText().fuzz()
         version = '0.0.1'
         recaptcha_key = "abc"
+        support_url = "http://test.edu/form"
         with self.settings(
             WEBPACK_DEV_SERVER_HOST=host,
             VERSION=version,
@@ -98,7 +101,8 @@ class TestViews(TestCase):
                 "HELP_WIDGET_ENABLED": False,
                 "HELP_WIDGET_KEY": "fake_key",
             },
-            RECAPTCHA_SITE_KEY=recaptcha_key
+            RECAPTCHA_SITE_KEY=recaptcha_key,
+            SUPPORT_URL=support_url
         ), patch('main.templatetags.render_bundle._get_bundle') as get_bundle:
             resp = self.client.get(reverse('pay'))
 
@@ -122,4 +126,5 @@ class TestViews(TestCase):
             },
             "zendesk_config": {"help_widget_enabled": False, "help_widget_key": "fake_key"},
             "recaptchaKey": recaptcha_key,
+            "support_url": support_url,
         }

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -7,7 +7,7 @@ declare var SETTINGS: {
   gaTrackingID: string,
   reactGaDebug: boolean,
   recaptchaKey: ?string,
-  support_email: string,
+  support_url: string,
   zendesk_config: {
     help_widget_enabled: boolean,
     help_widget_key: ?string

--- a/static/js/pages/login/LoginForgotPasswordPage.js
+++ b/static/js/pages/login/LoginForgotPasswordPage.js
@@ -107,8 +107,8 @@ export class LoginForgotPasswordPage extends React.Component<Props, State> {
             </ol>
             <div className="contact-support">
               <b>Still no password reset email? </b>
-              Please contact our
-              <a href={`mailto:${SETTINGS.support_email}`}>
+              Please contact our{" "}
+              <a href={SETTINGS.support_url} target="_blank" rel="noopener noreferrer">
                 Customer Support Center.
               </a>
             </div>

--- a/static/js/pages/login/LoginForgotPasswordPage.js
+++ b/static/js/pages/login/LoginForgotPasswordPage.js
@@ -108,7 +108,11 @@ export class LoginForgotPasswordPage extends React.Component<Props, State> {
             <div className="contact-support">
               <b>Still no password reset email? </b>
               Please contact our{" "}
-              <a href={SETTINGS.support_url} target="_blank" rel="noopener noreferrer">
+              <a
+                href={SETTINGS.support_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Customer Support Center.
               </a>
             </div>

--- a/static/js/pages/login/LoginForgotPasswordPage_test.js
+++ b/static/js/pages/login/LoginForgotPasswordPage_test.js
@@ -11,11 +11,11 @@ import { routes } from "../../lib/urls"
 
 describe("LoginForgotPasswordPage", () => {
   const email = "email@example.com"
-  const supportEmail = "email@localhost"
+  const supportUrl = "https://test.edu/form"
   let helper, renderPage, setSubmittingStub
 
   beforeEach(() => {
-    SETTINGS.support_email = supportEmail
+    SETTINGS.support_url = supportUrl
     helper = new IntegrationTestHelper()
 
     setSubmittingStub = helper.sandbox.stub()
@@ -81,10 +81,7 @@ describe("LoginForgotPasswordPage", () => {
     const { inner } = await renderPage()
     const onSubmit = inner.find("EmailForm").prop("onSubmit")
     await onSubmit({ email }, { setSubmitting: setSubmittingStub })
-    assert.equal(
-      inner.find(".contact-support > a").prop("href"),
-      `mailto:${supportEmail}`
-    )
+    assert.equal(inner.find(".contact-support > a").prop("href"), supportUrl)
   })
 
   it("contains the reset your password link", async () => {

--- a/static/js/pages/register/RegisterConfirmSentPage.js
+++ b/static/js/pages/register/RegisterConfirmSentPage.js
@@ -58,7 +58,7 @@ export class RegisterConfirmSentPage extends React.Component<Props> {
               Still no verification email?
             </span>{" "}
             Please contact our
-            <a href={`mailto:${SETTINGS.support_email}`}>
+            <a href={SETTINGS.support_url} target="_blank" rel="noopener noreferrer">
               {` Customer Support Center`}.
             </a>
           </div>

--- a/static/js/pages/register/RegisterConfirmSentPage.js
+++ b/static/js/pages/register/RegisterConfirmSentPage.js
@@ -58,7 +58,11 @@ export class RegisterConfirmSentPage extends React.Component<Props> {
               Still no verification email?
             </span>{" "}
             Please contact our
-            <a href={SETTINGS.support_url} target="_blank" rel="noopener noreferrer">
+            <a
+              href={SETTINGS.support_url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {` Customer Support Center`}.
             </a>
           </div>

--- a/static/js/pages/register/RegisterConfirmSentPage_test.js
+++ b/static/js/pages/register/RegisterConfirmSentPage_test.js
@@ -11,12 +11,12 @@ import { routes } from "../../lib/urls"
 
 describe("RegisterConfirmSentPage", () => {
   const userEmail = "test@example.com"
-  const supportEmail = "email@localhost"
+  const supportUrl = "https://test.edu/form"
 
   let helper, renderPage
 
   beforeEach(() => {
-    SETTINGS.support_email = supportEmail
+    SETTINGS.support_url = supportUrl
 
     helper = new IntegrationTestHelper()
 
@@ -38,10 +38,7 @@ describe("RegisterConfirmSentPage", () => {
 
   it("displays a link to email support", async () => {
     const { inner } = await renderPage()
-    assert.equal(
-      inner.find(".contact-support > a").prop("href"),
-      `mailto:${supportEmail}`
-    )
+    assert.equal(inner.find(".contact-support > a").prop("href"), supportUrl)
   })
 
   it("displays a link to create account page", async () => {

--- a/static/js/pages/register/RegisterDeniedPage.js
+++ b/static/js/pages/register/RegisterDeniedPage.js
@@ -31,7 +31,11 @@ export class RegisterDeniedPage extends React.Component<Props> {
             {error ? <p className="error-detail">{error}</p> : null}
             <p>
               Please contact us at our{" "}
-              <a href={SETTINGS.support_url} target="_blank" rel="noopener noreferrer">
+              <a
+                href={SETTINGS.support_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Customer Support Center
               </a>
             </p>

--- a/static/js/pages/register/RegisterDeniedPage.js
+++ b/static/js/pages/register/RegisterDeniedPage.js
@@ -30,9 +30,9 @@ export class RegisterDeniedPage extends React.Component<Props> {
             <p>Sorry, we cannot create an account for you at this time.</p>
             {error ? <p className="error-detail">{error}</p> : null}
             <p>
-              Please contact us at{" "}
-              <a href={`mailto:${SETTINGS.support_email}`}>
-                {SETTINGS.support_email}
+              Please contact us at our{" "}
+              <a href={SETTINGS.support_url} target="_blank" rel="noopener noreferrer">
+                Customer Support Center
               </a>
             </p>
           </div>

--- a/static/js/pages/register/RegisterDeniedPage_test.js
+++ b/static/js/pages/register/RegisterDeniedPage_test.js
@@ -10,12 +10,12 @@ import { isIf, shouldIf } from "../../lib/test_utils"
 
 describe("RegisterDeniedPage", () => {
   const error = "errorTestValue"
-  const email = "email@localhost"
+  const url = "https://test.edu/form"
 
   let helper, renderPage
 
   beforeEach(() => {
-    SETTINGS.support_email = email
+    SETTINGS.support_url = url
 
     helper = new IntegrationTestHelper()
 
@@ -38,7 +38,7 @@ describe("RegisterDeniedPage", () => {
   it("displays a link to email support", async () => {
     const { inner } = await renderPage()
 
-    assert.equal(inner.find("a").prop("href"), `mailto:${email}`)
+    assert.equal(inner.find("a").prop("href"), url)
   })
 
   //

--- a/static/js/pages/register/RegisterErrorPage.js
+++ b/static/js/pages/register/RegisterErrorPage.js
@@ -17,7 +17,11 @@ const RegisterErrorPage = () => (
         <p>Sorry, we cannot create an account for you at this time.</p>
         <p>
           Please try again later or contact us at our{" "}
-          <a href={SETTINGS.support_url} target="_blank" rel="noopener noreferrer">
+          <a
+            href={SETTINGS.support_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Customer Support Center
           </a>
         </p>

--- a/static/js/pages/register/RegisterErrorPage.js
+++ b/static/js/pages/register/RegisterErrorPage.js
@@ -16,9 +16,9 @@ const RegisterErrorPage = () => (
         <div className="register-error-icon" />
         <p>Sorry, we cannot create an account for you at this time.</p>
         <p>
-          Please try again later or contact us at{" "}
-          <a href={`mailto:${SETTINGS.support_email}`}>
-            {SETTINGS.support_email}
+          Please try again later or contact us at our{" "}
+          <a href={SETTINGS.support_url} target="_blank" rel="noopener noreferrer">
+            Customer Support Center
           </a>
         </p>
       </div>

--- a/static/js/pages/register/RegisterErrorPage_test.js
+++ b/static/js/pages/register/RegisterErrorPage_test.js
@@ -10,10 +10,10 @@ describe("RegisterErrorPage", () => {
   const renderPage = () => shallow(<RegisterErrorPage />)
 
   it("displays a link to email support", async () => {
-    const email = "email@localhost"
-    SETTINGS.support_email = email
+    const url = "https://test.edu/form"
+    SETTINGS.support_url = url
     const wrapper = await renderPage()
 
-    assert.equal(wrapper.find("a").prop("href"), `mailto:${email}`)
+    assert.equal(wrapper.find("a").prop("href"), url)
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #510 

#### What's this PR do?
Replaces support email links with zendesk links

#### How should this be manually tested?
- Go to `../create-account` and submit an email.  Click the 'Customer Support Center' link on the following page, it should open up the zendesk support contact page.
- Go to `../forgot-password` and repeat the above.
- set `DEBUG=False` and go to a nonexistent URL, the 404 message should have a link to the zendesk page.
