### PR TITLE
Added endpoint to create a bootcamp application

### DIFF
--- a/applications/api.py
+++ b/applications/api.py
@@ -8,31 +8,32 @@ from ecommerce.api import is_paid_in_full
 
 
 @transaction.atomic
-def get_or_create_bootcamp_application(user, bootcamp_run):
+def get_or_create_bootcamp_application(user, bootcamp_run_id):
     """
     Fetches a bootcamp application for a user if it exists. Otherwise, an application is created with the correct
     state.
 
     Args:
         user (User): The user applying for the bootcamp run
-        bootcamp_run (klasses.models.BootcampRun): The bootcamp run to which the user is applying
+        bootcamp_run_id (int): The id of the bootcamp run to which the user is applying
 
     Returns:
-        BootcampApplication: The bootcamp application
+        Tuple[BootcampApplication, bool]: The bootcamp application paired with a boolean indicating whether
+            or not a new application was created
     """
     bootcamp_app, created = (
         BootcampApplication.objects
         .select_for_update()
         .get_or_create(
             user=user,
-            bootcamp_run=bootcamp_run,
+            bootcamp_run_id=bootcamp_run_id,
         )
     )
     if created:
         derived_state = derive_application_state(bootcamp_app)
         bootcamp_app.state = derived_state
         bootcamp_app.save()
-    return bootcamp_app
+    return bootcamp_app, created
 
 
 def derive_application_state(bootcamp_application):  # pylint: disable=too-many-return-statements

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -113,18 +113,20 @@ def test_get_or_create_bootcamp_application(mocker):
     )
     users = UserFactory.create_batch(2)
     bootcamp_runs = BootcampRunFactory.create_batch(2)
-    bootcamp_app = get_or_create_bootcamp_application(bootcamp_run=bootcamp_runs[0], user=users[0])
+    bootcamp_app, created = get_or_create_bootcamp_application(bootcamp_run_id=bootcamp_runs[0].id, user=users[0])
     patched_derive_state.assert_called_once_with(bootcamp_app)
     assert bootcamp_app.bootcamp_run == bootcamp_runs[0]
     assert bootcamp_app.user == users[0]
     assert bootcamp_app.state == patched_derive_state.return_value
+    assert created is True
     # The function should just return the existing application if one exists already
     existing_app = BootcampApplicationFactory.create(
         user=users[1],
         bootcamp_run=bootcamp_runs[1]
     )
-    bootcamp_app = get_or_create_bootcamp_application(bootcamp_run=bootcamp_runs[1], user=users[1])
+    bootcamp_app, created = get_or_create_bootcamp_application(bootcamp_run_id=bootcamp_runs[1].id, user=users[1])
     assert bootcamp_app == existing_app
+    assert created is False
 
 
 @pytest.mark.django_db

--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -74,6 +74,7 @@ class BootcampApplicationDetailSerializer(serializers.ModelSerializer):
         model = models.BootcampApplication
         fields = [
             "id",
+            "bootcamp_run_id",
             "state",
             "resume_filename",
             "resume_upload_date",
@@ -85,9 +86,9 @@ class BootcampApplicationDetailSerializer(serializers.ModelSerializer):
         ]
 
 
-class BootcampApplicationListSerializer(serializers.ModelSerializer):
+class BootcampApplicationSerializer(serializers.ModelSerializer):
     """BootcampApplication serializer"""
