### PR TITLE
Define site_name in template for resource and bootcamp run pages

### DIFF
--- a/cms/factories.py
+++ b/cms/factories.py
@@ -47,6 +47,13 @@ class BootcampRunPageFactory(wagtail_factories.PageFactory):
         return obj
 
 
+class ResourcePageFactory(wagtail_factories.PageFactory):
+    """ResourcePage factory"""
+
+    class Meta:
+        model = models.ResourcePage
+
+
 class TitleLinksBlockFactory(wagtail_factories.StructBlockFactory):
     """TitleLinksBlock factory class"""
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -107,15 +107,11 @@ class BootcampPage(Page):
             "js_settings_json": json.dumps(_serialize_js_settings(request)),
             "site_name": settings.SITE_NAME,
             "title": self.title,
+            "site_name": settings.SITE_NAME,
             # The context variables below are added to avoid duplicate queries within the templates
             "three_column_image_text_section": self.three_column_image_text_section,
             "program_description_section": self.program_description_section,
         }
-
-    def _get_child_page_of_type(self, cls):
-        """Gets the first child page of the given type if it exists"""
-        child = self.get_children().type(cls).live().first()
-        return child.specific if child else None
 
     @property
     def instructors(self):
@@ -355,9 +351,10 @@ class ResourcePage(Page):
     ]
 
     def get_context(self, request, *args, **kwargs):
-        context = super().get_context(request)
-
-        return context
+        return {
+            **super().get_context(request, *args, **kwargs),
+            "site_name": settings.SITE_NAME,
+        }
 
 
 @register_snippet

--- a/cms/models.py
+++ b/cms/models.py
@@ -107,7 +107,6 @@ class BootcampPage(Page):
             "js_settings_json": json.dumps(_serialize_js_settings(request)),
             "site_name": settings.SITE_NAME,
             "title": self.title,
-            "site_name": settings.SITE_NAME,
             # The context variables below are added to avoid duplicate queries within the templates
             "three_column_image_text_section": self.three_column_image_text_section,
             "program_description_section": self.program_description_section,

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -6,6 +6,7 @@ import pytest
 from cms.factories import (
     SiteNotificationFactory,
     BootcampRunPageFactory,
+    ResourcePageFactory,
     LearningResourcePageFactory,
     ProgramDescriptionPageFactory,
 )
@@ -75,3 +76,21 @@ def test_program_description_page():
         assert block.block_type == "steps"
         assert block.value["title"] == "Introduction"
         assert block.value["description"].source == "description of title"
+
+
+def test_bootcamp_run_page_site_name(settings, mocker):
+    """
+    BootcampRunPage should include site_name in its context
+    """
+    settings.SITE_NAME = "a site's name"
+    page = BootcampRunPageFactory.create()
+    assert page.get_context(mocker.Mock())["site_name"] == settings.SITE_NAME
+
+
+def test_resource_page_site_name(settings, mocker):
+    """
+    ResourcePage should include site_name in its context
+    """
+    settings.SITE_NAME = "a site's name"
+    page = ResourcePageFactory.create()
+    assert page.get_context(mocker.Mock())["site_name"] == settings.SITE_NAME


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #598 

#### What's this PR do?
Adds `site_name` to template

#### How should this be manually tested?
- Create a bootcamp run page and a resource page if you don't have either already available
- Set the environment variable `SITE_NAME` to whatever you prefer
- View the page. You should see your site name in the title of the browser, followed by the title of the page
