### PR TITLE
Don't error on unexpected arguments in react view

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -49,7 +49,7 @@ def index(request):
 
 
 @csrf_exempt
-def react(request):
+def react(request, **kwargs):
     """
     View for pages served by react
     """

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -60,3 +60,10 @@ def test_index_logged_in_post(client):
     resp = client.post(reverse("bootcamp-index") + "?foo=bar")
     assert resp.status_code == HTTP_302_FOUND
     assert resp.url == reverse("applications") + "?foo=bar"
+
+
+@pytest.mark.django_db
+def test_password_reset_link(client):
+    """Verify that the password reset link doesn't cause an error"""
+    resp = client.get("/signin/forgot-password/confirm/MTA3/5gw-ccd72e49361be41f4924/")
+    assert resp.status_code == 200


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #589 

#### What's this PR do?
Adds a `**kwargs` so the react view is more flexible with arguments passed in

#### How should this be manually tested?
Reset a password for an account, then click the link in the email. On master you should see an error, and on this PR you should see password prompts for new passwords.
