### PR TITLE
personal price search and filter

### DIFF
--- a/klasses/admin.py
+++ b/klasses/admin.py
@@ -50,6 +50,16 @@ class PersonalPriceAdmin(admin.ModelAdmin):
 
     model = models.PersonalPrice
     list_display = ("bootcamp_run", "user", "price")
+    list_filter = ("bootcamp_run__bootcamp", "bootcamp_run")
+    search_fields = (
+        "price",
+        "bootcamp_run__title",
+        "user__email",
+        "user__username",
+        "user__profile__name",
+        "user__legal_address__first_name",
+        "user__legal_address__last_name",
+    )
 
 
 admin.site.register(models.Bootcamp, BootcampAdmin)


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #385 

#### What's this PR do?
Adds filters (bootcamp and bootcamp run) and a search field (search by bootcamp title, full name, first name, last name, username, or email)

#### How should this be manually tested?
Go to http://bc.odl.local:8099/admin/klasses/personalprice/ and try it out

#### Screenshots (if appropriate)
<img width="1026" alt="Screen Shot 2020-06-01 at 2 22 38 PM" src="https://user-images.githubusercontent.com/187676/83441333-5b858680-a414-11ea-8fa0-34c8e8db5837.png">



