### PR TITLE
Add API for available bootcamp runs

### DIFF
--- a/klasses/serializers.py
+++ b/klasses/serializers.py
@@ -24,6 +24,7 @@ class BootcampRunSerializer(serializers.ModelSerializer):
         model = BootcampRun
         fields = [
             "id",
+            "display_title",
             "bootcamp",
             "title",
             "run_key",

--- a/klasses/serializers_test.py
+++ b/klasses/serializers_test.py
@@ -3,8 +3,9 @@ Tests for serializers
 """
 import pytest
 
-from klasses.factories import InstallmentFactory
-from klasses.serializers import InstallmentSerializer
+from klasses.factories import BootcampFactory, BootcampRunFactory, InstallmentFactory
+from klasses.serializers import BootcampSerializer, BootcampRunSerializer, InstallmentSerializer
+from main.test_utils import serializer_date_format
 
 # pylint: disable=missing-docstring,redefined-outer-name,unused-argument
 
@@ -22,3 +23,26 @@ def test_installment_serializer():
         'deadline': inst.deadline.strftime('%Y-%m-%dT%H:%M:%SZ'),
     }
     assert InstallmentSerializer(inst).data == expected
+
+
+def test_bootcamp_serializer():
+    """BootcampSerializer should serialize basic Bootcamp information"""
+    bootcamp = BootcampFactory.create()
+    assert BootcampSerializer(bootcamp).data == {
+        "title": bootcamp.title,
+        "id": bootcamp.id,
+    }
+
+
+def test_bootcamp_run_serializer():
+    """BootcampRunSerializer should serialize the bootcamp run"""
+    run = BootcampRunFactory.create()
+    assert BootcampRunSerializer(run).data == {
+        "id": run.id,
+        "title": run.title,
+        "display_title": run.display_title,
+        "bootcamp": BootcampSerializer(run.bootcamp).data,
+        "start_date": serializer_date_format(run.start_date),
+        "end_date": serializer_date_format(run.end_date),
+        "run_key": run.run_key,
+    }

--- a/klasses/urls.py
+++ b/klasses/urls.py
@@ -1,0 +1,14 @@
+"""urls for bootcamps"""
+
+from django.urls import path, include
+from rest_framework import routers
+
+from klasses.views import BootcampViewSet
+
+
+router = routers.DefaultRouter()
+router.register("bootcampruns", BootcampViewSet, "bootcamp-runs")
+
+urlpatterns = [
+    path("api/", include(router.urls)),
+]

--- a/klasses/views.py
+++ b/klasses/views.py
@@ -1,0 +1,21 @@
+"""views for bootcamps"""
+from django.db.models.functions import Now
+from rest_framework.mixins import ListModelMixin
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import GenericViewSet
+
+from klasses.serializers import BootcampRunSerializer
+from klasses.models import BootcampRun
+
+
+class BootcampViewSet(ListModelMixin, GenericViewSet):
+    """Viewset for bootcamps"""
+    permission_classes = (IsAuthenticated,)
+    serializer_class = BootcampRunSerializer
+
+    def get_queryset(self):
+        """Make a queryset which optionally shows what runs are available for enrollment"""
+        queryset = BootcampRun.objects.all().select_related("bootcamp")
+        if self.request.query_params.get("available") == "true":
+            queryset = queryset.filter(start_date__lt=Now()).exclude(enrollments__user=self.request.user)
+        return queryset.order_by("id")

--- a/klasses/views.py
+++ b/klasses/views.py
@@ -1,4 +1,5 @@
 """views for bootcamps"""
+from django.db.models import Q
 from django.db.models.functions import Now
 from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticated
@@ -17,5 +18,5 @@ class BootcampViewSet(ListModelMixin, GenericViewSet):
         """Make a queryset which optionally shows what runs are available for enrollment"""
         queryset = BootcampRun.objects.all().select_related("bootcamp")
         if self.request.query_params.get("available") == "true":
-            queryset = queryset.filter(start_date__lt=Now()).exclude(enrollments__user=self.request.user)
+            queryset = queryset.filter(start_date__lt=Now()).exclude(applications__user=self.request.user)
         return queryset.order_by("id")

--- a/klasses/views.py
+++ b/klasses/views.py
@@ -1,5 +1,4 @@
 """views for bootcamps"""
-from django.db.models import Q
 from django.db.models.functions import Now
 from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticated

--- a/klasses/views_test.py
+++ b/klasses/views_test.py
@@ -1,0 +1,52 @@
+"""Views for bootcamps"""
+from datetime import timedelta
+
+from django.urls import reverse
+import pytest
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_403_FORBIDDEN,
+)
+
+from klasses.factories import BootcampRunFactory
+from klasses.models import BootcampRunEnrollment
+from klasses.serializers import BootcampRunSerializer
+from main.utils import now_in_utc
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def runs(user):
+    """Make some test runs"""
+    run = BootcampRunFactory.create()
+    unavailable_run = BootcampRunFactory.create(start_date=now_in_utc()+timedelta(days=1))
+    already_enrolled_run = BootcampRunFactory.create()
+    BootcampRunEnrollment.objects.create(user=user, bootcamp_run=already_enrolled_run)
+
+    return run, unavailable_run, already_enrolled_run
+
+
+# pylint: disable=redefined-outer-name
+def test_bootcamp_runs(client, user, runs):
+    """The REST API should output a list of serialized bootcamp runs"""
+    run, unavailable_run, already_enrolled_run = runs
+    client.force_login(user)
+
+    full_list_resp = client.get(reverse("bootcamp-runs-list"))
+    assert full_list_resp.status_code == HTTP_200_OK
+    assert full_list_resp.json() == BootcampRunSerializer(
+        instance=[
+            run, unavailable_run, already_enrolled_run
+        ], many=True
+    ).data
+
+    available_resp = client.get(f"{reverse('bootcamp-runs-list')}?available=true")
+    assert available_resp.status_code == HTTP_200_OK
+    assert available_resp.json() == BootcampRunSerializer(instance=[run], many=True).data
+
+
+def test_bootcamp_runs_not_logged_in(client):
+    """Anonymous users should not be able to access the API"""
+    assert client.get(reverse("bootcamp-runs-list")).status_code == HTTP_403_FORBIDDEN

--- a/klasses/views_test.py
+++ b/klasses/views_test.py
@@ -28,6 +28,8 @@ def runs(user):
     unavailable_run = BootcampRunFactory.create(start_date=now_in_utc()+timedelta(days=1))
     submitted_application_run = BootcampRunFactory.create()
     BootcampApplicationFactory.create(user=user, bootcamp_run=submitted_application_run)
+    # Applications by other users should not affect whether the run is available
+    BootcampApplicationFactory.create(bootcamp_run=run)
 
     yield RunInfo(run=run, unavailable_run=unavailable_run, submitted_application_run=submitted_application_run)
 

--- a/klasses/views_test.py
+++ b/klasses/views_test.py
@@ -1,4 +1,5 @@
 """Views for bootcamps"""
+from collections import namedtuple
 from datetime import timedelta
 
 from django.urls import reverse
@@ -8,8 +9,8 @@ from rest_framework.status import (
     HTTP_403_FORBIDDEN,
 )
 
+from applications.factories import BootcampApplicationFactory
 from klasses.factories import BootcampRunFactory
-from klasses.models import BootcampRunEnrollment
 from klasses.serializers import BootcampRunSerializer
 from main.utils import now_in_utc
 
@@ -17,34 +18,36 @@ from main.utils import now_in_utc
 pytestmark = pytest.mark.django_db
 
 
+RunInfo = namedtuple("RunInfo", ["run", "unavailable_run", "submitted_application_run"])
+
+
 @pytest.fixture
 def runs(user):
     """Make some test runs"""
     run = BootcampRunFactory.create()
     unavailable_run = BootcampRunFactory.create(start_date=now_in_utc()+timedelta(days=1))
-    already_enrolled_run = BootcampRunFactory.create()
-    BootcampRunEnrollment.objects.create(user=user, bootcamp_run=already_enrolled_run)
+    submitted_application_run = BootcampRunFactory.create()
+    BootcampApplicationFactory.create(user=user, bootcamp_run=submitted_application_run)
 
-    return run, unavailable_run, already_enrolled_run
+    yield RunInfo(run=run, unavailable_run=unavailable_run, submitted_application_run=submitted_application_run)
 
 
 # pylint: disable=redefined-outer-name
 def test_bootcamp_runs(client, user, runs):
     """The REST API should output a list of serialized bootcamp runs"""
-    run, unavailable_run, already_enrolled_run = runs
     client.force_login(user)
 
     full_list_resp = client.get(reverse("bootcamp-runs-list"))
     assert full_list_resp.status_code == HTTP_200_OK
     assert full_list_resp.json() == BootcampRunSerializer(
         instance=[
-            run, unavailable_run, already_enrolled_run
+            runs.run, runs.unavailable_run, runs.submitted_application_run
         ], many=True
     ).data
 
     available_resp = client.get(f"{reverse('bootcamp-runs-list')}?available=true")
     assert available_resp.status_code == HTTP_200_OK
-    assert available_resp.json() == BootcampRunSerializer(instance=[run], many=True).data
+    assert available_resp.json() == BootcampRunSerializer(instance=[runs.run], many=True).data
 
 
 def test_bootcamp_runs_not_logged_in(client):

--- a/main/urls.py
+++ b/main/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     url('', include('social_django.urls', namespace='social')),
     path("", include("authentication.urls")),
     path("", include("profiles.urls")),
+    path("", include("klasses.urls")),
     url('', include('jobma.urls')),
     url(r'^logout/$', auth_views.LogoutView.as_view(), name='logout'),
     url(r'^background-images\.css$', BackgroundImagesCSSView.as_view(), name='background-images-css'),


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #447 

#### What's this PR do?
Creates an API at `/api/bootcampruns/` which shows all bootcamp runs to logged in users. A user can also add `?available=true` to the URL and see only runs which are available for enrollment, which are runs which haven't started yet and which aren't already enrolled in by the user.

#### How should this be manually tested?
Go to `/api/bootcampruns/` and `/api/bootcampruns/?available=true` and verify that the output makes sense. Create a `BootcampRunEnrollment` and note that the run is not in the available runs list anymore.
