### PR TITLE
Change PaymentView to accept an application id instead of a run key

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -11,12 +11,10 @@ import uuid
 
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Q
 from django_fsm import TransitionNotAllowed
 import pytz
 from rest_framework.exceptions import ValidationError
 
-from applications.constants import AppStates
 from backends.utils import get_social_username
 from klasses.models import BootcampRun, BootcampRunEnrollment
 from klasses.serializers import InstallmentSerializer
@@ -39,28 +37,20 @@ _REFERENCE_NUMBER_PREFIX = 'BOOTCAMP-'
 
 
 @transaction.atomic
-def create_unfulfilled_order(user, run_key, payment_amount):
+def create_unfulfilled_order(*, application, payment_amount):
     """
     Create a new Order which is not fulfilled for a bootcamp run.
 
     Args:
-        user (User):
-            The purchaser of the bootcamp run
-        run_key (int):
-            A bootcamp run key, a class within a bootcamp
+        application (BootcampApplication):
+            A bootcamp application
         payment_amount (Decimal): The payment of the user
     Returns:
         Order: A newly created Order for the bootcamp run
     """
     payment_amount = Decimal(payment_amount)
-    try:
-        bootcamp_run = BootcampRun.objects.get(run_key=run_key)
-    except BootcampRun.DoesNotExist:
-        # In the near future we should do other checking here based on information from Bootcamp REST API
-        raise ValidationError("Incorrect bootcamp run key {}".format(run_key))
-
-    if not bootcamp_run.run_key in payable_bootcamp_run_keys(user):
-        raise ValidationError("User is unable to pay for bootcamp run {}".format(run_key))
+    bootcamp_run = application.bootcamp_run
+    run_key = bootcamp_run.run_key
 
     if payment_amount <= 0:
         raise ValidationError("Payment is less than or equal to zero")
@@ -68,7 +58,8 @@ def create_unfulfilled_order(user, run_key, payment_amount):
     order = Order.objects.create(
         status=Order.CREATED,
         total_price_paid=payment_amount,
-        user=user,
+        user=application.user,
+        application=application,
     )
     Line.objects.create(
         order=order,
@@ -76,7 +67,7 @@ def create_unfulfilled_order(user, run_key, payment_amount):
         description='Installment for {}'.format(bootcamp_run.title),
         price=payment_amount,
     )
-    order.save_and_log(user)
+    order.save_and_log(application.user)
     return order
 
 
@@ -296,12 +287,6 @@ def handle_rejected_order(*, order, decision):
 def serialize_user_bootcamp_runs(user):
     """
     Returns serialized bootcamp run and payment details for a user.
-    Note, this function will combine the bootcamp runs for orders already placed and
-    the bootcamp runs from the remote authorization system.
-
-    This is to prevent that a failure of the remote system will prevent the user to
-    see the payments already done. In this case, though, the user will not be authorized to make additional
-    payments but just to see the ones already made.
 
     Args:
         user (User): a user
@@ -309,17 +294,10 @@ def serialize_user_bootcamp_runs(user):
     Returns:
         list: list of dictionaries describing a bootcamp run and payments for it by the user
     """
-    # extract the payments already done.
-    run_keys_in_lines = list(Line.fulfilled_for_user(user).values_list(
-        'run_key', flat=True).distinct())
-
-    all_bootcamp_run_keys = list(set(run_keys_in_lines).union(set(payable_bootcamp_run_keys(user))))
-    bootcamp_runs_qset = (
-        BootcampRun.objects.filter(run_key__in=all_bootcamp_run_keys)
-        .select_related('bootcamp').order_by('run_key')
-    )
-
-    return [serialize_user_bootcamp_run(user, bootcamp_run) for bootcamp_run in bootcamp_runs_qset]
+    return [
+        serialize_user_bootcamp_run(user, bootcamp_run) for bootcamp_run in
+        BootcampRun.objects.filter(applications__user=user).select_related('bootcamp').order_by('run_key')
+    ]
 
 
 def serialize_user_bootcamp_run(user, bootcamp_run):
