### PR TITLE
Fix registration profile form validation

### DIFF
--- a/static/js/components/forms/EditProfileForm.js
+++ b/static/js/components/forms/EditProfileForm.js
@@ -26,6 +26,7 @@ const getInitialValues = (user: User) => ({
     birth_year:        pathOr("", ["birth_year"], user.profile),
     job_function:      pathOr("", ["job_function"], user.profile),
     company_size:      pathOr("", ["company_size"], user.profile),
+    industry:          pathOr("", ["industry"], user.profile),
     years_experience:  pathOr("", ["years_experience"], user.profile),
     highest_education: pathOr("", ["highest_education"], user.profile)
   }

--- a/static/js/components/forms/EditProfileForm_test.js
+++ b/static/js/components/forms/EditProfileForm_test.js
@@ -102,7 +102,25 @@ describe("EditProfileForm", () => {
     ["profile.gender", "", "Gender is a required field"],
     ["profile.gender", "f", ""],
     ["profile.birth_year", "", "Birth Year is a required field"],
-    ["profile.birth_year", "2000", ""]
+    ["profile.birth_year", "2000", ""],
+    ["profile.industry", "Education", ""],
+    ["profile.industry", "", "Industry is a required field"],
+    ["profile.company_size", "9999", ""],
+    ["profile.company_size", "", "Company Size is a required field"],
+    ["profile.job_function", "Administrative", ""],
+    ["profile.job_function", "", "Job Function is a required field"],
+    ["profile.years_experience", "Administrative", ""],
+    [
+      "profile.years_experience",
+      "",
+      "Years of Work Experience is a required field"
+    ],
+    ["profile.highest_education", "Masters Degree", ""],
+    [
+      "profile.highest_education",
+      "",
+      "Highest Level of Education is a required field"
+    ]
   ].forEach(([name, value, errorMessage]) => {
     it(`validates the field name=${name}, value=${JSON.stringify(
       value
@@ -130,6 +148,7 @@ describe("EditProfileForm", () => {
         "job_function",
         "company_size",
         "years_experience",
+        "industry",
         "highest_education"
       ]
       for (const key of keys) {

--- a/static/js/components/forms/RegisterExtraDetailsForm.js
+++ b/static/js/components/forms/RegisterExtraDetailsForm.js
@@ -11,10 +11,15 @@ type Props = {
 
 const INITIAL_VALUES = {
   profile: {
-    birth_year: "",
-    gender:     "",
-    company:    "",
-    job_title:  ""
+    birth_year:        "",
+    gender:            "",
+    company:           "",
+    job_title:         "",
+    job_function:      "",
+    industry:          "",
+    company_size:      "",
+    years_experience:  "",
+    highest_education: ""
   }
 }
 

--- a/static/js/factories/user.js
+++ b/static/js/factories/user.js
@@ -40,9 +40,9 @@ export const makeUser = (username: ?string): LoggedInUser => ({
     birth_year:        1980,
     company:           casual.company_name,
     company_size:      99,
-    industry:          "",
+    industry:          "Education",
     job_title:         casual.word,
-    job_function:      "",
+    job_function:      "Administrative",
     years_experience:  20,
     highest_education: "Doctorate"
   },

--- a/static/js/pages/profile/EditProfilePage.js
+++ b/static/js/pages/profile/EditProfilePage.js
@@ -52,15 +52,7 @@ export class EditProfilePage extends React.Component<Props> {
       ...(profileData.profile ?
         {
           profile: {
-            ...profileData.profile,
-            company_size:
-                profileData.profile.company_size === "" ?
-                  null :
-                  profileData.profile.company_size,
-            years_experience:
-                profileData.profile.years_experience === "" ?
-                  null :
-                  profileData.profile.years_experience
+            ...profileData.profile
           }
         } :
         {})

--- a/static/js/pages/profile/EditProfilePage_test.js
+++ b/static/js/pages/profile/EditProfilePage_test.js
@@ -54,22 +54,10 @@ describe("EditProfilePage", () => {
   })
 
   //
-  ;[
-    [true, true],
-    [true, false],
-    [false, true],
-    [false, false]
-  ].forEach(([hasError, hasEmptyFields]) => {
+  ;[true, false].forEach(hasError => {
     it(`submits the updated profile ${
-      hasEmptyFields ? "with some empty fields " : ""
-    }${hasError ? "and received an error" : "successfully"}`, async () => {
-      // $FlowFixMe
-      user.profile.company_size = hasEmptyFields ? "" : 50
-      // $FlowFixMe
-      user.profile.years_experience = hasEmptyFields ? "" : 5
-      // $FlowFixMe
-      user.profile.highest_education = hasEmptyFields ? "" : "Doctorate"
-
+      hasError ? "and received an error" : "successfully"
+    }`, async () => {
       const { wrapper } = await renderPage()
       const setSubmitting = helper.sandbox.stub()
       const setErrors = helper.sandbox.stub()
@@ -93,14 +81,6 @@ describe("EditProfilePage", () => {
         profile: {
           ...user.profile
         }
-      }
-      if (hasEmptyFields) {
-        // $FlowFixMe
-        expectedPayload.profile.company_size = null
-        // $FlowFixMe
-        expectedPayload.profile.years_experience = null
-        // $FlowFixMe
-        expectedPayload.profile.highest_education = ""
       }
       sinon.assert.calledWith(
         helper.handleRequestStub,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #516 

#### What's this PR do?
Adds initial values for new required fields on the RegisterExtraDetails form so that error messages will appear properly.  Adjusts some tests to account for all fields now being required.

#### How should this be manually tested?
- Set `FEATURE_SOCIAL_AUTH_API=True`, and copy over `MAILGUN` settings from CI.
- Go to `../create-account`, click on the confirmation email link, fill out and submit step 1 of the registration form.  On step 2, click submit with all fields blank.  Error messages should appear for each field.  Enter values for all fields and submit, you should end up on the payment page.
