### PR TITLE
Add API for submitting review for application submissions

### DIFF
--- a/applications/api.py
+++ b/applications/api.py
@@ -83,18 +83,22 @@ def process_upload_resume(resume_file, bootcamp_application):
     bootcamp_application.save()
 
 
-def submit_review_for_application_submission(review_status, submission):
+def set_submission_review_status(submission, review_status):
     """
     Process review of an application step submission
 
     Args:
-        review_status(str): approved or rejected submission
         submission(ApplicationStepSubmission): The submission that is being reviewed
+        review_status(str): approved or rejected submission
     """
     bootcamp_application = submission.bootcamp_application
     if bootcamp_application.state != AppStates.AWAITING_SUBMISSION_REVIEW.value:
-        raise InvalidApplicationException("The BootcampApplication is not awaiting submission review")
-
+        raise InvalidApplicationException(
+            "The BootcampApplication is not awaiting submission review (id: {}, state: {})".format(
+                bootcamp_application.id,
+                bootcamp_application.state
+            )
+        )
     submission.review_status = review_status
     submission.review_status_date = now_in_utc()
     submission.save()

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -141,12 +141,13 @@ def test_process_upload_resume():
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("review,other_submissions,expected", [
-    (REVIEW_STATUS_APPROVED, True, AppStates.AWAITING_SUBMISSION_REVIEW.value),
-    (REVIEW_STATUS_APPROVED, False, AppStates.AWAITING_PAYMENT.value),
-    (REVIEW_STATUS_REJECTED, False, AppStates.REJECTED.value),
+@pytest.mark.parametrize("review,other_submissions,other_steps,expected", [
+    (REVIEW_STATUS_APPROVED, True, True, AppStates.AWAITING_USER_SUBMISSIONS.value),
+    (REVIEW_STATUS_APPROVED, False, True, AppStates.AWAITING_USER_SUBMISSIONS.value),
+    (REVIEW_STATUS_APPROVED, False, False, AppStates.AWAITING_PAYMENT.value),
+    (REVIEW_STATUS_REJECTED, False, False, AppStates.REJECTED.value),
 ])
-def test_set_submission_review_status(review, other_submissions, expected):
+def test_set_submission_review_status(review, other_submissions, other_steps, expected):
     """
     set_submission_review_status should set submission review and update application state
     """
@@ -166,6 +167,9 @@ def test_set_submission_review_status(review, other_submissions, expected):
             bootcamp_application=bootcamp_application,
             run_application_step=application_step,
         )
+    if other_steps:
+        BootcampRunApplicationStepFactory.create(bootcamp_run=bootcamp_application.bootcamp_run)
+
     set_submission_review_status(submission, review)
     assert submission.review_status == review
     assert bootcamp_application.state == expected

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -6,7 +6,7 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from applications.api import get_or_create_bootcamp_application, derive_application_state, process_upload_resume, \
-    InvalidApplicationException, submit_review_for_application_submission
+    InvalidApplicationException, set_submission_review_status
 from applications.constants import (
     AppStates, REVIEW_STATUS_APPROVED, REVIEW_STATUS_REJECTED
 )
@@ -146,9 +146,9 @@ def test_process_upload_resume():
     (REVIEW_STATUS_APPROVED, False, AppStates.AWAITING_PAYMENT.value),
     (REVIEW_STATUS_REJECTED, False, AppStates.REJECTED.value),
 ])
