### PR TITLE
Refactor hubspot deal/line syncing

### DIFF
--- a/applications/__init__.py
+++ b/applications/__init__.py
@@ -1,0 +1,2 @@
+"""Initialize applications app"""
+default_app_config = "applications.apps.ApplicationConfig"

--- a/applications/api.py
+++ b/applications/api.py
@@ -65,7 +65,7 @@ def derive_application_state(bootcamp_application):  # pylint: disable=too-many-
 
 def get_required_submission_type(application):
     """
-    Get the submission type of the first unsubmitted application step for an application
+    Get the submission type of the first unsubmitted step for an application
 
     Args:
         application (BootcampApplication): The application to query

--- a/applications/api.py
+++ b/applications/api.py
@@ -63,6 +63,30 @@ def derive_application_state(bootcamp_application):  # pylint: disable=too-many-
     return AppStates.COMPLETE.value
 
 
+def get_required_submission_type(application):
+    """
+    Get the submission type of the first unsubmitted application step for an application
+
+    Args:
+        application (BootcampApplication): The application to query
+
+    Returns:
+        str: The submission type
+
+    """
+    submission_subquery = application.submissions.all()
+    return (
+        application.bootcamp_run.application_steps.exclude(
+            id__in=submission_subquery.values_list(
+                "run_application_step", flat=True
+            )
+        )
+        .order_by("application_step__step_order")
+        .values_list("application_step__submission_type", flat=True)
+        .first()
+    )
+
+
 def process_upload_resume(resume_file, bootcamp_application):
     """
     Process the resume file and save it to BootcampApplication

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -6,10 +6,10 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from applications.api import get_or_create_bootcamp_application, derive_application_state, process_upload_resume, \
-    InvalidApplicationException, set_submission_review_status
+    InvalidApplicationException, set_submission_review_status, get_required_submission_type
 from applications.constants import (
-    AppStates, REVIEW_STATUS_APPROVED, REVIEW_STATUS_REJECTED
-)
+    AppStates, REVIEW_STATUS_APPROVED, REVIEW_STATUS_REJECTED,
+    SUBMISSION_QUIZ)
 from applications.factories import (
     BootcampApplicationFactory,
     BootcampRunApplicationStepFactory,
@@ -173,3 +173,24 @@ def test_set_submission_review_status(review, other_submissions, other_steps, ex
     set_submission_review_status(submission, review)
     assert submission.review_status == review
     assert bootcamp_application.state == expected
+
+
+@pytest.mark.django_db
+def test_get_required_submission_type(awaiting_submission_app):
+    """ Test that get_required_submission_type returns the correct submission type"""
+
+    # New application for a bootcamp with no steps at all
+    stepless_app = BootcampApplicationFactory.create()
+    assert get_required_submission_type(stepless_app) is None
+
+    # The fixture has 2 steps (Video, Quiz) and first step has been submitted
+    assert get_required_submission_type(awaiting_submission_app.application) == SUBMISSION_QUIZ
+
+    # After submitting all required steps, no type should be returned
+    ApplicationStepSubmissionFactory.create(
+        bootcamp_application=awaiting_submission_app.application,
+        run_application_step=awaiting_submission_app.run_steps[1]
+    )
+    assert get_required_submission_type(awaiting_submission_app.application) is None
+
+    #

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -5,11 +5,20 @@ import pytest
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 
-from applications.api import get_or_create_bootcamp_application, derive_application_state, process_upload_resume, \
-    InvalidApplicationException, set_submission_review_status, get_required_submission_type
+from applications.api import (
+    get_or_create_bootcamp_application,
+    derive_application_state,
+    process_upload_resume,
+    InvalidApplicationException,
+    set_submission_review_status,
+    get_required_submission_type,
+)
 from applications.constants import (
-    AppStates, REVIEW_STATUS_APPROVED, REVIEW_STATUS_REJECTED,
-    SUBMISSION_QUIZ)
+    AppStates,
+    REVIEW_STATUS_APPROVED,
+    REVIEW_STATUS_REJECTED,
+    SUBMISSION_QUIZ,
+)
 from applications.factories import (
     BootcampApplicationFactory,
     BootcampRunApplicationStepFactory,
@@ -142,10 +151,10 @@ def test_process_upload_resume():
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("review,other_submissions,other_steps,expected", [
-    (REVIEW_STATUS_APPROVED, True, True, AppStates.AWAITING_USER_SUBMISSIONS.value),
+        (REVIEW_STATUS_APPROVED, True, True, AppStates.AWAITING_USER_SUBMISSIONS.value),
     (REVIEW_STATUS_APPROVED, False, True, AppStates.AWAITING_USER_SUBMISSIONS.value),
-    (REVIEW_STATUS_APPROVED, False, False, AppStates.AWAITING_PAYMENT.value),
-    (REVIEW_STATUS_REJECTED, False, False, AppStates.REJECTED.value),
+        (REVIEW_STATUS_APPROVED, False, False, AppStates.AWAITING_PAYMENT.value),
+        (REVIEW_STATUS_REJECTED, False, False, AppStates.REJECTED.value),
 ])
 def test_set_submission_review_status(review, other_submissions, other_steps, expected):
     """
@@ -184,13 +193,14 @@ def test_get_required_submission_type(awaiting_submission_app):
     assert get_required_submission_type(stepless_app) is None
 
     # The fixture has 2 steps (Video, Quiz) and first step has been submitted
-    assert get_required_submission_type(awaiting_submission_app.application) == SUBMISSION_QUIZ
+    assert (
+        get_required_submission_type(awaiting_submission_app.application)
+        == SUBMISSION_QUIZ
+    )
 
     # After submitting all required steps, no type should be returned
     ApplicationStepSubmissionFactory.create(
         bootcamp_application=awaiting_submission_app.application,
-        run_application_step=awaiting_submission_app.run_steps[1]
+        run_application_step=awaiting_submission_app.run_steps[1],
     )
     assert get_required_submission_type(awaiting_submission_app.application) is None
-
-    #

--- a/applications/apps.py
+++ b/applications/apps.py
@@ -5,3 +5,7 @@ from django.apps import AppConfig
 class ApplicationConfig(AppConfig):
     """AppConfig for bootcamp applications"""
     name = 'applications'
+
+    def ready(self):
+        """Application is ready"""
+        import applications.signals  # pylint:disable=unused-import, unused-variable

--- a/applications/constants.py
+++ b/applications/constants.py
@@ -3,10 +3,18 @@
 from enum import Enum
 
 
+SUBMISSION_VIDEO = "videointerviewsubmission"
+SUBMISSION_QUIZ = "quizsubmission"
+
 VALID_SUBMISSION_TYPE_CHOICES = [
-    ("videointerviewsubmission", "Video Interview"),
-    ("quizsubmission", "Quiz"),
+    (SUBMISSION_VIDEO, "Video Interview"),
+    (SUBMISSION_QUIZ, "Quiz"),
 ]
+
+SUBMISSION_TYPE_STATE = {
+    SUBMISSION_VIDEO: "AWAITING_VIDEO_INTERVIEW",
+    SUBMISSION_QUIZ: "AWAITING_QUIZ_SUBMISSION",
+}
 
 
 class AppStates(Enum):

--- a/applications/models.py
+++ b/applications/models.py
@@ -200,7 +200,11 @@ class BootcampApplication(TimestampedModel):
     @property
     def integration_id(self):
         """
-        Return an integration id to be used by Hubspot
+        Return an integration id to be used by Hubspot as the unique deal id.
+        This is necessary because the integration id used to be based on PersonalPrice.id,
+        and going forward, not all applicants will have a PersonalPrice.  So hubspot deals
+        will be based on BootcampApplication instead and this requires that there be no
+        overlap in integration ids between new and old deals.
 
         Returns:
             str: the integration id

--- a/applications/models.py
+++ b/applications/models.py
@@ -197,6 +197,16 @@ class BootcampApplication(TimestampedModel):
             return not self.submissions.exclude(review_status=REVIEW_STATUS_APPROVED).exists()
         return False
 
+    @property
+    def integration_id(self):
+        """
+        Return an integration id to be used by Hubspot
+
+        Returns:
+            str: the integration id
+        """
+        return f"BootcampApplication-{self.id}"
+
     def __str__(self):
         return f"user='{self.user.email}', run='{self.bootcamp_run.title}', state={self.state}"
 

--- a/applications/signals.py
+++ b/applications/signals.py
@@ -1,5 +1,4 @@
 """Signals for application models"""
-import logging
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -7,8 +6,6 @@ from applications.models import BootcampApplication, ApplicationStepSubmission
 from hubspot.task_helpers import sync_hubspot_deal
 
 # pylint:disable=unused-argument
-
-log = logging.getLogger()
 
 
 @receiver(

--- a/applications/signals.py
+++ b/applications/signals.py
@@ -1,0 +1,15 @@
+"""Signals for application models"""
+import logging
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from applications.models import BootcampApplication
+from hubspot.task_helpers import sync_hubspot_deal
+
+log = logging.getLogger()
+
+
+@receiver(post_save, sender=BootcampApplication, dispatch_uid="bootcamp_application_post_save")
+def sync_deal_application(sender, instance, created, **kwargs):  # pylint:disable=unused-argument
+    """Sync application to hubspot"""
+    sync_hubspot_deal(instance)

--- a/applications/signals.py
+++ b/applications/signals.py
@@ -11,13 +11,19 @@ from hubspot.task_helpers import sync_hubspot_deal
 log = logging.getLogger()
 
 
-@receiver(post_save, sender=BootcampApplication, dispatch_uid="bootcamp_application_post_save")
+@receiver(
+    post_save, sender=BootcampApplication, dispatch_uid="bootcamp_application_post_save"
+)
 def sync_deal_application(sender, instance, created, **kwargs):
     """Sync application to hubspot"""
     sync_hubspot_deal(instance)
 
 
-@receiver(post_save, sender=ApplicationStepSubmission, dispatch_uid="application_step_submission_post_save")
+@receiver(
+    post_save,
+    sender=ApplicationStepSubmission,
+    dispatch_uid="application_step_submission_post_save",
+)
 def sync_deal_on_submission(sender, instance, created, **kwargs):
     """Sync application to hubspot when a submission is created"""
     if created:

--- a/applications/signals.py
+++ b/applications/signals.py
@@ -3,13 +3,22 @@ import logging
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from applications.models import BootcampApplication
+from applications.models import BootcampApplication, ApplicationStepSubmission
 from hubspot.task_helpers import sync_hubspot_deal
+
+# pylint:disable=unused-argument
 
 log = logging.getLogger()
 
 
 @receiver(post_save, sender=BootcampApplication, dispatch_uid="bootcamp_application_post_save")
-def sync_deal_application(sender, instance, created, **kwargs):  # pylint:disable=unused-argument
+def sync_deal_application(sender, instance, created, **kwargs):
     """Sync application to hubspot"""
     sync_hubspot_deal(instance)
+
+
+@receiver(post_save, sender=ApplicationStepSubmission, dispatch_uid="application_step_submission_post_save")
+def sync_deal_on_submission(sender, instance, created, **kwargs):
+    """Sync application to hubspot when a submission is created"""
+    if created:
+        sync_hubspot_deal(instance.bootcamp_application)

--- a/applications/signals_test.py
+++ b/applications/signals_test.py
@@ -1,0 +1,34 @@
+""" Tests for applications.signals"""
+import pytest
+
+from applications.factories import BootcampApplicationFactory, ApplicationStepSubmissionFactory
+
+pytestmark = pytest.mark.django_db
+
+# pylint: disable=redefined-outer-name
+
+@pytest.fixture
+def mock_hubspot(mocker):
+    """ Mock sync_hubspot_deal"""
+    return mocker.patch("applications.signals.sync_hubspot_deal")
+
+
+def test_application_signal(mock_hubspot):
+    """Test that hubspot is synced whenever a BootcampApplication is created/updated"""
+
+    application = BootcampApplicationFactory.create()
+    application.save()
+    application.save()
+    assert mock_hubspot.call_count == 3  # Once for creation, twice for updates
+    mock_hubspot.assert_any_call(application)
+
+
+def test_submission_signal(mock_hubspot):
+    """ Test that hubspot is synced whenever an ApplicationStepSubmission is created"""
+
+    submission = ApplicationStepSubmissionFactory.create()
+    submission.run_application_step.bootcamp_run = submission.bootcamp_application.bootcamp_run
+    submission.save()
+    submission.save()
+    assert mock_hubspot.call_count == 2 # Once for application creation, once for submission creation
+    mock_hubspot.assert_any_call(submission.bootcamp_application)

--- a/applications/signals_test.py
+++ b/applications/signals_test.py
@@ -1,11 +1,15 @@
 """ Tests for applications.signals"""
 import pytest
 
-from applications.factories import BootcampApplicationFactory, ApplicationStepSubmissionFactory
+from applications.factories import (
+    BootcampApplicationFactory,
+    ApplicationStepSubmissionFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
 # pylint: disable=redefined-outer-name
+
 
 @pytest.fixture
 def mock_hubspot(mocker):
@@ -27,8 +31,12 @@ def test_submission_signal(mock_hubspot):
     """ Test that hubspot is synced whenever an ApplicationStepSubmission is created"""
 
     submission = ApplicationStepSubmissionFactory.create()
-    submission.run_application_step.bootcamp_run = submission.bootcamp_application.bootcamp_run
+    submission.run_application_step.bootcamp_run = (
+        submission.bootcamp_application.bootcamp_run
+    )
     submission.save()
     submission.save()
-    assert mock_hubspot.call_count == 2 # Once for application creation, once for submission creation
+    assert (
+        mock_hubspot.call_count == 2
+    )  # Once for application creation, once for submission creation
     mock_hubspot.assert_any_call(submission.bootcamp_application)

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -101,7 +101,9 @@ def test_payment(mocker, client, user, bootcamp_run):
     """
     client.force_login(user)
     fake_payload = "fake_payload"
-    fake_order = 'fake_order'
+    fake_order = OrderFactory.create(
+        application=BootcampApplicationFactory.create(bootcamp_run=bootcamp_run, user=user)
+    )
     generate_cybersource_sa_payload_mock = mocker.patch(
         'ecommerce.views.generate_cybersource_sa_payload', autospec=True, return_value=fake_payload
     )

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -108,6 +108,7 @@ def home_page(wagtail_site):
 
 @pytest.fixture()
 def awaiting_submission_app():
+    """Fixture for testing application submission types"""
     application = BootcampApplicationFactory.create(
         state=AppStates.AWAITING_USER_SUBMISSIONS.value
     )

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -1,13 +1,19 @@
 """Common fixtures"""
 # pylint: disable=unused-argument, redefined-outer-name
+from types import SimpleNamespace
 
 import pytest
 import responses
+
 from django.test.client import Client
 from rest_framework.test import APIClient
 from wagtail.core.models import Site
 
+from applications.constants import AppStates, VALID_SUBMISSION_TYPE_CHOICES
+from applications.factories import BootcampApplicationFactory, ApplicationStepFactory, \
+    BootcampRunApplicationStepFactory, ApplicationStepSubmissionFactory
 from backends.edxorg import EdxOrgOAuth2
+from klasses.factories import InstallmentFactory
 from profiles.factories import UserFactory
 
 
@@ -98,3 +104,36 @@ def wagtail_site():
 def home_page(wagtail_site):
     """Fixture for the home page"""
     return wagtail_site.root_page
+
+
+@pytest.fixture()
+def awaiting_submission_app():
+    application = BootcampApplicationFactory.create(
+        state=AppStates.AWAITING_USER_SUBMISSIONS.value
+    )
+    installment = InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
+    app_steps = [
+        ApplicationStepFactory.create(
+            submission_type=VALID_SUBMISSION_TYPE_CHOICES[0][0]
+        ),
+        ApplicationStepFactory.create(
+            submission_type=VALID_SUBMISSION_TYPE_CHOICES[1][0]
+        ),
+    ]
+    run_steps = [
+        BootcampRunApplicationStepFactory.create(
+            bootcamp_run=application.bootcamp_run, application_step=app_steps[0]
+        ),
+        BootcampRunApplicationStepFactory.create(
+            bootcamp_run=application.bootcamp_run, application_step=app_steps[1]
+        ),
+    ]
+    ApplicationStepSubmissionFactory.create(
+        bootcamp_application=application, run_application_step=run_steps[0]
+    )
+
+    return SimpleNamespace(
+        application=application,
+        run_steps=run_steps,
+        installment=installment
+    )

--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -13,10 +13,11 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.utils import timezone
 
+from applications.models import BootcampApplication
 from hubspot.decorators import try_again
 from hubspot.serializers import HubspotProductSerializer, \
     HubspotDealSerializer, HubspotLineSerializer
-from klasses.models import Bootcamp, PersonalPrice
+from klasses.models import Bootcamp
 
 
 HUBSPOT_API_BASE_URL = "https://api.hubapi.com"
@@ -257,35 +258,35 @@ def make_product_sync_message(bootcamp_id):
     return [make_sync_message(bootcamp.id, properties)]
 
 
-def make_deal_sync_message(personal_price_id):
+def make_deal_sync_message(application_id):
     """
     Create the body of a sync message for a deal.
 
     Args:
-        personal_price_id (int): Personal Price id
+        application_id (int): BootcampApplication id
 
     Returns:
         list: dict containing serializable sync-message data
     """
-    personal_price = PersonalPrice.objects.get(id=personal_price_id)
-    properties = HubspotDealSerializer(instance=personal_price).data
-    return [make_sync_message(personal_price.id, properties)]
+    application = BootcampApplication.objects.get(id=application_id)
+    properties = HubspotDealSerializer(instance=application).data
+    return [make_sync_message(application.integration_id, properties)]
 
 
-def make_line_sync_message(personal_price_id):
+def make_line_sync_message(application_id):
     """
     Create the body of a sync message for a Line Item.
 
     Args:
-        personal_price_id (int): Personal Price id
+        application_id (int):BootcampApplication id
 
     Returns:
         list: dict containing serializable sync-message data
     """
-    personal_price = PersonalPrice.objects.get(id=personal_price_id)
-    properties = HubspotLineSerializer(instance=personal_price).data
+    application = BootcampApplication.objects.get(id=application_id)
+    properties = HubspotLineSerializer(instance=application).data
     properties['quantity'] = 1
-    return [make_sync_message(personal_price.id, properties)]
+    return [make_sync_message(application.integration_id, properties)]
 
 
 def sync_object_property(object_type, property_dict):

--- a/hubspot/api_test.py
+++ b/hubspot/api_test.py
@@ -161,7 +161,7 @@ def test_make_contact_sync_message():
 
 @pytest.mark.django_db
 def test_make_deal_sync_message():
-    """Test make_contact_sync_message serializes a profile and returns a properly formatted sync message"""
+    """Test make_deal_sync_message serializes a deal and returns a properly formatted sync message"""
     application = OrderFactory.create().application
     InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
     serialized_app = HubspotDealSerializer(application).data
@@ -177,7 +177,7 @@ def test_make_deal_sync_message():
 
 @pytest.mark.django_db
 def test_make_line_sync_message():
-    """Test make_contact_sync_message serializes a profile and returns a properly formatted sync message"""
+    """Test make_line_sync_message serializes a line and returns a properly formatted sync message"""
     application = OrderFactory.create().application
     InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
     serialized_line = HubspotLineSerializer(application).data

--- a/hubspot/conftest.py
+++ b/hubspot/conftest.py
@@ -7,7 +7,11 @@ from types import SimpleNamespace
 import pytz
 from django.conf import settings
 import pytest
+
+from applications.factories import BootcampRunApplicationStepFactory, BootcampApplicationFactory, \
+    ApplicationStepSubmissionFactory
 from hubspot.api import hubspot_timestamp
+from klasses.factories import BootcampRunFactory
 
 TIMESTAMPS = [
     datetime(2017, 1, 1, tzinfo=pytz.utc),
@@ -130,3 +134,19 @@ def mock_hubspot_request(mocker):
 def mock_hubspot_api_request(mocker):
     """Mock the send hubspot request method"""
     yield mocker.patch("hubspot.api.send_hubspot_request")
+
+
+@pytest.fixture
+def application_data():
+    """Fixture for a bootcamp application and related data"""
+    bootcamp_run = BootcampRunFactory.create()
+    run_steps = BootcampRunApplicationStepFactory.create_batch(3, bootcamp_run=bootcamp_run)
+    application = BootcampApplicationFactory(
+        bootcamp_run=bootcamp_run
+    )
+    submission = ApplicationStepSubmissionFactory(bootcamp_application=application, run_application_step=run_steps[0])
+    return SimpleNamespace(
+        application=application,
+        run_steps=run_steps,
+        submission=submission
+    )

--- a/hubspot/conftest.py
+++ b/hubspot/conftest.py
@@ -7,11 +7,7 @@ from types import SimpleNamespace
 import pytz
 from django.conf import settings
 import pytest
-
-from applications.factories import BootcampRunApplicationStepFactory, BootcampApplicationFactory, \
-    ApplicationStepSubmissionFactory
 from hubspot.api import hubspot_timestamp
-from klasses.factories import BootcampRunFactory
 
 TIMESTAMPS = [
     datetime(2017, 1, 1, tzinfo=pytz.utc),
@@ -134,19 +130,3 @@ def mock_hubspot_request(mocker):
 def mock_hubspot_api_request(mocker):
     """Mock the send hubspot request method"""
     yield mocker.patch("hubspot.api.send_hubspot_request")
-
-
-@pytest.fixture
-def application_data():
-    """Fixture for a bootcamp application and related data"""
-    bootcamp_run = BootcampRunFactory.create()
-    run_steps = BootcampRunApplicationStepFactory.create_batch(3, bootcamp_run=bootcamp_run)
-    application = BootcampApplicationFactory(
-        bootcamp_run=bootcamp_run
-    )
-    submission = ApplicationStepSubmissionFactory(bootcamp_application=application, run_application_step=run_steps[0])
-    return SimpleNamespace(
-        application=application,
-        run_steps=run_steps,
-        submission=submission
-    )

--- a/hubspot/management/commands/sync_hubspot.py
+++ b/hubspot/management/commands/sync_hubspot.py
@@ -5,13 +5,14 @@ and Line Items
 from django.contrib.auth.models import User
 from django.core.management import BaseCommand
 
+from applications.models import BootcampApplication
 from hubspot.api import (
     make_contact_sync_message,
     make_product_sync_message,
     make_deal_sync_message,
     make_line_sync_message)
 from hubspot.tasks import sync_bulk_with_hubspot
-from klasses.models import PersonalPrice, Bootcamp
+from klasses.models import Bootcamp
 
 
 class Command(BaseCommand):
@@ -66,8 +67,8 @@ class Command(BaseCommand):
         and the ecommerce Order
         """
         print("  Syncing orders with hubspot deals...")
-        self.bulk_sync_model(PersonalPrice.objects.all(), make_deal_sync_message, "DEAL")
-        self.bulk_sync_model(PersonalPrice.objects.all(), make_line_sync_message, "LINE_ITEM")
+        self.bulk_sync_model(BootcampApplication.objects.all(), make_deal_sync_message, "DEAL")
+        self.bulk_sync_model(BootcampApplication.objects.all(), make_line_sync_message, "LINE_ITEM")
         print("  Finished")
 
     def sync_all(self):

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -53,7 +53,7 @@ class HubspotDealSerializer(serializers.ModelSerializer):
     def get_application_stage(self, instance):
         """Get the application stage"""
         state = instance.state
-        if state == AppStates.AWAITING_USER_SUBMISSIONS:
+        if state == AppStates.AWAITING_USER_SUBMISSIONS.value:
             submission_subquery = instance.submissions.all()
             next_step = (
                 instance.bootcamp_run.application_steps.exclude(

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -3,13 +3,8 @@ from decimal import Decimal
 
 import pytest
 
-from applications.constants import (
-    AppStates,
-    SUBMISSION_TYPE_STATE,
-)
-from applications.factories import (
-    BootcampApplicationFactory
-)
+from applications.constants import AppStates, SUBMISSION_TYPE_STATE
+from applications.factories import BootcampApplicationFactory
 from ecommerce.factories import OrderFactory, LineFactory
 from ecommerce.models import Order
 from hubspot.api import format_hubspot_id
@@ -43,9 +38,13 @@ def test_product_serializer():
 )
 def test_deal_serializer_with_personal_price(pay_amount, status):
     """Test that the HubspotDealSerializer correctly serializes a BootcampApplication w/personal price"""
-    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_PAYMENT.value)
+    application = BootcampApplicationFactory.create(
+        state=AppStates.AWAITING_PAYMENT.value
+    )
     personal_price = PersonalPriceFactory.create(
-        bootcamp_run=application.bootcamp_run, user=application.user, price=Decimal("50.00")
+        bootcamp_run=application.bootcamp_run,
+        user=application.user,
+        price=Decimal("50.00"),
     )
     serialized_data = {
         "application_stage": application.state,
@@ -53,14 +52,14 @@ def test_deal_serializer_with_personal_price(pay_amount, status):
         "price": personal_price.price.to_eng_string(),
         "purchaser": format_hubspot_id(application.user.profile.id),
         "name": f"Bootcamp-application-order-{application.id}",
-        "status": status
+        "status": status,
     }
     if pay_amount is not None:
         order = OrderFactory.create(
             application=application,
             total_price_paid=pay_amount,
             user=application.user,
-            status=Order.FULFILLED
+            status=Order.FULFILLED,
         )
         LineFactory.create(order=order, run_key=application.bootcamp_run.run_key)
         serialized_data["total_price_paid"] = pay_amount
@@ -71,7 +70,9 @@ def test_deal_serializer_with_personal_price(pay_amount, status):
 
 def test_deal_serializer_with_installment_price():
     """Test that the HubspotDealSerializer correctly serializes a BootcampApplication w/installment price"""
-    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_RESUME.value)
+    application = BootcampApplicationFactory.create(
+        state=AppStates.AWAITING_RESUME.value
+    )
     installment = InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
 
     serialized_data = {
@@ -88,7 +89,9 @@ def test_deal_serializer_with_installment_price():
 
 def test_deal_serializer_with_no_price():
     """Test that the HubspotDealSerializer correctly serializes a BootcampApplication w/no price"""
-    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_RESUME.value)
+    application = BootcampApplicationFactory.create(
+        state=AppStates.AWAITING_RESUME.value
+    )
 
     serialized_data = {
         "application_stage": application.state,
@@ -110,7 +113,9 @@ def test_deal_serializer_awaiting_submissions(awaiting_submission_app):
         ),
         "bootcamp_name": awaiting_submission_app.application.bootcamp_run.bootcamp.title,
         "price": awaiting_submission_app.installment.amount.to_eng_string(),
-        "purchaser": format_hubspot_id(awaiting_submission_app.application.user.profile.id),
+        "purchaser": format_hubspot_id(
+            awaiting_submission_app.application.user.profile.id
+        ),
         "name": f"Bootcamp-application-order-{awaiting_submission_app.application.id}",
         "status": "checkout_pending",
     }

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -47,7 +47,7 @@ def test_product_serializer():
 )
 def test_deal_serializer_with_personal_price(pay_amount, status):
     """Test that the HubspotDealSerializer correctly serializes a BootcampApplication w/personal price"""
-    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_PAYMENT)
+    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_PAYMENT.value)
     personal_price = PersonalPriceFactory.create(
         bootcamp_run=application.bootcamp_run, user=application.user, price=Decimal("50.00")
     )