-    bootcamp_run = BootcampRunSerializer(read_only=True)
+    bootcamp_run = BootcampRunSerializer()
 
     class Meta:
         model = models.BootcampApplication

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -9,7 +9,7 @@ import factory
 from applications.serializers import (
     BootcampApplicationDetailSerializer,
     BootcampRunStepSerializer,
-    SubmissionSerializer, BootcampApplicationListSerializer,
+    SubmissionSerializer, BootcampApplicationSerializer,
 )
 from applications.factories import (
     BootcampApplicationFactory,
@@ -48,6 +48,7 @@ def test_application_detail_serializer(app_data):
     data = BootcampApplicationDetailSerializer(instance=application).data
     assert data == {
         "id": application.id,
+        "bootcamp_run_id": application.bootcamp_run_id,
         "state": application.state,
         "resume_filename": None,
         "resume_upload_date": serializer_date_format(application.resume_upload_date),
@@ -106,7 +107,7 @@ def test_application_list_serializer(app_data):
     """
     other_app = BootcampApplicationFactory.create(user=app_data.application.user)
     user_applications = [app_data.application, other_app]
-    data = BootcampApplicationListSerializer(instance=user_applications, many=True).data
+    data = BootcampApplicationSerializer(instance=user_applications, many=True).data
     assert data == [
         {
             "id": application.id,

--- a/applications/views.py
+++ b/applications/views.py
@@ -1,17 +1,21 @@
 """Views for bootcamp applications"""
-from django.core.exceptions import ImproperlyConfigured
-from rest_framework import viewsets, mixins
+from rest_framework import viewsets, mixins, status
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.exceptions import MethodNotAllowed, ValidationError
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from applications.models import BootcampApplication
-from applications.serializers import BootcampApplicationDetailSerializer, BootcampApplicationListSerializer
+from applications.serializers import BootcampApplicationDetailSerializer, BootcampApplicationSerializer
+from applications.api import get_or_create_bootcamp_application
+from klasses.models import BootcampRun
 from main.permissions import UserIsOwnerPermission
 
 
 class BootcampApplicationViewset(
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
+    mixins.CreateModelMixin,
     viewsets.GenericViewSet
 ):
     """
@@ -19,12 +23,36 @@ class BootcampApplicationViewset(
     """
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated, UserIsOwnerPermission,)
-    queryset = BootcampApplication.objects.prefetch_state_data()
     owner_field = "user"
+
+    def get_queryset(self):
+        if self.action == "retrieve":
+            return BootcampApplication.objects.prefetch_state_data()
+        else:
+            return BootcampApplication.objects.all()
 
     def get_serializer_class(self):
         if self.action == "retrieve":
             return BootcampApplicationDetailSerializer
-        elif self.action == "list":
-            return BootcampApplicationListSerializer
-        raise ImproperlyConfigured("Cannot perform the requested action.")
+        elif self.action in {"list", "create"}:
+            return BootcampApplicationSerializer
+        raise MethodNotAllowed("Cannot perform the requested action.")
+
+    def create(self, request, *args, **kwargs):
+        bootcamp_run_id = request.data.get("bootcamp_run_id")
+        if not bootcamp_run_id:
+            raise ValidationError("Bootcamp run ID required.")
+        if not BootcampRun.objects.filter(id=bootcamp_run_id).exists():
+            return Response(
+                data={"error": "Bootcamp does not exist"},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        application, created = get_or_create_bootcamp_application(
+            user=request.user,
+            bootcamp_run_id=bootcamp_run_id
+        )
+        serializer_cls = self.get_serializer_class()
+        return Response(
+            data=serializer_cls(instance=application).data,
+            status=(status.HTTP_201_CREATED if created else status.HTTP_200_OK)
+        )

--- a/applications/views_test.py
+++ b/applications/views_test.py
@@ -5,14 +5,16 @@ from django.urls import reverse
 from rest_framework import status
 
 from applications.factories import BootcampApplicationFactory
-from applications.serializers import BootcampApplicationDetailSerializer, BootcampApplicationListSerializer
+from applications.serializers import BootcampApplicationDetailSerializer, BootcampApplicationSerializer
 from applications.views import BootcampApplicationViewset
+from klasses.factories import BootcampRunFactory
+from profiles.factories import UserFactory
 
 
 @pytest.mark.parametrize(
     "action,expected_serializer", [
         ["retrieve", BootcampApplicationDetailSerializer],
-        ["list", BootcampApplicationListSerializer],
+        ["list", BootcampApplicationSerializer],
     ]
 )
 def test_view_serializer(mocker, action, expected_serializer):
@@ -41,6 +43,28 @@ def test_app_list_view(client):
     resp = client.get(url)
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()[0]["id"] == application.id
+
+
+@pytest.mark.django_db
+def test_app_create_view(client):
+    """The bootcamp application create view should return a successful response"""
+    bootcamp_run = BootcampRunFactory.create()
+    user = UserFactory.create()
+    client.force_login(user)
+    url = reverse("applications_api-list")
+    resp = client.post(
+        url,
+        data={"bootcamp_run_id": bootcamp_run.id}
+    )
+    assert resp.status_code == status.HTTP_201_CREATED
+    application_id = resp.json()["id"]
+    # Making a request for an existing application should return a 200 instead of a 201
+    resp = client.post(
+        url,
+        data={"bootcamp_run_id": bootcamp_run.id}
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["id"] == application_id
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #491 

#### What's this PR do?
Adds an endpoint to create a new bootcamp application (or return it if it already exists)

#### How should this be manually tested?
In a Django shell, log in with some user with a test client, make a post request to `/api/applications/` with `{"bootcamp_run_id": <some BootcampRun id>}` in the request body. The response should indicate success, the application should be serialized in the response body, and the `BootcampApplication` should be created with the correct state.
