### PR TITLE
Add checkout data API

### DIFF
--- a/applications/api.py
+++ b/applications/api.py
@@ -4,7 +4,6 @@ from django.db import transaction
 from applications.constants import AppStates, REVIEW_STATUS_REJECTED, REVIEW_STATUS_APPROVED
 from applications.exceptions import InvalidApplicationException
 from applications.models import BootcampApplication
-from ecommerce.api import is_paid_in_full
 from main.utils import now_in_utc
 
 
@@ -59,10 +58,7 @@ def derive_application_state(bootcamp_application):  # pylint: disable=too-many-
         return AppStates.AWAITING_SUBMISSION_REVIEW.value
     elif len(submissions) < bootcamp_application.bootcamp_run.application_steps.count():
         return AppStates.AWAITING_USER_SUBMISSIONS.value
-    if not is_paid_in_full(
-        user=bootcamp_application.user,
-        bootcamp_run=bootcamp_application.bootcamp_run
-    ):
+    elif not bootcamp_application.is_paid_in_full:
         return AppStates.AWAITING_PAYMENT.value
     return AppStates.COMPLETE.value
 

--- a/applications/constants.py
+++ b/applications/constants.py
@@ -19,6 +19,10 @@ class AppStates(Enum):
     COMPLETE = "COMPLETE"
     REJECTED = "REJECTED"
 
