### PR TITLE
Configured dashboard link to open profile drawer

### DIFF
--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -19,7 +19,8 @@ import { currentUserSelector } from "../../lib/queries/users"
 import { formatStartEndDateStrings, formatTitle } from "../../util/util"
 import {
   APP_STATE_TEXT_MAP,
-  APPLICATIONS_DASHBOARD_PAGE_TITLE
+  APPLICATIONS_DASHBOARD_PAGE_TITLE,
+  PROFILE_VIEW
 } from "../../constants"
 import { setDrawerOpen, setDrawerState } from "../../reducers/drawer"
 
@@ -73,12 +74,12 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
     }
     return (
       <div className="row application-detail">
-        <div className="col-12">
+        <div className="col-12 section-profile">
           <h3>Profile Information</h3>
           <a
             className="btn-link"
             onClick={() => {
-              setDrawerState("profileEdit")
+              setDrawerState(PROFILE_VIEW)
               setDrawerOpen(true)
             }}
           >
@@ -155,7 +156,7 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
         <div className="row text-right">
           <div className="col-12">
             <a
-              className="btn-text"
+              className="btn-text expand-collapse"
               onClick={R.partial(this.loadAndRevealAppDetail, [application.id])}
             >
               {isOpen ? "Collapse −" : "Expand ＋"}

--- a/static/js/pages/applications/ApplicationDashboardPage_test.js
+++ b/static/js/pages/applications/ApplicationDashboardPage_test.js
@@ -5,7 +5,7 @@ import wait from "waait"
 
 import ApplicationDashboardPage from "./ApplicationDashboardPage"
 import IntegrationTestHelper from "../../util/integration_test_helper"
-import { APP_STATE_TEXT_MAP } from "../../constants"
+import { APP_STATE_TEXT_MAP, PROFILE_VIEW } from "../../constants"
 import {
   makeApplication,
   makeApplicationDetail
@@ -103,18 +103,21 @@ describe("ApplicationDashboardPage", () => {
   })
 
   it("loads detailed application data when the detail section is expanded", async () => {
+    const applicationIndex = 0
     const { wrapper } = await renderPage()
-    let firstApplicationCard = wrapper.find(".application-card").at(0)
+    let firstApplicationCard = wrapper
+      .find(".application-card")
+      .at(applicationIndex)
     assert.isFalse(firstApplicationCard.find("Collapse").prop("isOpen"))
-    const btnLinks = firstApplicationCard.find(".btn-text")
-    assert.isTrue(btnLinks.exists())
-    const expandLink = btnLinks.last()
+    const expandLink = firstApplicationCard.find(".expand-collapse")
     assert.include(expandLink.text(), "Expand")
 
     await expandLink.simulate("click")
     await wait()
     wrapper.update()
-    firstApplicationCard = wrapper.find(".application-card").at(0)
+    firstApplicationCard = wrapper
+      .find(".application-card")
+      .at(applicationIndex)
     sinon.assert.calledWith(
       helper.handleRequestStub,
       `/api/applications/${String(fakeApplicationDetail.id)}/`,
@@ -129,5 +132,22 @@ describe("ApplicationDashboardPage", () => {
       "Collapse"
     )
     assert.exists(firstApplicationCard.find(".application-detail"))
+  })
+
+  it("opens and closes a profile view/edit drawer", async () => {
+    const applicationIndex = 0
+    const { wrapper, store } = await renderPage()
+
+    let appCard = wrapper.find(".application-card").at(applicationIndex)
+    await appCard.find(".expand-collapse").simulate("click")
+    await wait()
+    wrapper.update()
+
+    appCard = wrapper.find(".application-card").at(applicationIndex)
+    await appCard.find(".section-profile a").simulate("click")
+    await wait()
+    const state = store.getState()
+    assert.isTrue(state.drawer.drawerOpen)
+    assert.equal(state.drawer.drawerState, PROFILE_VIEW)
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/bootcamp-ecommerce/pull/575

#### What's this PR do?
Finalizes the profile view/edit UI introduced in the PR above. The profile view/edit drawer is now launched from the application dashboard in the correct place

#### How should this be manually tested?
Open the dashboard, expand the detail for an application, and click the "view/edit profile" link. The drawer should open with the correct form