@@ -343,27 +321,8 @@ def serialize_user_bootcamp_run(user, bootcamp_run):
         "start_date": bootcamp_run.start_date,
         "end_date": bootcamp_run.end_date,
         "price": bootcamp_run.personal_price(user),
-        "is_user_eligible_to_pay": bootcamp_run.run_key in payable_bootcamp_run_keys(user),
+        "is_user_eligible_to_pay": True,
         "total_paid": Line.total_paid_for_bootcamp_run(user, bootcamp_run.run_key).get('total') or Decimal('0.00'),
         "payments": LineSerializer(Line.for_user_bootcamp_run(user, bootcamp_run.run_key), many=True).data,
         "installments": InstallmentSerializer(bootcamp_run.installment_set.order_by('deadline'), many=True).data,
     }
-
-
-def payable_bootcamp_run_keys(user):
-    """
-    Fetches a list of bootcamp run keys for which the user has applied
-
-    Args:
-        user (User): a user
-
-    Returns:
-        list of int: bootcamp run keys the user has applied for
-
-    """
-    return (
-        BootcampRun.objects.prefetch_related("applications")
-            .filter((Q(applications__user=user) & Q(applications__state=AppStates.AWAITING_PAYMENT.value)) |
-                    Q(personal_prices__user=user))
-            .values_list("run_key", flat=True)
-    )

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -321,7 +321,6 @@ def serialize_user_bootcamp_run(user, bootcamp_run):
         "start_date": bootcamp_run.start_date,
         "end_date": bootcamp_run.end_date,
         "price": bootcamp_run.personal_price(user),
-        "is_user_eligible_to_pay": True,
         "total_paid": Line.total_paid_for_bootcamp_run(user, bootcamp_run.run_key).get('total') or Decimal('0.00'),
         "payments": LineSerializer(Line.for_user_bootcamp_run(user, bootcamp_run.run_key), many=True).data,
         "installments": InstallmentSerializer(bootcamp_run.installment_set.order_by('deadline'), many=True).data,

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -279,7 +279,6 @@ def test_serialize_user_run_paid(test_data):
         "start_date": run_paid.start_date,
         "end_date": run_paid.end_date,
         "price": run_paid.personal_price(user),