+    def __str__(self):
+        """If an enum is silently cast to string it should be treated as if the user added .value to the end"""
+        return self.value
+
 
 VALID_APP_STATE_CHOICES = list(zip(
     (member.value for member in AppStates),

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -31,7 +31,6 @@ from ecommerce.models import (
     Line,
     Order,
 )
-from ecommerce.serializers import LineSerializer
 from mail.api import MailgunClient
 
 
@@ -381,6 +380,8 @@ def serialize_user_bootcamp_run(user, bootcamp_run):
     Returns:
         dict: a dictionary describing a bootcamp run and payments for it by the user
     """
+
+    from ecommerce.serializers import LineSerializer
 
     return {
         "run_key": bootcamp_run.run_key,

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -71,7 +71,7 @@ class CheckoutDataSerializer(serializers.ModelSerializer):
     def get_payments(self, application):
         """Serialized payments made by the user"""
         return LineSerializer(
-            (order.line_set.first() for order in application.orders.filter(status=Order.FULFILLED)),
+            (order.line_set.first() for order in application.orders.all() if order.status == Order.FULFILLED),
             many=True,
         ).data
 

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -72,12 +72,12 @@ class CheckoutDataSerializer(serializers.ModelSerializer):
 
     def get_total_price(self, application):
         """The personal price for the user, or the full price for the run"""
-        return application.bootcamp_run.personal_price(self.context["request"].user) or Decimal(0)
+        return application.bootcamp_run.personal_price(application.user) or Decimal(0)
 
     def get_total_paid(self, application):
         """The total paid by the user for this application so far"""
         return get_total_paid(
-            user=self.context["request"].user,
+            user=application.user,
             application_id=application.id,
             run_key=application.bootcamp_run.run_key,
         )
@@ -85,7 +85,7 @@ class CheckoutDataSerializer(serializers.ModelSerializer):
     def get_payments(self, application):
         """Serialized payments made by the user"""
         return LineSerializer(
-            Line.for_user_bootcamp_run(self.context["request"].user, application.bootcamp_run.run_key),
+            Line.objects.filter(order__application=application, order__status=Order.FULFILLED),
             many=True,
         ).data
 

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -88,7 +88,7 @@ def test_line_serializer(line):
 
 
 @pytest.mark.parametrize("has_paid", [True, False])
-def test_checkout_data(mocker, has_paid):
+def test_checkout_data(has_paid):
     """
     Test checkout data serializer
     """
@@ -106,8 +106,7 @@ def test_checkout_data(mocker, has_paid):
 
     InstallmentFactory.create(bootcamp_run=run)
 
-    request_mock = mocker.Mock(user=user)
-    assert CheckoutDataSerializer(instance=application, context={"request": request_mock}).data == {
+    assert CheckoutDataSerializer(instance=application).data == {
         "id": application.id,
         "bootcamp_run": {
             "id": run.id,

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -1,9 +1,7 @@
 """Tests for serializers"""
-from decimal import Decimal
 import pytest
 
 from main.test_utils import serializer_date_format
-from ecommerce.api import get_total_paid
 from ecommerce.factories import (
     LineFactory,
     BootcampApplicationFactory,
@@ -138,6 +136,6 @@ def test_checkout_data(has_paid):
                 "description": line.description,
             }
         ] if has_paid else [],
-        "total_paid": get_total_paid(user=user, run_key=run.run_key, application_id=application.id),
-        "total_price": run.personal_price(user) or Decimal(0),
+        "total_paid": application.total_paid,
+        "total_price": application.price,
     }

--- a/ecommerce/test_utils.py
+++ b/ecommerce/test_utils.py
@@ -1,0 +1,53 @@
+"""Functions for testing ecommerce"""
+from unittest.mock import patch
+
+from applications.constants import AppStates
+from backends.pipeline_api import EdxOrgOAuth2
+from ecommerce.api import create_unfulfilled_order
+from ecommerce.factories import BootcampApplicationFactory
+from ecommerce.models import Order
+from klasses.factories import InstallmentFactory
+from profiles.factories import ProfileFactory
+
+
+def create_test_application():
+    """Create a purchasable bootcamp run, and a user to be associated with it"""
+    profile = ProfileFactory.create()
+    user = profile.user
+    user.social_auth.create(
+        provider=EdxOrgOAuth2.name,
+        uid="{}_edx".format(user.username),
+    )
+    installment_1 = InstallmentFactory.create(amount=200)
+    bootcamp_run = installment_1.bootcamp_run
+    InstallmentFactory.create(bootcamp_run=bootcamp_run)
+    application = BootcampApplicationFactory.create(
+        user=user,
+        bootcamp_run=bootcamp_run,
+        state=AppStates.AWAITING_PAYMENT.value,
+    )
+    return application
+
+
+def create_purchasable_bootcamp_run():
+    """A pair of (bootcamp run, user)"""
+    application = create_test_application()
+    return application.bootcamp_run, application.user
+
+
+def create_test_order(application, payment, *, fulfilled):
+    """
+    Pass through arguments to create_unfulfilled_order and mock payable_bootcamp_run_keys
+    """
+    run_key = application.bootcamp_run.run_key
+    user = application.user
+    with patch(
+        'ecommerce.api.payable_bootcamp_run_keys',
+        return_value=[run_key],
+    ):
+        order = create_unfulfilled_order(user, run_key, payment)
+    order.application = application
+    if fulfilled:
+        order.status = Order.FULFILLED
+    order.save()
+    return order

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -2,20 +2,16 @@
 URLs for ecommerce
 """
 from django.conf.urls import url
-from django.urls import include, path
-from rest_framework import routers
+from django.urls import path
 
 from ecommerce.views import (
-    CheckoutDataViewSet,
+    CheckoutDataView,
     OrderFulfillmentView,
     PaymentView,
     UserBootcampRunDetail,
     UserBootcampRunList,
     UserBootcampRunStatement,
 )
-
-router = routers.DefaultRouter()
-router.register("checkout", CheckoutDataViewSet, "checkout-data")
 
 
 urlpatterns = [
@@ -28,5 +24,5 @@ urlpatterns = [
         name='bootcamp-run-detail'
     ),
     url(r'statement/(?P<run_key>[0-9]+)/$', UserBootcampRunStatement.as_view(), name='bootcamp-run-statement'),
-    path("api/", include(router.urls))
+    path("api/checkout/", CheckoutDataView.as_view(), name="checkout-data-detail"),
 ]

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -2,14 +2,20 @@
 URLs for ecommerce
 """
 from django.conf.urls import url
+from django.urls import include, path
+from rest_framework import routers
 
 from ecommerce.views import (
+    CheckoutDataViewSet,
     OrderFulfillmentView,
     PaymentView,
-    UserBootcampRunList,
     UserBootcampRunDetail,
+    UserBootcampRunList,
     UserBootcampRunStatement,
 )
+
+router = routers.DefaultRouter()
+router.register("checkout", CheckoutDataViewSet, "checkout-data")
 
 
 urlpatterns = [
@@ -21,5 +27,6 @@ urlpatterns = [
         UserBootcampRunDetail.as_view(),
         name='bootcamp-run-detail'
     ),
-    url(r'^statement/(?P<run_key>[0-9]+)/$', UserBootcampRunStatement.as_view(), name='bootcamp-run-statement'),
+    url(r'statement/(?P<run_key>[0-9]+)/$', UserBootcampRunStatement.as_view(), name='bootcamp-run-statement'),
+    path("api/", include(router.urls))
 ]

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -233,4 +233,5 @@ class CheckoutDataViewSet(ReadOnlyModelViewSet):
             "bootcamp_run__personal_prices",
             "bootcamp_run__installment_set",
             "orders",
+            "orders__line_set",
         ).order_by("id")

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -229,4 +229,8 @@ class CheckoutDataViewSet(ReadOnlyModelViewSet):
             user=self.request.user,
             state=AppStates.AWAITING_PAYMENT.value,
             id=application_id,
+        ).select_related("bootcamp_run").prefetch_related(
+            "bootcamp_run__personal_prices",
+            "bootcamp_run__installment_set",
+            "orders",
         ).order_by("id")

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -222,10 +222,11 @@ class CheckoutDataViewSet(ReadOnlyModelViewSet):
     def get_queryset(self):
         """Filter on logged in user"""
         application_id = self.request.query_params.get("application")
-        queryset = BootcampApplication.objects.filter(
+        if not application_id:
+            raise Http404
+
+        return BootcampApplication.objects.filter(
             user=self.request.user,
             state=AppStates.AWAITING_PAYMENT.value,
-        )
-        if application_id is not None:
-            queryset = queryset.filter(id=application_id)
-        return queryset.order_by("id")
+            id=application_id,
+        ).order_by("id")

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -495,12 +495,11 @@ def test_checkout_data(mocker, client):
     mock_request = mocker.Mock(user=user)
 
     client.force_login(user)
-    url = f'{reverse("checkout-data-list")}?application={app_awaiting_payment.id}'
+    url = f'{reverse("checkout-data-detail")}?application={app_awaiting_payment.id}'
     resp = client.get(url)
 
     assert resp.json() == CheckoutDataSerializer(
-        instance=[app_awaiting_payment],
-        many=True,
+        instance=app_awaiting_payment,
         context={"request": mock_request}
     ).data
 
@@ -508,11 +507,11 @@ def test_checkout_data(mocker, client):
 def test_checkout_data_no_application_id(client, user):
     """check that the application query parameter is required"""
     client.force_login(user)
-    resp = client.get(reverse("checkout-data-list"))
+    resp = client.get(reverse("checkout-data-detail"))
     assert resp.status_code == statuses.HTTP_404_NOT_FOUND
 
 
 def test_checkout_data_anonymous(client):
     """anonymous users cannot query the checkout data API"""
-    resp = client.get(reverse("checkout-data-list"))
+    resp = client.get(reverse("checkout-data-detail"))
     assert resp.status_code == statuses.HTTP_403_FORBIDDEN

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -467,8 +467,7 @@ def test_user_bootcamp_run_statement_without_order(test_data, client):
     assert response.status_code == statuses.HTTP_404_NOT_FOUND
 
 
-@pytest.mark.parametrize("with_application_id", [True, False])
-def test_checkout_data(mocker, client, with_application_id):
+def test_checkout_data(mocker, client):
     """The checkout data API should return serialized application data"""
     app_awaiting_payment = BootcampApplicationFactory.create(state=AppStates.AWAITING_PAYMENT.value)
     user = app_awaiting_payment.user
@@ -477,9 +476,7 @@ def test_checkout_data(mocker, client, with_application_id):
     mock_request = mocker.Mock(user=user)
 
     client.force_login(user)
-    url = reverse("checkout-data-list")
-    if with_application_id:
-        url += f"?application={app_awaiting_payment.id}"
+    url = f'{reverse("checkout-data-list")}?application={app_awaiting_payment.id}'
     resp = client.get(url)
 
     assert resp.json() == CheckoutDataSerializer(
@@ -487,3 +484,16 @@ def test_checkout_data(mocker, client, with_application_id):
         many=True,
         context={"request": mock_request}
     ).data
+
+
+def test_checkout_data_no_application_id(client, user):
+    """check that the application query parameter is required"""
+    client.force_login(user)
+    resp = client.get(reverse("checkout-data-list"))
+    assert resp.status_code == statuses.HTTP_404_NOT_FOUND
+
+
+def test_checkout_data_anonymous(client):
+    """anonymous users cannot query the checkout data API"""
+    resp = client.get(reverse("checkout-data-list"))
+    assert resp.status_code == statuses.HTTP_403_FORBIDDEN


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #492 

#### What's this PR do?
Adds a new API `/api/checkout` to provide checkout data regarding applications, what they cost and what the user has already paid. There is an optional query parameter `application=<pk>` which will filter the list to just the application listed, if it exists and if it's awaiting payment.

#### How should this be manually tested?
Go to `/api/checkout` and verify that the data looks appropriate. If you add `?application=<pk>` to the url it should show only that application. Also, make sure nothing has changed in the payment page.

#### Context
This is intended to replace `/api/v0/bootcamps` in the near future, so there is a lot of overlapping functionality. In a future PR we will remove that API and migrate frontend logic to use this API instead.