### PR TITLE
Add DrawerPage

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     url(r'^$', index, name='bootcamp-index'),
 
     url(r'^pay/$', react, name='pay'),
+    path("drawer/", react, name='drawer'),
 
     url(r'^terms_of_service/$', TemplateView.as_view(template_name='bootcamp/tos.html'), name='bootcamp-tos'),
     url(r'^terms_and_conditions/$', TemplateView.as_view(template_name='bootcamp/tac.html'), name='bootcamp-tac'),

--- a/static/js/components/Drawer.js
+++ b/static/js/components/Drawer.js
@@ -4,14 +4,9 @@ import * as React from "react"
 import { useDispatch, useSelector } from "react-redux"
 import { Drawer as RMWCDrawer, DrawerContent } from "@rmwc/drawer"
 import { Theme } from "@rmwc/theme"
-import { createSelector } from "reselect"
 
-import { toggleDrawer } from "../reducers/drawer"
-
-const drawerSelector = createSelector(
-  state => state.drawer,
-  drawer => drawer
-)
+import { drawerSelector } from "../lib/selectors"
+import { setDrawerOpen } from "../reducers/drawer"
 
 type Props = {
   children?: React.Node
@@ -19,16 +14,16 @@ type Props = {
 
 export default function Drawer(props: Props) {
   const { children } = props
-  const { showDrawer } = useSelector(drawerSelector)
+  const { drawerOpen } = useSelector(drawerSelector)
 
   const dispatch = useDispatch()
   const closeDrawer = useCallback(() => {
-    dispatch(toggleDrawer())
+    dispatch(setDrawerOpen(false))
   }, [dispatch])
 
   return (
     <Theme>
-      <RMWCDrawer open={showDrawer} onClose={closeDrawer} dir="rtl" modal>
+      <RMWCDrawer open={drawerOpen} onClose={closeDrawer} dir="rtl" modal>
         <DrawerContent dir="ltr">{children}</DrawerContent>
       </RMWCDrawer>
     </Theme>

--- a/static/js/lib/selectors.js
+++ b/static/js/lib/selectors.js
@@ -25,3 +25,8 @@ export const qsBackendSelector = createParamSelector(
 export const qsNextSelector = createParamSelector("next")
 export const qsErrorSelector = createParamSelector("error")
 export const qsEmailSelector = createParamSelector("email")
+
+export const drawerSelector = createSelector(
+  state => state.drawer,
+  drawer => drawer
+)

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -13,6 +13,7 @@ import RegisterPages from "./register/RegisterPages"
 import PaymentPage from "./PaymentPage"
 import EmailConfirmPage from "./settings/EmailConfirmPage"
 import AccountSettingsPage from "./settings/AccountSettingsPage"
+import DrawerPage from "./DrawerPage"
 
 import users, { currentUserSelector } from "../lib/queries/users"
 import { routes } from "../lib/urls"
@@ -58,6 +59,7 @@ export default function App(props: Props) {
           path={urljoin(match.url, String(routes.accountSettings))}
           component={AccountSettingsPage}
         />
+        <Route path={`${match.url}drawer/`} component={DrawerPage} />
       </Switch>
     </div>
   )

--- a/static/js/pages/DrawerPage.js
+++ b/static/js/pages/DrawerPage.js
@@ -1,0 +1,47 @@
+// @flow
+import React, {useCallback} from "react"
+import { connect } from "react-redux"
+import { useDispatch, useSelector } from "react-redux"
+
+import Drawer from "../components/Drawer"
+
+import { drawerSelector } from "../lib/selectors"
+import { setDrawerOpen, setDrawerState } from "../reducers/drawer"
+
+type Props = {
+}
+
+export function DrawerPage(props: Props) {
+  const { drawerOpen, drawerState } = useSelector(drawerSelector)
+  const dispatch = useDispatch()
+  const closeDrawer = () =>
+    dispatch(setDrawerOpen(false))
+
+  const openDrawer = (state) => {
+    dispatch(setDrawerOpen(true))
+    dispatch(setDrawerState(state))
+  }
+
+
+  return <>
+    <Drawer>
+      {drawerState}
+    </Drawer>
+    <ul>
+      <li><button onClick={() => closeDrawer()}>Close Drawer</button></li>
+      <li><button onClick={() => openDrawer("a")}>Open Drawer State A</button></li>
+      <li><button onClick={() => openDrawer("b")}>Open Drawer State B</button></li>
+    </ul>
+  </>
+}
+
+const mapStateToProps = state => ({
+  drawerState: state.drawer.drawerState,
+  drawerOpen:  state.drawer.drawerOpen,
+})
+
+const mapDispatchToProps = dispatch => ({
+  setDrawerState: (newState: ?string) => dispatch(setDrawerState(newState))
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(DrawerPage)

--- a/static/js/reducers/drawer.js
+++ b/static/js/reducers/drawer.js
@@ -1,13 +1,17 @@
 // @Flow
 import { createAction, createReducer } from "@reduxjs/toolkit"
 
-export const toggleDrawer = createAction("TOGGLE_DRAWER")
+export const setDrawerState = createAction("SET_DRAWER_STATE")
+export const setDrawerOpen = createAction("SET_DRAWER_OPEN")
 
 export const drawer = createReducer(
-  { showDrawer: false },
+  { drawerState: null, drawerOpen: false },
   {
-    [toggleDrawer]: state => {
-      state.showDrawer = !state.showDrawer
+    [setDrawerState]: (state, action) => {
+      state.drawerState = action.payload
+    },
+    [setDrawerOpen]: (state, action) => {
+      state.drawerOpen = action.payload
     }
   }
 )


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #572 

#### What's this PR do?
Adds logic to track drawer states

#### How should this be manually tested?
Go to `/drawer` and click the buttons. For the open drawer buttons it should show the state in the drawer panel when it opens. The close drawer button should appear to do nothing since the drawer is already closed but you should see an action dispatched in the console.