### PR TITLE
Removed repeated footers

### DIFF
--- a/main/templates/404.html
+++ b/main/templates/404.html
@@ -18,5 +18,4 @@
     </div>
   </div>
 </div>
-{% include "footer.html" %}
 {% endblock %}

--- a/main/templates/500.html
+++ b/main/templates/500.html
@@ -15,7 +15,6 @@
     </div>
   </div>
 </div>
-{% include "footer.html" %}
 {% if request.sentry.id %}
 <script>
   Sentry.showReportDialog({

--- a/main/templates/bootcamp/index.html
+++ b/main/templates/bootcamp/index.html
@@ -19,5 +19,4 @@
     </div>
   </div>
 </div>
-{% include "footer.html" %}
 {% endblock %}

--- a/main/templates/bootcamp/react.html
+++ b/main/templates/bootcamp/react.html
@@ -9,7 +9,6 @@
   <div id="container">
   </div>
 </div>
-{% include "footer.html" %}
 {% load render_bundle %}
 {% render_bundle "root" %}
 {% endblock %}

--- a/main/templates/bootcamp/tac.html
+++ b/main/templates/bootcamp/tac.html
@@ -73,5 +73,4 @@
  </p>
  <br/>
 </div>
-{% include "footer.html" %}
 {% endblock %}

--- a/main/templates/bootcamp/tos.html
+++ b/main/templates/bootcamp/tos.html
@@ -66,5 +66,4 @@
     </li>
   </ol>
 </div>
-{% include "footer.html" %}
 {% endblock %}


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket - found while working on a different issue

#### What's this PR do?
Removes repeated footers from Django templates

#### How should this be manually tested?
Visit the affected pages, check that the footer is not rendered twice

#### Any background context you want to provide?
Looks like someone added the footer to the `base.html` template but didn't remove it from the individual pages where it was previously added