-def test_submit_review_for_application_submission(review, other_submissions, expected):
+def test_set_submission_review_status(review, other_submissions, expected):
     """
-    submit_review_for_application_submission should set submission review and update application state
+    set_submission_review_status should set submission review and update application state
     """
     bootcamp_application = BootcampApplicationFactory(state=AppStates.AWAITING_SUBMISSION_REVIEW.value)
     submission = ApplicationStepSubmissionFactory(
@@ -166,6 +166,6 @@ def test_submit_review_for_application_submission(review, other_submissions, exp
             bootcamp_application=bootcamp_application,
             run_application_step=application_step,
         )
-    submit_review_for_application_submission(review, submission)
+    set_submission_review_status(submission, review)
     assert submission.review_status == review
     assert bootcamp_application.state == expected

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -6,7 +6,7 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from applications.api import get_or_create_bootcamp_application, derive_application_state, process_upload_resume, \
-    InvalidApplicationException
+    InvalidApplicationException, submit_review_for_application_submission
 from applications.constants import (
     AppStates, REVIEW_STATUS_APPROVED, REVIEW_STATUS_REJECTED
 )
@@ -138,3 +138,34 @@ def test_process_upload_resume():
     resume_file = SimpleUploadedFile('resume.pdf', b'file_content')
     with pytest.raises(InvalidApplicationException):
         process_upload_resume(resume_file, existing_app)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("review,other_submissions,expected", [
+    (REVIEW_STATUS_APPROVED, True, AppStates.AWAITING_SUBMISSION_REVIEW.value),
+    (REVIEW_STATUS_APPROVED, False, AppStates.AWAITING_PAYMENT.value),
+    (REVIEW_STATUS_REJECTED, False, AppStates.REJECTED.value),
+])
+def test_submit_review_for_application_submission(review, other_submissions, expected):
+    """
+    submit_review_for_application_submission should set submission review and update application state
+    """
+    bootcamp_application = BootcampApplicationFactory(state=AppStates.AWAITING_SUBMISSION_REVIEW.value)
+    submission = ApplicationStepSubmissionFactory(
+        review_status=None,
+        bootcamp_application=bootcamp_application,
+        run_application_step__bootcamp_run=bootcamp_application.bootcamp_run
+    )
+    if other_submissions:
+        application_step = BootcampRunApplicationStepFactory.create(
+            bootcamp_run=bootcamp_application.bootcamp_run,
+            application_step__bootcamp=bootcamp_application.bootcamp_run.bootcamp
+        )
+        ApplicationStepSubmissionFactory.create(
+            review_status=None,
+            bootcamp_application=bootcamp_application,
+            run_application_step=application_step,
+        )
+    submit_review_for_application_submission(review, submission)
+    assert submission.review_status == review
+    assert bootcamp_application.state == expected

--- a/applications/models.py
+++ b/applications/models.py
@@ -15,7 +15,7 @@ from applications.constants import (
     AppStates,
     VALID_APP_STATE_CHOICES,
     VALID_REVIEW_STATUS_CHOICES,
-    REVIEW_STATUS_REJECTED)
+    REVIEW_STATUS_APPROVED)
 from applications.utils import validate_file_extension
 from main.models import TimestampedModel, ValidateOnSaveMixin
 from main.utils import now_in_utc
@@ -171,8 +171,7 @@ class BootcampApplication(TimestampedModel):
         Make sure all steps are submitted, reviewed and approved
         """
         if self.all_application_steps_submitted():
-            return not self.submissions.filter(
-                models.Q(review_status=REVIEW_STATUS_REJECTED) | models.Q(review_status__isnull=True)).exists()
+            return not self.submissions.exclude(review_status=REVIEW_STATUS_APPROVED).exists()
         return False
 
     def __str__(self):

--- a/applications/models.py
+++ b/applications/models.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import User
-from django_fsm import FSMField, transition
+from django_fsm import FSMField, transition, RETURN_VALUE
 
 from applications.constants import (
     VALID_SUBMISSION_TYPE_CHOICES,
@@ -142,6 +142,27 @@ class BootcampApplication(TimestampedModel):
         self.resume_file = resume_file
         self.resume_upload_date = now_in_utc()
         self.save()
+
+    @transition(
+        field=state,
+        source=AppStates.AWAITING_SUBMISSION_REVIEW.value,
+        target=RETURN_VALUE(AppStates.AWAITING_SUBMISSION_REVIEW.value, AppStates.AWAITING_PAYMENT.value))
+    def approve_submission(self):
+        """Approve application submission"""
+        return (AppStates.AWAITING_SUBMISSION_REVIEW.value
+                if self.has_incomplete_submissions() else AppStates.AWAITING_PAYMENT.value)
+
+    @transition(
+        field=state,
+        source=AppStates.AWAITING_SUBMISSION_REVIEW.value,
+        target=AppStates.REJECTED.value
+    )
+    def reject_submission(self):
+        """Reject application submission"""
+
+    def has_incomplete_submissions(self):
+        """Check if the application is waiting for some submissions to be reviewed"""
+        return self.submissions.filter(review_status__isnull=True).exists()
 
     def __str__(self):
         return f"user='{self.user.email}', run='{self.bootcamp_run.title}', state={self.state}"

--- a/applications/models_test.py
+++ b/applications/models_test.py
@@ -79,7 +79,9 @@ def test_has_incomplete_submissions():
         run_application_step__bootcamp_run=bootcamp_run,
     )
     bootcamp_application = submission.bootcamp_application
-    assert bootcamp_application.has_incomplete_submissions() is False
+    bootcamp_application.state = AppStates.AWAITING_SUBMISSION_REVIEW.value
+    bootcamp_application.save()
+    assert bootcamp_application.all_submissions_are_reviewed() is True
 
     application_step = BootcampRunApplicationStepFactory.create(
         bootcamp_run=bootcamp_run,
@@ -90,7 +92,7 @@ def test_has_incomplete_submissions():
         bootcamp_application=bootcamp_application,
         run_application_step=application_step,
     )
-    assert bootcamp_application.has_incomplete_submissions() is True
+    assert bootcamp_application.all_submissions_are_reviewed() is False
 
 
 @pytest.mark.django_db

--- a/applications/models_test.py
+++ b/applications/models_test.py
@@ -69,9 +69,9 @@ def test_bootcamp_application_resume_file_validation(file_name, expected):
 
 
 @pytest.mark.django_db
-def test_has_incomplete_submissions():
+def test_all_submissions_are_reviewed():
     """
