### PR TITLE
Get user info from API on payment page

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -9,7 +9,6 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
 
 from main.templatetags.render_bundle import public_path
-from main.serializers import serialize_maybe_user
 
 
 def _serialize_js_settings(request):  # pylint: disable=missing-docstring
@@ -18,7 +17,6 @@ def _serialize_js_settings(request):  # pylint: disable=missing-docstring
         "environment": settings.ENVIRONMENT,
         "sentry_dsn": settings.SENTRY_DSN,
         "public_path": public_path(request),
-        "user": serialize_maybe_user(request.user),
         "zendesk_config": {
             "help_widget_enabled": settings.ZENDESK_CONFIG.get("HELP_WIDGET_ENABLED"),
             "help_widget_key": settings.ZENDESK_CONFIG.get("HELP_WIDGET_KEY"),

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -52,7 +52,6 @@ class TestViews(TestCase):
             "release_version": version,
             "sentry_dsn": "",
             "public_path": "/static/bundles/",
-            "user": None,
             "zendesk_config": {
                 "help_widget_enabled": False,
                 "help_widget_key": "fake_key",
@@ -109,7 +108,6 @@ class TestViews(TestCase):
             "release_version": version,
             "sentry_dsn": "",
             "public_path": "/static/bundles/",
-            "user": {"full_name": self.user.profile.name, "username": None},
             "zendesk_config": {
                 "help_widget_enabled": False,
                 "help_widget_key": "fake_key",

--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -13,6 +13,7 @@ import {
 } from "../util/util"
 import type { UIState } from "../reducers/ui"
 import type { InputEvent } from "../flow/events"
+import type { HttpAuthResponse, User } from "../flow/authTypes"
 
 export const PAYMENT_CONFIRMATION_DIALOG = "paymentConfirmationDialog"
 const isVisible = R.propOr(false, PAYMENT_CONFIRMATION_DIALOG)
@@ -28,7 +29,8 @@ export default class Payment extends React.Component<*, void> {
     sendPayment: () => void,
     setPaymentAmount: (event: InputEvent) => void,
     setSelectedBootcampRunKey: (event: InputEvent) => void,
-    showDialog: (dialogKey: string) => void
+    showDialog: (dialogKey: string) => void,
+    currentUser: () => Promise<HttpAuthResponse<User>>
   }
 
   getTotalOwedUpToInstallment = (nextInstallmentIndex: number): number => {
@@ -199,10 +201,14 @@ export default class Payment extends React.Component<*, void> {
   }
 
   render() {
-    const { payableBootcampRunsData, selectedBootcampRun } = this.props
+    const {
+      payableBootcampRunsData,
+      selectedBootcampRun,
+      currentUser
+    } = this.props
 
-    const welcomeMessage = !isNilOrBlank(SETTINGS.user.full_name) ? (
-      <h1 className="greeting">Hi {SETTINGS.user.full_name}!</h1>
+    const welcomeMessage = !isNilOrBlank(currentUser.profile.name) ? (
+      <h1 className="greeting">Hi {currentUser.profile.name}!</h1>
     ) : null
     let renderedRunChoice
     if (payableBootcampRunsData.length > 1) {

--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -207,10 +207,11 @@ export default class Payment extends React.Component<*, void> {
       currentUser
     } = this.props
 
-    // $FlowFixMe: an anon user shouldn't be here
     const welcomeMessage =
       currentUser &&
+      // $FlowFixMe: an anon user shouldn't be here
       currentUser.profile &&
+      // $FlowFixMe: an anon user shouldn't be here
       !isNilOrBlank(currentUser.profile.name) ? (
           <h1 className="greeting">Hi {currentUser.profile.name}!</h1>
         ) : null

--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -13,7 +13,7 @@ import {
 } from "../util/util"
 import type { UIState } from "../reducers/ui"
 import type { InputEvent } from "../flow/events"
-import type { HttpAuthResponse, User } from "../flow/authTypes"
+import type { CurrentUser } from "../flow/authTypes"
 
 export const PAYMENT_CONFIRMATION_DIALOG = "paymentConfirmationDialog"
 const isVisible = R.propOr(false, PAYMENT_CONFIRMATION_DIALOG)
@@ -30,7 +30,7 @@ export default class Payment extends React.Component<*, void> {
     setPaymentAmount: (event: InputEvent) => void,
     setSelectedBootcampRunKey: (event: InputEvent) => void,
     showDialog: (dialogKey: string) => void,
-    currentUser: () => Promise<HttpAuthResponse<User>>
+    currentUser: ?CurrentUser
   }
 
   getTotalOwedUpToInstallment = (nextInstallmentIndex: number): number => {
@@ -207,9 +207,13 @@ export default class Payment extends React.Component<*, void> {
       currentUser
     } = this.props
 
-    const welcomeMessage = !isNilOrBlank(currentUser.profile.name) ? (
-      <h1 className="greeting">Hi {currentUser.profile.name}!</h1>
-    ) : null
+    // $FlowFixMe: an anon user shouldn't be here
+    const welcomeMessage =
+      currentUser &&
+      currentUser.profile &&
+      !isNilOrBlank(currentUser.profile.name) ? (
+          <h1 className="greeting">Hi {currentUser.profile.name}!</h1>
+        ) : null
     let renderedRunChoice
     if (payableBootcampRunsData.length > 1) {
       renderedRunChoice = this.renderBootcampRunDropdown()

--- a/static/js/components/Payment_test.js
+++ b/static/js/components/Payment_test.js
@@ -12,6 +12,7 @@ import {
   formatReadableDate,
   formatReadableDateFromStr
 } from "../util/util"
+import { makeUser } from "../factories/user"
 
 describe("Payment", () => {
   const paymentSectionSelector = ".payment-section"
@@ -19,6 +20,7 @@ describe("Payment", () => {
   const runDropdownSelector = "select.klass-select"
   const welcomeMsgSelector = "h1.greeting"
   const runTitleSelector = ".klass-display-section .desc"
+  const user = makeUser()
 
   const defaultProps = {
     ui:                        {},
@@ -28,7 +30,8 @@ describe("Payment", () => {
     now:                       moment(),
     sendPayment:               () => {},
     setPaymentAmount:          () => {},
-    setSelectedBootcampRunKey: () => {}
+    setSelectedBootcampRunKey: () => {},
+    currentUser:               user
   }
 
   const renderPayment = (props = {}) => {
@@ -44,11 +47,11 @@ describe("Payment", () => {
     const fakeRuns = generateFakeRuns()
     const wrapper = renderPayment({ payableBootcampRunsData: fakeRuns })
     const welcomeMsg = wrapper.find(welcomeMsgSelector)
-    assert.include(welcomeMsg.text(), SETTINGS.user.full_name)
+    assert.include(welcomeMsg.text(), user.profile.name)
   })
 
   it("does not show the welcome message if the name of the user is blank", () => {
-    SETTINGS.user.full_name = ""
+    user.profile.name = ""
     const fakeRuns = generateFakeRuns()
     const wrapper = renderPayment({ payableBootcampRunsData: fakeRuns })
     assert.isFalse(wrapper.find(welcomeMsgSelector).exists())

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -65,6 +65,7 @@ export type UnusedCoupon = {
 }
 
 export type Profile = {
+  name: string,
   gender: string,
   birth_year: number,
   company: string,

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -1,9 +1,5 @@
 // @flow
 declare var SETTINGS: {
-  user: {
-    full_name: string,
-    username: string
-  },
   gaTrackingID: string,
   reactGaDebug: boolean,
   recaptchaKey: ?string,

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -7,12 +7,7 @@ import Adapter from "enzyme-adapter-react-16"
 
 configure({ adapter: new Adapter() })
 // Define globals we would usually get from Django
-const _createSettings = () => ({
-  user: {
-    full_name: "Jane Doe",
-    username:  "janedoe"
-  }
-})
+const _createSettings = () => ({})
 
 global.SETTINGS = _createSettings()
 global._testing = true

--- a/static/js/pages/PaymentPage.js
+++ b/static/js/pages/PaymentPage.js
@@ -66,9 +66,7 @@ export class PaymentPage extends React.Component<Props> {
   componentDidUpdate(prevProps: Props) {
     // This is meant to be an identity check, not a deep equality check. This shows whether we received an update
     // for enrollments based on the forceReload
-    if (
-      prevProps.bootcampRuns !== this.props.bootcampRuns
-    ) {
+    if (prevProps.bootcampRuns !== this.props.bootcampRuns) {
       this.handleOrderStatus()
     }
   }

--- a/static/js/pages/PaymentPage.js
+++ b/static/js/pages/PaymentPage.js
@@ -29,7 +29,7 @@ import type { UIState } from "../reducers/ui"
 import type { InputEvent } from "../flow/events"
 import type { PaymentPayload, PaymentResponse } from "../flow/ecommerceTypes"
 import type { BootcampRun, BootcampRunsResponse } from "../flow/bootcampTypes"
-import type { HttpAuthResponse, User } from "../flow/authTypes"
+import type { CurrentUser } from "../flow/authTypes"
 
 type Props = {
   ui: UIState,
@@ -50,7 +50,7 @@ type Props = {
   setTimeoutActive: (active: boolean) => void,
   setToastMessage: (payload: any) => void,
   showDialog: (dialogKey: string) => void,
-  currentUser: () => Promise<HttpAuthResponse<User>>
+  currentUser: ?CurrentUser
 }
 
 export class PaymentPage extends React.Component<Props> {
@@ -83,6 +83,7 @@ export class PaymentPage extends React.Component<Props> {
       currentUser
     } = this.props
     if (!bootcampRunsProcessing && currentUser) {
+      // $FlowFixMe: an anon user shouldn't end up here
       fetchBootcampRuns(currentUser.username)
     }
   }
@@ -180,7 +181,8 @@ export class PaymentPage extends React.Component<Props> {
         setTimeoutActive(false)
         const deadline = moment(ui.initialTime).add(2, "minutes")
         const now = moment()
-        if (now.isBefore(deadline)) {
+        // $FlowFixMe: an anon user won't end up here
+        if (now.isBefore(deadline) && currentUser.username) {
           fetchBootcampRuns(currentUser.username)
         } else {
           setToastMessage({

--- a/static/js/pages/PaymentPage_test.js
+++ b/static/js/pages/PaymentPage_test.js
@@ -8,22 +8,23 @@ import PaymentPage, { PaymentPage as InnerPaymentPage } from "./PaymentPage"
 import { PAYMENT_CONFIRMATION_DIALOG } from "../components/Payment"
 import * as util from "../util/util"
 import { generateFakeRuns } from "../factories"
+import { makeUser } from "../factories/user"
 import IntegrationTestHelper from "../util/integration_test_helper"
 
 describe("PaymentPage", () => {
   const paymentInputSelector = 'input[id="payment-amount"]'
   const paymentBtnSelector = "button.large-cta"
 
-  let helper, bootcampRunsUrl, fakeRuns, renderPage
+  let helper, bootcampRunsUrl, fakeRuns, renderPage, user
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
+    user = makeUser("user1")
+    helper.handleRequestStub
+      .withArgs("/api/v0/me/")
+      .returns({ status: 200, body: user })
 
-    SETTINGS.user = {
-      full_name: "john doe",
-      username:  "johndoe"
-    }
-    bootcampRunsUrl = `/api/v0/bootcamps/${SETTINGS.user.username}/`
+    bootcampRunsUrl = `/api/v0/bootcamps/${user.username}/`
     fakeRuns = generateFakeRuns(3, {
       hasInstallment: true,
       hasPayment:     true
@@ -35,7 +36,8 @@ describe("PaymentPage", () => {
       {
         entities: {
           bootcampRuns: fakeRuns,
-          payment:      null
+          payment:      null,
+          currentUser:  user
         },
         queries: {
           bootcampRuns: {
@@ -304,7 +306,7 @@ describe("PaymentPage", () => {
           helper.handleRequestStub.withArgs(bootcampRunsUrl).callCount,
           1
         )
-        clock.tick(3501)
+        clock.tick(90000)
         assert.equal(
           helper.handleRequestStub.withArgs(bootcampRunsUrl).callCount,
           2

--- a/static/js/pages/PaymentPage_test.js
+++ b/static/js/pages/PaymentPage_test.js
@@ -306,7 +306,7 @@ describe("PaymentPage", () => {
           helper.handleRequestStub.withArgs(bootcampRunsUrl).callCount,
           1
         )
-        clock.tick(90000)
+        clock.tick(3501)
         assert.equal(
           helper.handleRequestStub.withArgs(bootcampRunsUrl).callCount,
           2


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #538

#### What's this PR do?
- Removes `user` from js SETTINGS
- Use `state.entities.currentUser` on the `PaymentPage` instead

#### How should this be manually tested?
- Make a payment on the payment page, nothing should break.
