### PR TITLE
Fix login state

### DIFF
--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -95,7 +95,7 @@ def create_user_via_email(
 
     if not strategy.is_api_request():
         return strategy.redirect_with_partial(
-            reverse("signup-details"), current_partial
+            reverse("signup-details"), backend.name, current_partial
         )
 
     data = strategy.request_data().copy()
@@ -160,7 +160,9 @@ def create_profile(
         return {}
 
     if not strategy.is_api_request():
-        return strategy.redirect_with_partial(reverse("signup-extra"), current_partial)
+        return strategy.redirect_with_partial(
+            reverse("signup-extra"), backend.name, current_partial
+        )
 
     data = strategy.request_data().copy()
 

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -43,7 +43,7 @@ class SocialAuthSerializer(serializers.Serializer):
             (SocialAuthState.FLOW_REGISTER, "Register"),
         )
     )
-    provider = serializers.CharField(read_only=True)
+    backend = serializers.CharField(read_only=True)
     state = serializers.CharField(read_only=True)
     errors = serializers.ListField(read_only=True)
     field_errors = serializers.DictField(read_only=True)
@@ -137,8 +137,8 @@ class SocialAuthSerializer(serializers.Serializer):
             result = super().save(**kwargs)
         except RequireProviderException as exc:
             result = SocialAuthState(
-                SocialAuthState.STATE_LOGIN_PROVIDER,
-                provider=exc.social_auth.provider,
+                SocialAuthState.STATE_LOGIN_BACKEND,
+                backend=exc.social_auth.provider,
                 user=exc.social_auth.user,
             )
         except InvalidEmail:
@@ -186,8 +186,8 @@ class SocialAuthSerializer(serializers.Serializer):
         # this way they know if they're on a particular page because of an attempted registration or login
         result.flow = self.validated_data["flow"]
 
-        if result.provider is None:
-            result.provider = EmailAuth.name
+        if result.backend is None:
+            result.backend = self.context["backend"].name
 
         # update self.instance so we serialize the right object
         self.instance = result

--- a/authentication/strategy.py
+++ b/authentication/strategy.py
@@ -12,9 +12,9 @@ from profiles.models import LegalAddress, Profile
 class BootcampDjangoStrategy(DjangoStrategy):
     """Abstract strategy for botcamp app"""
 
-    def redirect_with_partial(self, url, partial_token):
+    def redirect_with_partial(self, url, backend, partial_token):
         """Redirect to the specified url with a partial token"""
-        qs = urlencode({"partial_token": partial_token.token})
+        qs = urlencode({"backend": backend, "partial_token": partial_token.token})
         return self.redirect(self.build_absolute_uri(f"{url}?{qs}"))
 
     def is_api_enabled(self):

--- a/authentication/utils.py
+++ b/authentication/utils.py
@@ -12,7 +12,7 @@ class SocialAuthState:  # pylint: disable=too-many-instance-attributes
     # login states
     STATE_LOGIN_EMAIL = "login/email"
     STATE_LOGIN_PASSWORD = "login/password"
-    STATE_LOGIN_PROVIDER = "login/provider"
+    STATE_LOGIN_BACKEND = "login/backend"
 
     # registration states
     STATE_REGISTER_EMAIL = "register/email"
@@ -34,7 +34,7 @@ class SocialAuthState:  # pylint: disable=too-many-instance-attributes
         self,
         state,
         *,
-        provider=None,
+        backend=None,
         partial=None,
         flow=None,
         errors=None,
@@ -45,7 +45,7 @@ class SocialAuthState:  # pylint: disable=too-many-instance-attributes
         self.state = state
         self.partial = partial
         self.flow = flow
-        self.provider = provider
+        self.backend = backend
         self.errors = errors or []
         self.field_errors = field_errors or {}
         self.redirect_url = redirect_url

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -78,7 +78,7 @@ def assert_api_call(
         "redirect_url": None,
         "extra_data": {},
         "state": None,
-        "provider": EmailAuth.name,
+        "backend": EmailAuth.name,
         "flow": None,
         "partial_token": any_instance_of(str),
     }
@@ -740,7 +740,7 @@ def test_login_email_error(client, mocker):
         "errors": [],
         "field_errors": {},
         "flow": SocialAuthState.FLOW_LOGIN,
-        "provider": EmailAuth.name,
+        "backend": EmailAuth.name,
         "redirect_url": None,
         "partial_token": None,
         "state": SocialAuthState.STATE_ERROR,

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -10,7 +10,7 @@ export type AuthStates =
   | "error-temporary"
   | "login/email"
   | "login/password"
