### PR TITLE
add `repl.py` from open-discussions

### DIFF
--- a/repl.py
+++ b/repl.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Run Django shell with imported modules"""
+if __name__ == "__main__":
+    import os
+
+    if not os.environ.get("PYTHONSTARTUP"):
+        from subprocess import check_call
+        import sys
+
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+
+        sys.exit(
+            check_call(
+                [os.path.join(base_dir, "manage.py"), "shell", *sys.argv[1:]],
+                env={**os.environ, "PYTHONSTARTUP": os.path.join(base_dir, "repl.py")},
+            )
+        )
+
+    # put imports here used by PYTHONSTARTUP
+    from django.conf import settings
+
+    for app in settings.INSTALLED_APPS:
+        try:
+            exec(  # pylint: disable=exec-used
+                "from {app}.models import *".format(app=app)
+            )
+        except ModuleNotFoundError:
+            pass


### PR DESCRIPTION
#### What are the relevant tickets?
none

#### What's this PR do?

I just noticed we didn't have the `repl.py` script over here and thought we might want it.

#### How should this be manually tested?

you should be able to run the script in the web container and it should open a django shell and automatically import a bunch of models for you, like `User` and so on.

I just copied the file from open-discussions without changing anything.