### PR TITLE
Added rough application detail view on dashboard

### DIFF
--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -76,6 +76,7 @@ class BootcampApplicationDetailSerializer(serializers.ModelSerializer):
             "bootcamp_run_id",
             "state",
             "resume_filename",
+            "linkedin_url",
             "resume_upload_date",
             "created_on",
             "payment_deadline",

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -51,6 +51,7 @@ def test_application_detail_serializer(app_data):
         "bootcamp_run_id": application.bootcamp_run_id,
         "state": application.state,
         "resume_filename": None,
+        "linkedin_url": None,
         "resume_upload_date": serializer_date_format(application.resume_upload_date),
         "payment_deadline": None,
         "created_on": serializer_date_format(application.created_on),

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-router-dom": "^5.1.2",
     "react-test-renderer": "^16.13.1",
     "react-zendesk": "^0.1.9",
-    "reactstrap": "^8.0.0",
+    "reactstrap": "^8.4.1",
     "redux": "^4.0.5",
     "redux-actions": "^2.6.5",
     "redux-asserts": "^0.0.12",

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -6,7 +6,7 @@ import { generateFakeRun } from "./index"
 import { incrementer } from "../util/util"
 import { APP_STATE_TEXT_MAP } from "../constants"
 
-import type { Application } from "../flow/applicationTypes"
+import type { Application, ApplicationDetail } from "../flow/applicationTypes"
 
 const incr = incrementer()
 
@@ -16,4 +16,19 @@ export const makeApplication = (): Application => ({
   state:        casual.random_element(Object.keys(APP_STATE_TEXT_MAP)),
   created_on:   moment().format(),
   bootcamp_run: generateFakeRun()
+})
+
+export const makeApplicationDetail = (): ApplicationDetail => ({
+  // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
+  id:                    incr.next().value,
+  state:                 casual.random_element(Object.keys(APP_STATE_TEXT_MAP)),
+  bootcamp_run_id:       casual.integer,
+  resume_filename:       `${casual.word}.${casual.file_extension}`,
+  linkedin_url:          casual.url,
+  resume_upload_date:    moment().format(),
+  payment_deadline:      moment().format(),
+  run_application_steps: [],
+  submissions:           [],
+  orders:                [],
+  created_on:            moment().format()
 })

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -1,9 +1,50 @@
 // @flow
-import type {BootcampRun} from "./bootcampTypes"
+import type { BootcampRun } from "./bootcampTypes"
 
 export type Application = {
   id:           number,
   state:        string,
   created_on:   any,
   bootcamp_run: BootcampRun
+}
+
+export type ApplicationRunStep = {
+  id:              number,
+  due_date:        string,
+  step_order:      number,
+  submission_type: string
+}
+
+export type ApplicationSubmission = {
+  id:                      number,
+  run_application_step_id: number,
+  submitted_date:          ?string,
+  review_status:           ?string,
+  review_status_date:      ?string
+}
+
+export type ApplicationOrder = {
+  id:               number,
+  status:           ?string,
+  total_price_paid: ?number,
+  created_on:       ?string,
+  updated_on:       ?string
+}
+
+export type ApplicationDetail = {
+  id:                    number,
+  state:                 string,
+  bootcamp_run_id:       number,
+  resume_filename:       ?string,
+  linkedin_url:          ?string,
+  resume_upload_date:    ?string,
+  payment_deadline:      string,
+  run_application_steps: Array<ApplicationRunStep>,
+  submissions:           Array<ApplicationSubmission>,
+  orders:                Array<ApplicationOrder>,
+  created_on:            string
+}
+
+export type ApplicationDetailState = {
+  [string]: ApplicationDetail
 }

--- a/static/js/lib/queries/applications.js
+++ b/static/js/lib/queries/applications.js
@@ -2,12 +2,21 @@
 import { objOf } from "ramda"
 import { nextState } from "./util"
 
-import type { Application } from "../../flow/applicationTypes"
+import type {
+  Application,
+  ApplicationDetail,
+  ApplicationDetailState
+} from "../../flow/applicationTypes"
 
 const applicationsKey = "applications"
+const applicationDetailKey = "applicationDetail"
 
 export const applicationsSelector = (state: any): ?Array<Application> =>
   state.entities[applicationsKey]
+
+export const applicationDetailSelector = (
+  state: any
+): { [string]: ApplicationDetail } => state.entities[applicationDetailKey]
 
 export default {
   applicationsQuery: () => ({
@@ -15,6 +24,25 @@ export default {
     transform: objOf(applicationsKey),
     update:    {
       [applicationsKey]: nextState
+    }
+  }),
+  applicationDetailQuery: (applicationId: string) => ({
+    url:       `/api/applications/${applicationId}/`,
+    transform: (json: ?ApplicationDetail) => {
+      return {
+        [applicationDetailKey]: {
+          [applicationId]: json
+        }
+      }
+    },
+    update: {
+      [applicationDetailKey]: (
+        prev: ApplicationDetailState,
+        transformed: ApplicationDetailState
+      ) => ({
+        ...prev,
+        ...transformed
+      })
     }
   })
 }

--- a/static/scss/_shared.scss
+++ b/static/scss/_shared.scss
@@ -15,6 +15,12 @@ h2 {
   font-weight: 600;
 }
 
+h3 {
+  font-size: 20px;
+  letter-spacing: 1.1px;
+  font-weight: 600;
+}
+
 .desc {
   font-size: 24px;
   line-height: 32px;
@@ -44,6 +50,21 @@ h3.section-header {
     background-color: $med-gray;
     margin-left: 15px;
     width: 70px;
+  }
+}
+
+a.btn-text {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+a.btn-link {
+  cursor: pointer;
+  text-decoration: none;
+  color: $link-blue;
+
+  &:hover {
+    color: $link-blue;
   }
 }
 

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -22,7 +22,7 @@ $black-transparent: rgba(0, 0, 0, 0.9);
 $light-gray: #c2c0bf;
 $soft-light-gray: #d8d8d8;
 $white-smoke: #f1f1f1;
-$link-blue: #126f9a;
+$link-blue: #0983ff;
 $light-blue: #15729b;
 $cornflower-blue: #579cf9;
 $tab-color: #c2c0bf;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9123,7 +9123,7 @@ react@16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-reactstrap@^8.0.0:
+reactstrap@^8.4.1:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-8.4.1.tgz#c7f63b9057f58b52833061711ebe235b9ec4e3e5"
   integrity sha512-oAjp9PYYUGKl7SLXwrQ1oRIrYw0MqfO2mUqYgGapFKHG2uwjEtLip5rYxtMujkGx3COjH5FX1WtcfNU4oqpH0Q==


### PR DESCRIPTION
#### What are the relevant tickets?
Partially addresses #558

#### What's this PR do?
Adds a rough version of the application detail view that expands in the dashboard

#### How should this be manually tested?
Load the dashboard, click expand and collapse

#### Any background context you want to provide?
There will be another PR following this which matches the [design](https://projects.invisionapp.com/d/#/console/19928472/417192808/inspect) more closely. This PR was put up so we could work on a couple other pages that are launched from this dashboard

#### Screenshots (if appropriate)a
<img width="1181" alt="ss 2020-06-02 at 09 01 07 " src="https://user-images.githubusercontent.com/14932219/83523394-22025900-a4b0-11ea-837e-bb8b3481436f.png">