-    has_incomplete_submissions should return true if there are other submissions that are waiting for review
+    all_submissions_are_reviewed should return true if all submissions have been reviewed
     """
     bootcamp_run = BootcampRunFactory()
     submission = ApplicationStepSubmissionFactory.create(

--- a/applications/models_test.py
+++ b/applications/models_test.py
@@ -69,6 +69,31 @@ def test_bootcamp_application_resume_file_validation(file_name, expected):
 
 
 @pytest.mark.django_db
+def test_has_incomplete_submissions():
+    """
+    has_incomplete_submissions should return true if there are other submissions that are waiting for review
+    """
+    bootcamp_run = BootcampRunFactory()
+    submission = ApplicationStepSubmissionFactory.create(
+        bootcamp_application__bootcamp_run=bootcamp_run,
+        run_application_step__bootcamp_run=bootcamp_run,
+    )
+    bootcamp_application = submission.bootcamp_application
+    assert bootcamp_application.has_incomplete_submissions() is False
+
+    application_step = BootcampRunApplicationStepFactory.create(
+        bootcamp_run=bootcamp_run,
+        application_step__bootcamp=bootcamp_run.bootcamp
+    )
+    ApplicationStepSubmissionFactory.create(
+        review_status=None,
+        bootcamp_application=bootcamp_application,
+        run_application_step=application_step,
+    )
+    assert bootcamp_application.has_incomplete_submissions() is True
+
+
+@pytest.mark.django_db
 def test_bootcamp_run_application_step_validation():
     """
     A BootcampRunApplicationStep object should raise an exception if it is saved when the bootcamp of the bootcamp run

--- a/applications/urls.py
+++ b/applications/urls.py
@@ -4,11 +4,12 @@ URLs for bootcamp applications
 from django.conf.urls import url, include
 from rest_framework import routers
 
-from applications.views import BootcampApplicationViewset
+from applications.views import BootcampApplicationViewset, ReviewSubmissionView
 
 router = routers.SimpleRouter()
 router.register(r"applications", BootcampApplicationViewset, basename="applications_api")
 
 urlpatterns = [
     url(r"^api/", include(router.urls)),
+    url(r'^api/submissions/(?P<pk>\d+)/$', ReviewSubmissionView.as_view(), name='submit-review'),
 ]


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #463

#### What's this PR do?
Add endpoint to set the review state of an application submission

#### How should this be manually tested?
Create two un-reviewed submissions, call `submit_review_for_application_submission` on one of the submissions, and make sure the `BootcampApplication` and `ApplicationStepSubmission` get updated accordingly.


