### PR TITLE
Fixed application list view to only return applications that belong to the logged-in user

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -29,7 +29,7 @@ class BootcampApplicationViewset(
         if self.action == "retrieve":
             return BootcampApplication.objects.prefetch_state_data()
         else:
-            return BootcampApplication.objects.all()
+            return BootcampApplication.objects.filter(user=self.request.user).all()
 
     def get_serializer_class(self):
         if self.action == "retrieve":

--- a/applications/views_test.py
+++ b/applications/views_test.py
@@ -15,6 +15,7 @@ from profiles.factories import UserFactory
     "action,expected_serializer", [
         ["retrieve", BootcampApplicationDetailSerializer],
         ["list", BootcampApplicationSerializer],
+        ["create", BootcampApplicationSerializer],
     ]
 )
 def test_view_serializer(mocker, action, expected_serializer):
@@ -36,13 +37,18 @@ def test_app_detail_view(client):
 
 @pytest.mark.django_db
 def test_app_list_view(client):
-    """The bootcamp application list view should return a successful response"""
-    application = BootcampApplicationFactory.create()
-    client.force_login(application.user)
+    """
+    The bootcamp application list view should return a successful response, and should not include
+    other user's applications in the response data
+    """
+    applications = BootcampApplicationFactory.create_batch(2)
+    client.force_login(applications[0].user)
     url = reverse("applications_api-list")
     resp = client.get(url)
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json()[0]["id"] == application.id
+    resp_json = resp.json()
+    assert len(resp_json) == 1
+    assert resp_json[0]["id"] == applications[0].id
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket. Noticed during RC testing

#### What's this PR do?
See title. Previously the view was returning all applications, not just the ones owned by the logged-in user

#### How should this be manually tested?
Create an application for some user, and another belonging to a different user. The list endpoint should not return the latter application in the results