-        "is_user_eligible_to_pay": True,
         "total_paid": Decimal('627.34'),
         "payments": LineSerializer(Line.for_user_bootcamp_run(user, run_paid.run_key), many=True).data,
         "installments": InstallmentSerializer(
@@ -301,7 +300,6 @@ def test_serialize_user_run_not_paid(test_data):
         "start_date": run_not_paid.start_date,
         "end_date": run_not_paid.end_date,
         "price": run_not_paid.personal_price(user),
-        "is_user_eligible_to_pay": True,
         "total_paid": Decimal('0.00'),
         "payments": [],
         "installments": InstallmentSerializer(
@@ -323,7 +321,6 @@ def test_serialize_user_bootcamp_runs(test_data):
             "start_date": run_paid.start_date,
             "end_date": run_paid.end_date,
             "price": run_paid.price,
-            "is_user_eligible_to_pay": True,
             "total_paid": Decimal('627.34'),
             "payments": LineSerializer(Line.for_user_bootcamp_run(user, run_paid.run_key), many=True).data,
             "installments": InstallmentSerializer(
@@ -336,7 +333,6 @@ def test_serialize_user_bootcamp_runs(test_data):
             "start_date": run_not_paid.start_date,
             "end_date": run_not_paid.end_date,
             "price": run_not_paid.price,
-            "is_user_eligible_to_pay": True,
             "total_paid": Decimal('0.00'),
             "payments": [],
             "installments": InstallmentSerializer(

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from decimal import Decimal
 import hashlib
 import hmac
-from unittest.mock import patch
 
 import pytest
 import pytz
@@ -15,7 +14,6 @@ from rest_framework.exceptions import ValidationError
 from applications.constants import AppStates
 from applications.factories import BootcampApplicationFactory
 from ecommerce.api import (
-    create_unfulfilled_order,
     generate_cybersource_sa_payload,
     generate_cybersource_sa_signature,
     get_new_order_by_reference_number,
@@ -73,18 +71,6 @@ def test_less_or_equal_to_zero(application, payment_amount):
         create_test_order(application, payment_amount, fulfilled=False)
 
     assert ex.value.args[0] == 'Payment is less than or equal to zero'
-
-
-def test_not_eligible_to_pay(user, bootcamp_run):
-    """
-    A validation error should be thrown if the user is not eligible to pay
-    """
-    with patch(
-        'ecommerce.api.payable_bootcamp_run_keys',
-        return_value=[],
-    ), pytest.raises(ValidationError) as ex:
-        create_unfulfilled_order(user, bootcamp_run.run_key, 123)
-    assert ex.value.args[0] == "User is unable to pay for bootcamp run {}".format(bootcamp_run.run_key)
 
 
 CYBERSOURCE_ACCESS_KEY = 'access'
@@ -358,21 +344,3 @@ def test_serialize_user_bootcamp_runs(test_data):
         }
     ]
     assert sorted(expected_ret, key=lambda x: x['run_key']) == serialize_user_bootcamp_runs(user)
-
-
-def test_serialize_user_bootcamp_runs_paid_not_payable(test_data, mocker):
-    """
-    Test for serialize_user_bootcamp_runs in case the user is not eligible to pay but she has already paid for the
-    bootcamp run
-    """
-    user, run_paid, run_not_paid = test_data
-    mocker.patch(
-        'ecommerce.api.payable_bootcamp_run_keys',
-        return_value=[run_not_paid.run_key],
-    )
-    res = serialize_user_bootcamp_runs(user)
-    assert run_paid.run_key in [bootcamp_run['run_key'] for bootcamp_run in res]
-    for bootcamp_run in res:
-        if bootcamp_run['run_key'] == run_paid.run_key:
-            break
-    assert bootcamp_run['is_user_eligible_to_pay'] is False  # pylint: disable=undefined-loop-variable

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -11,7 +11,7 @@ class PaymentSerializer(serializers.Serializer):
     Serializer for payment API, used to do basic validation.
     """
     payment_amount = serializers.DecimalField(max_digits=20, decimal_places=2, min_value=0.01)
-    run_key = serializers.IntegerField()
+    application_id = serializers.IntegerField()
 
 
 class OrderPartialSerializer(serializers.ModelSerializer):

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -25,10 +25,10 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize("payload, is_valid", [
-    [{"payment_amount": "345", "run_key": 3}, True],
-    [{"payment_amount": "-3", "run_key": 3}, False],
+    [{"payment_amount": "345", "application_id": 3}, True],
+    [{"payment_amount": "-3", "application_id": 3}, False],
     [{"payment_amount": "345"}, False],
-    [{"run_key": "345"}, False],
+    [{"application_id": "345"}, False],
 ])
 def test_validation(payload, is_valid):
     """

--- a/ecommerce/test_utils.py
+++ b/ecommerce/test_utils.py
@@ -1,6 +1,4 @@
 """Functions for testing ecommerce"""
-from unittest.mock import patch
-
 from applications.constants import AppStates
 from backends.pipeline_api import EdxOrgOAuth2
 from ecommerce.api import create_unfulfilled_order
@@ -37,15 +35,9 @@ def create_purchasable_bootcamp_run():
 
 def create_test_order(application, payment, *, fulfilled):
     """
-    Pass through arguments to create_unfulfilled_order and mock payable_bootcamp_run_keys
+    Pass through arguments to create_unfulfilled_order
     """
-    run_key = application.bootcamp_run.run_key
-    user = application.user
-    with patch(
-        'ecommerce.api.payable_bootcamp_run_keys',
-        return_value=[run_key],
-    ):
-        order = create_unfulfilled_order(user, run_key, payment)
+    order = create_unfulfilled_order(application=application, payment_amount=payment)
     order.application = application
     if fulfilled:
         order.status = Order.FULFILLED

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -331,7 +331,6 @@ BOOTCAMP_RUN_FIELDS = [
     'payments',
     'bootcamp_run_name',
     'display_title',
-    'is_user_eligible_to_pay',
     'price',
 ]
 

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -9,7 +9,7 @@ import faker
 import pytest
 from rest_framework import status as statuses
 
-from applications.constants import AppStates
+from applications.constants import AppStates, VALID_APP_STATE_CHOICES
 from applications.factories import BootcampApplicationFactory
 from backends.edxorg import EdxOrgOAuth2
 from ecommerce.api import make_reference_id
@@ -81,7 +81,7 @@ def test_using_serializer_validation(client):
     client.force_login(user)
     resp = client.post(payment_url, data={
         "payment_amount": "-1",
-        "run_key": 3,
+        "application_id": 3,
     })
     assert resp.status_code == statuses.HTTP_400_BAD_REQUEST
     assert resp.json() == {
@@ -95,7 +95,7 @@ def test_login_required(client):
     assert resp.status_code == statuses.HTTP_403_FORBIDDEN
 
 
-def test_payment(mocker, client, user, bootcamp_run):
+def test_payment(mocker, client, user, bootcamp_run, application):
     """
     If a user POSTs to the payment API an unfulfilled order should be created
     """
@@ -112,7 +112,7 @@ def test_payment(mocker, client, user, bootcamp_run):
     )
     resp = client.post(reverse('create-payment'), data={
         "payment_amount": bootcamp_run.price,
-        "run_key": bootcamp_run.run_key,
+        "application_id": application.id,
     })
     assert resp.status_code == statuses.HTTP_200_OK
     assert resp.json() == {
@@ -122,7 +122,26 @@ def test_payment(mocker, client, user, bootcamp_run):
     assert generate_cybersource_sa_payload_mock.call_count == 1
     generate_cybersource_sa_payload_mock.assert_any_call(fake_order, "http://testserver/pay/")
     assert create_unfulfilled_order_mock.call_count == 1
-    create_unfulfilled_order_mock.assert_any_call(user, bootcamp_run.run_key, bootcamp_run.price)
+    create_unfulfilled_order_mock.assert_any_call(application=application, payment_amount=bootcamp_run.price)
+
+
+@pytest.mark.parametrize("state", [
+    state for state, _ in VALID_APP_STATE_CHOICES if state != AppStates.AWAITING_PAYMENT.value
+])
+def test_payment_invalid_state(client, state, application, user, bootcamp_run):
+    """
+    A user should only be able to pay if the application state is AWAITING_PAYMENT
+    """
+    application.state = state
+    application.save()
+
+    client.force_login(user)
+    resp = client.post(reverse('create-payment'), data={
+        "payment_amount": bootcamp_run.price,
+        "application_id": application.id,
+    })
+    assert resp.status_code == statuses.HTTP_400_BAD_REQUEST
+    assert resp.json() == ["Invalid application state"]
 
 
 # pylint: disable=too-many-arguments
@@ -415,43 +434,6 @@ def test_bootcamp_run_list(test_data, client):
     assert len(response_json) == 1
     for resp in response_json:
         assert sorted(list(resp.keys())) == sorted(BOOTCAMP_RUN_FIELDS)
-
-
-def test_bootcamp_run_list_with_no_authorized_runs(test_data, client, mocker):
-    """
-    The view returns an empty list if no authorized bootcamp runs for the user are found
-    """
-    user, _, _ = test_data
-    mocker.patch(
-        'ecommerce.api.payable_bootcamp_run_keys',
-        return_value=[],
-    )
-    bootcamp_run_list_url = reverse('bootcamp-run-list', kwargs={'username': user.username})
-    client.force_login(user)
-
-    response = client.get(bootcamp_run_list_url)
-    assert response.status_code == statuses.HTTP_200_OK
-    assert response.json() == []
-
-
-def test_bootcamp_run_list_paid_with_no_authorized_runs(test_data, fulfilled_order, client, mocker):
-    """
-    The view returns the paid bootcamp runs even if if no authorized bootcamp runs for the user are found
-    """
-    user, _, bootcamp_run = test_data
-    mocker.patch(
-        'ecommerce.api.payable_bootcamp_run_keys',
-        return_value=[],
-    )
-
-    bootcamp_run_list_url = reverse('bootcamp-run-list', kwargs={'username': user.username})
-    client.force_login(user)
-    response = client.get(bootcamp_run_list_url)
-    assert response.status_code == statuses.HTTP_200_OK
-    response_json = response.json()
-    assert len(response_json) == 1
-    assert response_json[0]['run_key'] == bootcamp_run.run_key
-    assert response_json[0]['is_user_eligible_to_pay'] is False
 
 
 def test_user_bootcamp_run_statement(test_data, fulfilled_order, client):

--- a/static/js/factories/index.js
+++ b/static/js/factories/index.js
@@ -8,15 +8,14 @@ export const generateFakeRuns = (
   return _.times(numRuns, i => {
     const runKey = i + 1
     return {
-      bootcamp_run_name:       `Bootcamp Run ${i}`,
-      display_title:           `Bootcamp Run ${i}`,
-      run_key:                 runKey,
-      payment_deadline:        moment(),
-      total_paid:              hasPayment ? 100 : 0,
-      price:                   1000,
-      is_user_eligible_to_pay: true,
-      payments:                hasPayment ? [generateFakePayment({ runKey: runKey })] : [],
-      installments:            hasInstallment ? [generateFakeInstallment()] : []
+      bootcamp_run_name: `Bootcamp Run ${i}`,
+      display_title:     `Bootcamp Run ${i}`,
+      run_key:           runKey,
+      payment_deadline:  moment(),
+      total_paid:        hasPayment ? 100 : 0,
+      price:             1000,
+      payments:          hasPayment ? [generateFakePayment({ runKey: runKey })] : [],
+      installments:      hasInstallment ? [generateFakeInstallment()] : []
     }
   })
 }

--- a/static/js/flow/bootcampTypes.js
+++ b/static/js/flow/bootcampTypes.js
@@ -23,7 +23,6 @@ export type BootcampRun = {
   start_date: string,
   end_date: string,
   price: number,
-  is_user_eligible_to_pay: boolean,
   total_paid: number,
   payments: Array<Payment>,
   installments: Array<Installment>

--- a/static/js/pages/PaymentPage.js
+++ b/static/js/pages/PaymentPage.js
@@ -298,14 +298,10 @@ export class PaymentPage extends React.Component<Props> {
   }
 }
 
-const withPayableBootcampRuns = state => {
-  return {
-    ...state,
-    payableBootcampRunsData: R.filter(
-      R.propEq("is_user_eligible_to_pay", true)
-    )(state.bootcampRuns || [])
-  }
-}
+const withPayableBootcampRuns = state => ({
+  ...state,
+  payableBootcampRunsData: state.bootcampRuns || []
+})
 
 const withDerivedSelectedRun = state => {
   const {

--- a/static/js/pages/PaymentPage_test.js
+++ b/static/js/pages/PaymentPage_test.js
@@ -74,13 +74,6 @@ describe("PaymentPage", () => {
     )
   })
 
-  it("only passes payable fakeRuns to the Payment component", async () => {
-    fakeRuns[1].is_user_eligible_to_pay = false
-
-    const { inner } = await renderPage()
-    assert.lengthOf(inner.find("Payment").prop("payableBootcampRunsData"), 2)
-  })
-
   it("does not show the payment & payment history sections while API results are still pending", async () => {
     const { wrapper } = await renderPage({
       queries: {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #493 

#### What's this PR do?
 - Updates PaymentView to accept an application id instead of a run key
 - Add validation so that only `AWAITING_PAYMENT`. @gsidebo this isn't quite what the issue specifies. Are there other states which should be allowed?
 - Remove payable bootcamp run logic. All runs are now payable.

#### How should this be manually tested?
No front end portion yet so this will be difficult to manually test