-  | "login/provider"
+  | "login/backend"
   | "register/email"
   | "register/confirm-sent"
   | "register/confirm"
@@ -33,6 +33,7 @@ export type AuthExtraData = {
 export type AuthResponse = {
   partial_token: ?string,
   flow:          AuthFlow,
+  backend:       string,
   state:         AuthStates,
   errors:        AuthErrors,
   field_errors:  AuthFieldErrors,

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -20,7 +20,7 @@ export const STATE_USER_BLOCKED = "user-blocked"
 
 export const STATE_LOGIN_EMAIL = "login/email"
 export const STATE_LOGIN_PASSWORD = "login/password"
-export const STATE_LOGIN_PROVIDER = "login/provider"
+export const STATE_LOGIN_BACKEND = "login/backend"
 
 export const STATE_REGISTER_EMAIL = "register/email"
 export const STATE_REGISTER_CONFIRM_SENT = "register/confirm-sent"
@@ -41,7 +41,7 @@ export const ALL_STATES = [
   STATE_USER_BLOCKED,
   STATE_LOGIN_EMAIL,
   STATE_LOGIN_PASSWORD,
-  STATE_LOGIN_PROVIDER,
+  STATE_LOGIN_BACKEND,
   STATE_REGISTER_EMAIL,
   STATE_REGISTER_CONFIRM,
   STATE_REGISTER_CONFIRM_SENT,
@@ -71,13 +71,17 @@ const getErrorQs = (errors: Array<string>) =>
 export const handleAuthResponse = (
   history: RouterHistory,
   response: AuthResponse,
-  handlers: StateHandlers,
-  backend?: string
+  handlers: StateHandlers
 ) => {
   /* eslint-disable camelcase */
-  const { state, redirect_url, partial_token, errors, field_errors } = response
-
-  backend = backend || STATE_REGISTER_BACKEND_EDX
+  const {
+    state,
+    backend,
+    redirect_url,
+    partial_token,
+    errors,
+    field_errors
+  } = response
 
   // If a specific handler function was passed in for this response state, invoke it
   if (has(state, handlers)) {

--- a/static/js/lib/queries/auth.js
+++ b/static/js/lib/queries/auth.js
@@ -54,9 +54,13 @@ export default {
     body: { email, recaptcha, next, flow: FLOW_REGISTER }
   }),
 
-  registerConfirmEmailMutation: (code: string, partialToken: string) => ({
+  registerConfirmMutation: (
+    code: string,
+    partialToken: string,
+    backend: string
+  ) => ({
     ...DEFAULT_OPTIONS,
-    url:  "/api/register/email/confirm/",
+    url:  `/api/register/${backend}/confirm/`,
     body: {
       verification_code: code,
       partial_token:     partialToken,

--- a/static/js/lib/selectors.js
+++ b/static/js/lib/selectors.js
@@ -3,7 +3,7 @@ import { createSelector } from "reselect"
 import { propOr } from "ramda"
 import qs from "query-string"
 
-import { STATE_REGISTER_BACKEND_EDX } from "./auth"
+import { STATE_REGISTER_BACKEND_EMAIL } from "./auth"
 
 export const qsSelector = createSelector(
   (_, ownProps) => ownProps.location.search,
@@ -20,7 +20,7 @@ export const qsVerificationCodeSelector = createParamSelector(
 )
 export const qsBackendSelector = createParamSelector(
   "backend",
-  STATE_REGISTER_BACKEND_EDX
+  STATE_REGISTER_BACKEND_EMAIL
 )
 export const qsNextSelector = createParamSelector("next")
 export const qsErrorSelector = createParamSelector("error")

--- a/static/js/pages/login/LoginEmailPage.js
+++ b/static/js/pages/login/LoginEmailPage.js
@@ -12,7 +12,6 @@ import { routes, getNextParam } from "../../lib/urls"
 import {
   STATE_ERROR,
   STATE_REGISTER_REQUIRED,
-  STATE_REGISTER_BACKEND_EMAIL,
   handleAuthResponse
 } from "../../lib/auth"
 import { LOGIN_EMAIL_PAGE_TITLE } from "../../constants"
@@ -46,19 +45,14 @@ export class LoginEmailPage extends React.Component<Props> {
     try {
       const { body } = await loginEmail(email, nextUrl)
 
-      handleAuthResponse(
-        history,
-        body,
-        {
-          // eslint-disable-next-line camelcase
-          [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
-            setErrors(field_errors),
-          // eslint-disable-next-line camelcase
-          [STATE_REGISTER_REQUIRED]: ({ field_errors }: AuthResponse) =>
-            setErrors(field_errors)
-        },
-        STATE_REGISTER_BACKEND_EMAIL
-      )
+      handleAuthResponse(history, body, {
+        // eslint-disable-next-line camelcase
+        [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
+          setErrors(field_errors),
+        // eslint-disable-next-line camelcase
+        [STATE_REGISTER_REQUIRED]: ({ field_errors }: AuthResponse) =>
+          setErrors(field_errors)
+      })
     } finally {
       setSubmitting(false)
     }

--- a/static/js/pages/register/RegisterConfirmPage.js
+++ b/static/js/pages/register/RegisterConfirmPage.js
@@ -41,33 +41,23 @@ type Props = {
 
 export class RegisterConfirmPage extends React.Component<Props> {
   componentDidUpdate(prevProps: Props) {
-    const {
-      addUserNotification,
-      auth,
-      history,
-      params: { backend }
-    } = this.props
+    const { addUserNotification, auth, history } = this.props
     const prevState = path(["auth", "state"], prevProps)
 
     if (auth && auth.state !== prevState) {
-      handleAuthResponse(
-        history,
-        auth,
-        {
-          [STATE_REGISTER_DETAILS]: () => {
-            addUserNotification({
-              "email-verified": {
-                type:  ALERT_TYPE_TEXT,
-                props: {
-                  text:
-                    "Success! We've verified your email. Please finish your account creation below."
-                }
+      handleAuthResponse(history, auth, {
+        [STATE_REGISTER_DETAILS]: () => {
+          addUserNotification({
+            "email-verified": {
+              type:  ALERT_TYPE_TEXT,
+              props: {
+                text:
+                  "Success! We've verified your email. Please finish your account creation below."
               }
-            })
-          }
-        },
-        backend
-      )
+            }
+          })
+        }
+      })
     }
   }
 
@@ -106,12 +96,17 @@ const mapStateToProps = createStructuredSelector({
   })
 })
 
-const registerConfirmEmail = (code: string, partialToken: string) =>
+const registerConfirmEmail = (
+  code: string,
+  partialToken: string,
+  backend: string
+) =>
   // $FlowFixMe
-  mutateAsync(queries.auth.registerConfirmEmailMutation(code, partialToken))
+  mutateAsync(queries.auth.registerConfirmMutation(code, partialToken, backend))
 
-const mapPropsToConfig = ({ params: { verificationCode, partialToken } }) =>
-  registerConfirmEmail(verificationCode, partialToken)
+const mapPropsToConfig = ({
+  params: { verificationCode, partialToken, backend }
+}) => registerConfirmEmail(verificationCode, partialToken, backend)
 
 const mapDispatchToProps = {
   addUserNotification

--- a/static/js/pages/register/RegisterConfirmPage_test.js
+++ b/static/js/pages/register/RegisterConfirmPage_test.js
@@ -4,7 +4,7 @@ import { assert } from "chai"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import RegisterConfirmPage from "./RegisterConfirmPage"
 import {
-  STATE_REGISTER_BACKEND_EDX,
+  STATE_REGISTER_BACKEND_EMAIL,
   STATE_REGISTER_DETAILS
 } from "../../lib/auth"
 
@@ -25,6 +25,7 @@ describe("RegisterConfirmPage", () => {
         entities: {
           auth: {
             state:         STATE_REGISTER_DETAILS,
+            backend:       STATE_REGISTER_BACKEND_EMAIL,
             partial_token: token,
             extra_data:    {
               name: "name"
@@ -60,7 +61,7 @@ describe("RegisterConfirmPage", () => {
     assert.equal(helper.currentLocation.pathname, "/create-account/details/")
     assert.equal(
       helper.currentLocation.search,
-      `?backend=${STATE_REGISTER_BACKEND_EDX}&partial_token=${token}`
+      `?backend=${STATE_REGISTER_BACKEND_EMAIL}&partial_token=${token}`
     )
   })
 })

--- a/static/js/pages/register/RegisterDetailsPage.js
+++ b/static/js/pages/register/RegisterDetailsPage.js
@@ -73,16 +73,11 @@ export class RegisterDetailsPage extends React.Component<Props> {
         backend
       )
 
-      handleAuthResponse(
-        history,
-        body,
-        {
-          // eslint-disable-next-line camelcase
-          [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
-            setErrors(field_errors)
-        },
-        backend
-      )
+      handleAuthResponse(history, body, {
+        // eslint-disable-next-line camelcase
+        [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
+          setErrors(field_errors)
+      })
     } finally {
       setSubmitting(false)
     }

--- a/static/js/pages/register/RegisterDetailsPage_test.js
+++ b/static/js/pages/register/RegisterDetailsPage_test.js
@@ -135,7 +135,7 @@ describe("RegisterDetailsPage", () => {
       ""
     ]
   ].forEach(([state, errors, pathname, backend, search]) => {
-    it(`redirects to ${pathname} when it receives auth state ${state}`, async () => {
+    it(`redirects to ${pathname} when it receives auth state ${state} for backend ${backend}`, async () => {
       const { wrapper } = await helper.configureReduxQueryRenderer(
         RegisterDetailsPage,
         {
@@ -149,6 +149,7 @@ describe("RegisterDetailsPage", () => {
         body: makeRegisterAuthResponse({
           state,
           errors,
+          backend,
           partial_token: "new_partial_token"
         })
       })

--- a/static/js/pages/register/RegisterEmailPage.js
+++ b/static/js/pages/register/RegisterEmailPage.js
@@ -14,7 +14,6 @@ import {
   STATE_ERROR,
   STATE_REGISTER_CONFIRM_SENT,
   STATE_LOGIN_PASSWORD,
-  STATE_REGISTER_BACKEND_EMAIL,
   handleAuthResponse
 } from "../../lib/auth"
 import { qsNextSelector } from "../../lib/selectors"
@@ -58,34 +57,29 @@ export class RegisterEmailPage extends React.Component<Props> {
     try {
       const { body } = await registerEmail(email, recaptcha, next)
 
-      handleAuthResponse(
-        history,
-        body,
-        {
-          [STATE_REGISTER_CONFIRM_SENT]: () => {
-            const params = qs.stringify({
-              email
-            })
-            history.push(`${routes.register.confirmSent}?${params}`)
-          },
-
-          [STATE_LOGIN_PASSWORD]: () => {
-            addUserNotification({
-              "account-exists": {
-                type:  ALERT_TYPE_TEXT,
-                color: "danger",
-                props: {
-                  text: accountExistsNotificationText(email)
-                }
-              }
-            })
-          },
-          // eslint-disable-next-line camelcase
-          [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
-            setErrors(field_errors)
+      handleAuthResponse(history, body, {
+        [STATE_REGISTER_CONFIRM_SENT]: () => {
+          const params = qs.stringify({
+            email
+          })
+          history.push(`${routes.register.confirmSent}?${params}`)
         },
-        STATE_REGISTER_BACKEND_EMAIL
-      )
+
+        [STATE_LOGIN_PASSWORD]: () => {
+          addUserNotification({
+            "account-exists": {
+              type:  ALERT_TYPE_TEXT,
+              color: "danger",
+              props: {
+                text: accountExistsNotificationText(email)
+              }
+            }
+          })
+        },
+        // eslint-disable-next-line camelcase
+        [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
+          setErrors(field_errors)
+      })
     } finally {
       setSubmitting(false)
     }

--- a/static/js/pages/register/RegisterExtraDetailsPage.js
+++ b/static/js/pages/register/RegisterExtraDetailsPage.js
@@ -59,16 +59,11 @@ export class RegisterExtraDetailsPage extends React.Component<Props> {
         backend
       )
 
-      handleAuthResponse(
-        history,
-        body,
-        {
-          // eslint-disable-next-line camelcase
-          [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
-            setErrors(field_errors)
-        },
-        backend
-      )
+      handleAuthResponse(history, body, {
+        // eslint-disable-next-line camelcase
+        [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
+          setErrors(field_errors)
+      })
     } finally {
       setSubmitting(false)
     }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #617 

#### What's this PR do?
Fixes an exception caused by the /signin page sending the user into an edx auth flow instead of the email one.

#### How should this be manually tested?
This could potentially regress any one of the following flows so they all need to be tested.

To verify the fix:
- For the following, set a required profile field (e.g. name, city, etc) to an empty:
  - You can login with an existing account via email
  - You can login with an existing account via edx (go to `/login/edxorg/`)

To verify no regressions occurred:
- You can sign up for a new account via email
- You can sign up for a new account via edx (we won't officially support this for users, but the code path should be exercised nonetheless)
- You can login with an existing account via email
- You can login with an existing account via edx