@@ -75,7 +75,7 @@ def test_deal_serializer_with_personal_price(pay_amount, status):
 
 def test_deal_serializer_with_installment_price():
     """Test that the HubspotDealSerializer correctly serializes a BootcampApplication w/installment price"""
-    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_RESUME)
+    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_RESUME.value)
     installment = InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
 
     serialized_data = {
@@ -93,7 +93,7 @@ def test_deal_serializer_with_installment_price():
 def test_deal_serializer_awaiting_submissions():
     """Test that the HubspotDealSerializer correctly returns the correct application stage"""
     application = BootcampApplicationFactory.create(
-        state=AppStates.AWAITING_USER_SUBMISSIONS
+        state=AppStates.AWAITING_USER_SUBMISSIONS.value
     )
     installment = InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
     app_steps = [

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -2,13 +2,14 @@
 
 import pytest
 
-from applications.factories import BootcampApplicationFactory
+from applications.constants import AppStates, VALID_SUBMISSION_TYPE_CHOICES, SUBMISSION_TYPE_STATE
+from applications.factories import BootcampApplicationFactory, BootcampRunApplicationStepFactory, \
+    ApplicationStepSubmissionFactory, ApplicationStepFactory
 from hubspot.api import format_hubspot_id
 from hubspot.serializers import HubspotProductSerializer, HubspotDealSerializer, \
     HubspotLineSerializer
 from klasses.factories import PersonalPriceFactory, InstallmentFactory
 from klasses.models import Bootcamp
-from profiles.factories import ProfileFactory
 
 pytestmark = [pytest.mark.django_db]
 
@@ -23,10 +24,8 @@ def test_product_serializer():
 
 def test_deal_serializer_with_personal_price():
     """Test that the HubspotDealSerializer correctly serializes a BootcampApplication w/personal price"""
-    application = BootcampApplicationFactory.create()
+    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_PAYMENT)
     personal_price = PersonalPriceFactory.create(bootcamp_run=application.bootcamp_run, user=application.user)
-    profile = ProfileFactory.create()
-    application.user.profile = profile
 
     serialized_data = {'application_stage': application.state,
                        'bootcamp_name': application.bootcamp_run.bootcamp.title,
@@ -40,12 +39,34 @@ def test_deal_serializer_with_personal_price():
 
 def test_deal_serializer_with_installment_price():
     """Test that the HubspotDealSerializer correctly serializes a BootcampApplication w/installment price"""
-    application = BootcampApplicationFactory.create()
+    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_RESUME)
     installment = InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
-    profile = ProfileFactory.create()
-    application.user.profile = profile
 
     serialized_data = {'application_stage': application.state,
+                       'bootcamp_name': application.bootcamp_run.bootcamp.title,
+                       'price': installment.amount.to_eng_string(),
+                       'purchaser': format_hubspot_id(application.user.profile.id),
+                       'name': f'Bootcamp-application-order-{application.id}',
+                       'status': 'checkout_pending'}
+    data = HubspotDealSerializer(instance=application).data
+    assert data == serialized_data
+
+
+def test_deal_serializer_awaiting_submissions():
+    """Test that the HubspotDealSerializer correctly returns the correct application stage"""
+    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_USER_SUBMISSIONS)
+    installment = InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
+    app_steps = [
+        ApplicationStepFactory.create(submission_type=VALID_SUBMISSION_TYPE_CHOICES[0][0]),
+        ApplicationStepFactory.create(submission_type=VALID_SUBMISSION_TYPE_CHOICES[1][0]),
+    ]
+    run_steps = [
+        BootcampRunApplicationStepFactory.create(bootcamp_run=application.bootcamp_run, application_step=app_steps[0]),
+        BootcampRunApplicationStepFactory.create(bootcamp_run=application.bootcamp_run, application_step=app_steps[1]),
+    ]
+    ApplicationStepSubmissionFactory(bootcamp_application=application, run_application_step=run_steps[0])
+
+    serialized_data = {'application_stage': SUBMISSION_TYPE_STATE.get(run_steps[1].application_step.submission_type),
                        'bootcamp_name': application.bootcamp_run.bootcamp.title,
                        'price': installment.amount.to_eng_string(),
                        'purchaser': format_hubspot_id(application.user.profile.id),

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -2,12 +2,23 @@
 
 import pytest
 
-from applications.constants import AppStates, VALID_SUBMISSION_TYPE_CHOICES, SUBMISSION_TYPE_STATE
-from applications.factories import BootcampApplicationFactory, BootcampRunApplicationStepFactory, \
-    ApplicationStepSubmissionFactory, ApplicationStepFactory
+from applications.constants import (
+    AppStates,
+    VALID_SUBMISSION_TYPE_CHOICES,
+    SUBMISSION_TYPE_STATE,
+)
+from applications.factories import (
+    BootcampApplicationFactory,
+    BootcampRunApplicationStepFactory,
+    ApplicationStepSubmissionFactory,
+    ApplicationStepFactory,
+)
 from hubspot.api import format_hubspot_id
-from hubspot.serializers import HubspotProductSerializer, HubspotDealSerializer, \
-    HubspotLineSerializer
+from hubspot.serializers import (
+    HubspotProductSerializer,
+    HubspotDealSerializer,
+    HubspotLineSerializer,
+)
 from klasses.factories import PersonalPriceFactory, InstallmentFactory
 from klasses.models import Bootcamp
 
@@ -16,8 +27,8 @@ pytestmark = [pytest.mark.django_db]
 
 def test_product_serializer():
     """Test that the HubspotProductSerializer correctly serializes a Bootcamp"""
-    bootcamp = Bootcamp.objects.create(title='test bootcamp 123')
-    serialized_data = {'title': bootcamp.title}
+    bootcamp = Bootcamp.objects.create(title="test bootcamp 123")
+    serialized_data = {"title": bootcamp.title}
     data = HubspotProductSerializer(instance=bootcamp).data
     assert data == serialized_data
 
@@ -25,14 +36,18 @@ def test_product_serializer():
 def test_deal_serializer_with_personal_price():
     """Test that the HubspotDealSerializer correctly serializes a BootcampApplication w/personal price"""
     application = BootcampApplicationFactory.create(state=AppStates.AWAITING_PAYMENT)
-    personal_price = PersonalPriceFactory.create(bootcamp_run=application.bootcamp_run, user=application.user)
+    personal_price = PersonalPriceFactory.create(
+        bootcamp_run=application.bootcamp_run, user=application.user
+    )
 
-    serialized_data = {'application_stage': application.state,
-                       'bootcamp_name': application.bootcamp_run.bootcamp.title,
-                       'price': personal_price.price.to_eng_string(),
-                       'purchaser': format_hubspot_id(application.user.profile.id),
-                       'name': f'Bootcamp-application-order-{application.id}',
-                       'status': 'checkout_pending'}
+    serialized_data = {
+        "application_stage": application.state,
+        "bootcamp_name": application.bootcamp_run.bootcamp.title,
+        "price": personal_price.price.to_eng_string(),
+        "purchaser": format_hubspot_id(application.user.profile.id),
+        "name": f"Bootcamp-application-order-{application.id}",
+        "status": "checkout_pending",
+    }
     data = HubspotDealSerializer(instance=application).data
     assert data == serialized_data
 
@@ -42,36 +57,54 @@ def test_deal_serializer_with_installment_price():
     application = BootcampApplicationFactory.create(state=AppStates.AWAITING_RESUME)
     installment = InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
 
-    serialized_data = {'application_stage': application.state,
-                       'bootcamp_name': application.bootcamp_run.bootcamp.title,
-                       'price': installment.amount.to_eng_string(),
-                       'purchaser': format_hubspot_id(application.user.profile.id),
-                       'name': f'Bootcamp-application-order-{application.id}',
-                       'status': 'checkout_pending'}
+    serialized_data = {
+        "application_stage": application.state,
+        "bootcamp_name": application.bootcamp_run.bootcamp.title,
+        "price": installment.amount.to_eng_string(),
+        "purchaser": format_hubspot_id(application.user.profile.id),
+        "name": f"Bootcamp-application-order-{application.id}",
+        "status": "checkout_pending",
+    }
     data = HubspotDealSerializer(instance=application).data
     assert data == serialized_data
 
 
 def test_deal_serializer_awaiting_submissions():
     """Test that the HubspotDealSerializer correctly returns the correct application stage"""
-    application = BootcampApplicationFactory.create(state=AppStates.AWAITING_USER_SUBMISSIONS)
+    application = BootcampApplicationFactory.create(
+        state=AppStates.AWAITING_USER_SUBMISSIONS
+    )
     installment = InstallmentFactory.create(bootcamp_run=application.bootcamp_run)
     app_steps = [
-        ApplicationStepFactory.create(submission_type=VALID_SUBMISSION_TYPE_CHOICES[0][0]),
-        ApplicationStepFactory.create(submission_type=VALID_SUBMISSION_TYPE_CHOICES[1][0]),
+        ApplicationStepFactory.create(
+            submission_type=VALID_SUBMISSION_TYPE_CHOICES[0][0]
+        ),
+        ApplicationStepFactory.create(
+            submission_type=VALID_SUBMISSION_TYPE_CHOICES[1][0]
+        ),
     ]
     run_steps = [
-        BootcampRunApplicationStepFactory.create(bootcamp_run=application.bootcamp_run, application_step=app_steps[0]),
-        BootcampRunApplicationStepFactory.create(bootcamp_run=application.bootcamp_run, application_step=app_steps[1]),
+        BootcampRunApplicationStepFactory.create(
+            bootcamp_run=application.bootcamp_run, application_step=app_steps[0]
+        ),
+        BootcampRunApplicationStepFactory.create(
+            bootcamp_run=application.bootcamp_run, application_step=app_steps[1]
+        ),
     ]
-    ApplicationStepSubmissionFactory(bootcamp_application=application, run_application_step=run_steps[0])
+    ApplicationStepSubmissionFactory(
+        bootcamp_application=application, run_application_step=run_steps[0]
+    )
 
-    serialized_data = {'application_stage': SUBMISSION_TYPE_STATE.get(run_steps[1].application_step.submission_type),
-                       'bootcamp_name': application.bootcamp_run.bootcamp.title,
-                       'price': installment.amount.to_eng_string(),
-                       'purchaser': format_hubspot_id(application.user.profile.id),
-                       'name': f'Bootcamp-application-order-{application.id}',
-                       'status': 'checkout_pending'}
+    serialized_data = {
+        "application_stage": SUBMISSION_TYPE_STATE.get(
+            run_steps[1].application_step.submission_type
+        ),
+        "bootcamp_name": application.bootcamp_run.bootcamp.title,
+        "price": installment.amount.to_eng_string(),
+        "purchaser": format_hubspot_id(application.user.profile.id),
+        "name": f"Bootcamp-application-order-{application.id}",
+        "status": "checkout_pending",
+    }
     data = HubspotDealSerializer(instance=application).data
     assert data == serialized_data
 
@@ -79,7 +112,9 @@ def test_deal_serializer_awaiting_submissions():
 def test_line_serializer():
     """Test that the HubspotLineSerializer correctly serializes a PersonalPrice"""
     application = BootcampApplicationFactory.create()
-    serialized_data = {'order': format_hubspot_id(application.integration_id),
-                       'product': format_hubspot_id(application.bootcamp_run.bootcamp_id)}
+    serialized_data = {
+        "order": format_hubspot_id(application.integration_id),
+        "product": format_hubspot_id(application.bootcamp_run.bootcamp_id),
+    }
     data = HubspotLineSerializer(instance=application).data
     assert data == serialized_data

--- a/hubspot/task_helpers.py
+++ b/hubspot/task_helpers.py
@@ -3,7 +3,6 @@ import logging
 
 from django.conf import settings
 
-from applications.models import BootcampApplication
 from hubspot import tasks
 
 
@@ -42,7 +41,7 @@ def sync_hubspot_deal_from_order(order):
     """
     try:
         sync_hubspot_deal(order.application)
-    except BootcampApplication.DoesNotExist:
+    except AttributeError:
         log.error("No matching BootcampApplication found for order %s", order.id)
 
 

--- a/hubspot/task_helpers.py
+++ b/hubspot/task_helpers.py
@@ -1,9 +1,13 @@
 """ Task helper functions for ecommerce """
+import logging
+
 from django.conf import settings
 
-from ecommerce.models import Order
+from applications.models import BootcampApplication
 from hubspot import tasks
-from klasses.models import PersonalPrice
+
+
+log = logging.getLogger(__name__)
 
 
 def sync_hubspot_user(user):
@@ -17,16 +21,16 @@ def sync_hubspot_user(user):
         tasks.sync_contact_with_hubspot.delay(user.id)
 
 
-def sync_hubspot_deal(personal_price):
+def sync_hubspot_deal(application):
     """
     Trigger celery task to sync a deal to Hubspot
 
     Args:
-        personal_price (PersonalPrice): The PersonalPrice to sync
+        application (BootcampApplication): The BootcampApplication to sync
     """
     if settings.HUBSPOT_API_KEY:
-        tasks.sync_deal_with_hubspot.delay(personal_price.id)
-        tasks.sync_line_with_hubspot.delay(personal_price.id)
+        tasks.sync_deal_with_hubspot.delay(application.id)
+        tasks.sync_line_with_hubspot.delay(application.id)
 
 
 def sync_hubspot_deal_from_order(order):
@@ -36,19 +40,10 @@ def sync_hubspot_deal_from_order(order):
     Args:
         order (Order): The order to sync
     """
-
-    if not isinstance(order, Order):
-        # Some tests cause order to be a string.
-        return
-
     try:
-        personal_price = PersonalPrice.objects.get(
-            user=order.user,
-            bootcamp_run=order.get_bootcamp_run()  # Under tha assumption that its one klass per order
-        )
-        sync_hubspot_deal(personal_price)
-    except PersonalPrice.DoesNotExist:
-        pass
+        sync_hubspot_deal(order.application)
+    except BootcampApplication.DoesNotExist:
+        log.error("No matching BootcampApplication found for order %s", order.id)
 
 
 def sync_hubspot_product(bootcamp):

--- a/hubspot/task_helpers_test.py
+++ b/hubspot/task_helpers_test.py
@@ -1,0 +1,96 @@
+"""
+Tests for hubspot task_helpers
+"""
+import pytest
+
+from applications.models import BootcampApplication
+from ecommerce.models import Order
+from hubspot.task_helpers import (
+    sync_hubspot_deal,
+    sync_hubspot_deal_from_order,
+    sync_hubspot_user,
+    sync_hubspot_product,
+)
+from klasses.factories import BootcampFactory
+
+pytestmark = pytest.mark.django_db
+
+# pylint:disable=redefined-outer-name
+
+
+@pytest.fixture
+def mock_hubspot(mocker):
+    """Mock hubspot tasks"""
+    return mocker.patch("hubspot.task_helpers.tasks", autospec=True)
+
+
+@pytest.mark.parametrize("hubspot_key", [None, "abc"])
+def test_sync_hubspot_deal(settings, mock_hubspot, hubspot_key):
+    """ sync_hubspot_deal task helper should call tasks if an API key is present """
+    settings.HUBSPOT_API_KEY = hubspot_key
+    application = BootcampApplication()
+    sync_hubspot_deal(application)
+    if hubspot_key is not None:
+        mock_hubspot.sync_deal_with_hubspot.delay.assert_called_once_with(
+            application.id
+        )
+        mock_hubspot.sync_line_with_hubspot.delay.assert_called_once_with(
+            application.id
+        )
+    else:
+        mock_hubspot.sync_deal_with_hubspot.delay.assert_not_called()
+        mock_hubspot.sync_line_with_hubspot.delay.assert_not_called()
+
+
+@pytest.mark.parametrize("hubspot_key", [None, "abc"])
+def test_sync_hubspot_deal_from_order(settings, mock_hubspot, hubspot_key):
+    """ sync_hubspot_deal_from_order task helper should call tasks if an API key is present """
+    settings.HUBSPOT_API_KEY = hubspot_key
+    order = Order(application=BootcampApplication())
+    sync_hubspot_deal_from_order(order)
+    if hubspot_key is not None:
+        mock_hubspot.sync_deal_with_hubspot.delay.assert_called_once_with(
+            order.application.id
+        )
+        mock_hubspot.sync_line_with_hubspot.delay.assert_called_once_with(
+            order.application.id
+        )
+    else:
+        mock_hubspot.sync_deal_with_hubspot.delay.assert_not_called()
+        mock_hubspot.sync_line_with_hubspot.delay.assert_not_called()
+
+
+def test_sync_hubspot_deal_from_order_no_application(settings, mocker):
+    """ sync_hubspot_deal_from_order should log an error if no application exists for the order """
+    settings.HUBSPOT_API_KEY = "abc"
+    mock_log = mocker.patch("hubspot.task_helpers.log.error")
+    order = Order(application=None, id=2)
+    sync_hubspot_deal_from_order(order)
+    mock_log.assert_called_once_with(
+        "No matching BootcampApplication found for order %s", order.id
+    )
+
+
+@pytest.mark.parametrize("hubspot_key", [None, "abc"])
+def test_sync_hubspot_user(settings, mock_hubspot, hubspot_key, user):
+    """ sync_hubspot_user helper should call task if an API key is present """
+    settings.HUBSPOT_API_KEY = hubspot_key
+    sync_hubspot_user(user)
+    if hubspot_key is not None:
+        mock_hubspot.sync_contact_with_hubspot.delay.assert_called_once_with(user.id)
+    else:
+        mock_hubspot.sync_contact_with_hubspot.delay.assert_not_called()
+
+
+@pytest.mark.parametrize("hubspot_key", [None, "abc"])
+def test_sync_hubspot_product(settings, mock_hubspot, hubspot_key):
+    """ sync_hubspot_product helper should call task if an API key is present """
+    settings.HUBSPOT_API_KEY = hubspot_key
+    bootcamp = BootcampFactory.create()
+    sync_hubspot_product(bootcamp)
+    if hubspot_key is not None:
+        mock_hubspot.sync_product_with_hubspot.delay.assert_called_once_with(
+            bootcamp.id
+        )
+    else:
+        mock_hubspot.sync_product_with_hubspot.delay.assert_not_called()

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -47,9 +47,9 @@ def sync_product_with_hubspot(bootcamp_id):
 
 
 @app.task
-def sync_deal_with_hubspot(personal_price_id):
+def sync_deal_with_hubspot(application_id):
     """Send a sync-message to sync a personal price with a hubspot deal"""
-    body = make_deal_sync_message(personal_price_id)
+    body = make_deal_sync_message(application_id)
     response = send_hubspot_request("DEAL", HUBSPOT_SYNC_URL, "PUT", body=body)
     response.raise_for_status()
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes #545 
Closes #542 

#### What's this PR do?
- Refactors hubspot syncing code to base serialized messages on `BootcampApplication` instead of `PersonalPrice`
- Adds a signal to trigger the hubspot deal sync whenever a `BootcampApplication` is created or saved.
- Adds a signal to trigger the hubspot deal sync whenever an `ApplicationStepSubmission` is created (indicating that one of the application's required steps has been submitted).
- Sets the deal `application_stage` value on hubspot to `BootcampApplication.state` if it is anything other than `AWAITING_USER_SUBMISSIONS `.  Otherwise, sets it to either `AWAITING_VIDEO_INTERVIEW` or `AWAITING_QUIZ_SUBMISSION` depending on the first application step that doesn't have a submission yet.

#### How should this be manually tested?
- Populate cybersource and hubspot env values.
- If you've never done so before, run `manage.py sync_hubspot_data`.  It should complete without errors.  If you have any existing applications, they should show up in hubspot within a few minutes.  
- Manually create an application or two via django admin or shell and save.  The applications should show up under hubspot deals within a few minutes, with an associated contact and product.
- Update the state of an application and save.  The change should be reflected in hubspot.
- Associate a fulfilled order with an application via django admin or shell
- Run `manage.py sync_hubspot_data` again, it should complete without errors and the hubspot deal 'Total price paid' should reflect the order amount.

#### Any background context you want to provide?
Currently, when paying for a run, there is no code that associates the order with the application or ensures that the user has an application before making a payment.  My assumption is that this will be handled later as a separate issue.

