### PR TITLE
Added endpoint for fetching list of user applications

### DIFF
--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -45,7 +45,6 @@ class SubmissionSerializer(serializers.ModelSerializer):
 
 class BootcampApplicationDetailSerializer(serializers.ModelSerializer):
     """Detailed BootcampApplication serializer"""
-    bootcamp_run = BootcampRunSerializer(read_only=True)
     resume_filename = serializers.SerializerMethodField()
     payment_deadline = serializers.SerializerMethodField()
     run_application_steps = serializers.SerializerMethodField()
@@ -75,8 +74,6 @@ class BootcampApplicationDetailSerializer(serializers.ModelSerializer):
         model = models.BootcampApplication
         fields = [
             "id",
-            "user_id",
-            "bootcamp_run",
             "state",
             "resume_filename",
             "resume_upload_date",
@@ -85,4 +82,18 @@ class BootcampApplicationDetailSerializer(serializers.ModelSerializer):
             "run_application_steps",
             "submissions",
             "orders",
+        ]
+
+
+class BootcampApplicationListSerializer(serializers.ModelSerializer):
+    """BootcampApplication serializer"""
+    bootcamp_run = BootcampRunSerializer(read_only=True)
+
+    class Meta:
+        model = models.BootcampApplication
+        fields = [
+            "id",
+            "state",
+            "created_on",
+            "bootcamp_run",
         ]

--- a/applications/views.py
+++ b/applications/views.py
@@ -1,14 +1,19 @@
 """Views for bootcamp applications"""
+from django.core.exceptions import ImproperlyConfigured
 from rest_framework import viewsets, mixins
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 
 from applications.models import BootcampApplication
-from applications.serializers import BootcampApplicationDetailSerializer
+from applications.serializers import BootcampApplicationDetailSerializer, BootcampApplicationListSerializer
 from main.permissions import UserIsOwnerPermission
 
 
-class BootcampApplicationViewset(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+class BootcampApplicationViewset(
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet
+):
     """
     View for fetching users' serialized bootcamp application(s)
     """
@@ -18,4 +23,8 @@ class BootcampApplicationViewset(mixins.RetrieveModelMixin, viewsets.GenericView
     owner_field = "user"
 
     def get_serializer_class(self):
-        return BootcampApplicationDetailSerializer
+        if self.action == "retrieve":
+            return BootcampApplicationDetailSerializer
+        elif self.action == "list":
+            return BootcampApplicationListSerializer
+        raise ImproperlyConfigured("Cannot perform the requested action.")


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #494 

#### What's this PR do?
Adds endpoint for fetching list of user applications

#### How should this be manually tested?
Create a few bootcamp applications for some user, start a Django shell, log that user in with a django test client and make a request to the applications endpoint (`/api/applications`). You should get a response with those applications you created.

#### Any background context you want to provide?
[Design](https://projects.invisionapp.com/d/main#/console/19928472/417192809/preview)
