### PR TITLE
Fix DEFAULT_FILE_STORAGE value for S3 backend

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -635,7 +635,7 @@ if BOOTCAMP_ECOMMERCE_USE_S3 and (
         "AWS_STORAGE_BUCKET_NAME"
     )
 if BOOTCAMP_ECOMMERCE_USE_S3:
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 # Celery
 REDISCLOUD_URL = get_string(


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes the value of `DEFAULT_FILE_STORAGE` when S3 is in use as a backend. There was a typo in the module name string.

#### How should this be manually tested?
Try to upload media, it should serve as expected.
