### PR TITLE
Added new application UI

### DIFF
--- a/static/js/components/Drawer.js
+++ b/static/js/components/Drawer.js
@@ -8,15 +8,21 @@ import * as R from "ramda"
 
 import { drawerSelector } from "../lib/selectors"
 import { setDrawerOpen } from "../reducers/drawer"
-import { PAYMENT, PROFILE_EDIT, PROFILE_VIEW } from "../constants"
+import {
+  NEW_APPLICATION,
+  PAYMENT,
+  PROFILE_EDIT,
+  PROFILE_VIEW
+} from "../constants"
 
 import EditProfileDisplay from "./EditProfileDisplay"
 import ViewProfileDisplay from "./ViewProfileDisplay"
 import PaymentDisplay from "./PaymentDisplay"
+import NewApplication from "./NewApplication"
 
 const renderDrawerContents = (
   drawerState: string,
-  drawerMeta?: Object
+  drawerMeta: ?Object
 ): ?React$Element<*> => {
   switch (drawerState) {
   case PROFILE_EDIT:
@@ -25,6 +31,10 @@ const renderDrawerContents = (
     return <ViewProfileDisplay />
   case PAYMENT:
     return <PaymentDisplay application={R.prop("application", drawerMeta)} />
+  case NEW_APPLICATION:
+    return (
+      <NewApplication appliedRunIds={R.prop("appliedRunIds", drawerMeta)} />
+    )
   default:
     return null
   }

--- a/static/js/components/Drawer_test.js
+++ b/static/js/components/Drawer_test.js
@@ -3,7 +3,12 @@ import { assert } from "chai"
 import { Drawer as RMWCDrawer } from "@rmwc/drawer"
 
 import Drawer from "./Drawer"
-import { PAYMENT, PROFILE_EDIT, PROFILE_VIEW } from "../constants"
+import {
+  NEW_APPLICATION,
+  PAYMENT,
+  PROFILE_EDIT,
+  PROFILE_VIEW
+} from "../constants"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
 import { setDrawerOpen, setDrawerState, openDrawer } from "../reducers/drawer"
@@ -14,6 +19,13 @@ describe("Drawer", () => {
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
+    // Mock API response for bootcamp runs. NewApplication requests this when loading
+    helper.handleRequestStub
+      .withArgs("/api/bootcampruns/?available=true")
+      .returns({
+        status: 200,
+        body:   []
+      })
     render = helper.configureReduxQueryRenderer(Drawer)
   })
 
@@ -25,7 +37,8 @@ describe("Drawer", () => {
   ;[
     [PROFILE_EDIT, "EditProfileDisplay"],
     [PROFILE_VIEW, "ViewProfileDisplay"],
-    [PAYMENT, "PaymentDisplay"]
+    [PAYMENT, "PaymentDisplay"],
+    [NEW_APPLICATION, "NewApplication"]
   ].forEach(([drawerType, expComponent]) => {
     it(`should render a drawer component with a ${expComponent} child`, async () => {
       const { wrapper } = await render({}, [

--- a/static/js/components/EditProfileDisplay.js
+++ b/static/js/components/EditProfileDisplay.js
@@ -72,7 +72,7 @@ export class EditProfileDisplay extends React.Component<Props> {
   render() {
     const { countries, currentUser } = this.props
     return countries && currentUser ? (
-      <div className="container auth-page registration-page">
+      <div className="container p-0 edit-profile">
         <MetaTags>
           <title>{formatTitle(EDIT_PROFILE_PAGE_TITLE)}</title>
         </MetaTags>

--- a/static/js/components/EditProfileDisplay_test.js
+++ b/static/js/components/EditProfileDisplay_test.js
@@ -34,7 +34,7 @@ describe("EditProfileDisplay", () => {
     assert.isTrue(wrapper.find("EditProfileForm").exists())
     assert.isFalse(
       wrapper
-        .find(".auth-page")
+        .find(".edit-profile")
         .text()
         .includes("You must be logged in to edit your profile.")
     )
@@ -48,7 +48,7 @@ describe("EditProfileDisplay", () => {
     const { wrapper } = await renderPage()
     assert.isTrue(
       wrapper
-        .find(".auth-page")
+        .find(".edit-profile")
         .text()
         .includes("You must be logged in to edit your profile.")
     )

--- a/static/js/components/NewApplication.js
+++ b/static/js/components/NewApplication.js
@@ -1,0 +1,146 @@
+/* global SETTINGS: false */
+import React from "react"
+import { compose } from "redux"
+import { connect } from "react-redux"
+import { mutateAsync } from "redux-query"
+import { connectRequest } from "redux-query-react"
+import { createStructuredSelector } from "reselect"
+import {
+  Dropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem
+} from "reactstrap"
+import { partial } from "ramda"
+
+import { setDrawerOpen } from "../reducers/drawer"
+import users, { currentUserSelector } from "../lib/queries/users"
+import bootcamps, { bootcampRunsSelector } from "../lib/queries/bootcamps"
+import applications, { createAppQueryKey } from "../lib/queries/applications"
+import { isQueryPending } from "../lib/queries/util"
+
+import type { User } from "../flow/authTypes"
+import type { BootcampRun } from "../flow/bootcampTypes"
+
+type Props = {
+  currentUser: User,
+  bootcampRuns: ?Array<BootcampRun>,
+  appliedRunIds: Array<number>,
+  createAppIsPending: boolean,
+  createNewApplication: (bootcampRunId: number) => void,
+  setDrawerOpen: (newState: boolean) => void
+}
+
+type State = {
+  selectedBootcamp: ?BootcampRun,
+  dropdownOpen: boolean
+}
+
+const INITIAL_STATE: State = {
+  selectedBootcamp: null,
+  dropdownOpen:     false
+}
+
+export class NewApplication extends React.Component<Props, State> {
+  state = { ...INITIAL_STATE }
+
+  changeSelectedRun = (run: BootcampRun) => {
+    this.setState({
+      selectedBootcamp: run
+    })
+  }
+
+  handleSubmit = async () => {
+    const { createNewApplication, setDrawerOpen } = this.props
+    const { selectedBootcamp } = this.state
+
+    if (!selectedBootcamp) {
+      return
+    }
+    await createNewApplication(selectedBootcamp.id)
+    this.setState({ ...INITIAL_STATE })
+    setDrawerOpen(false)
+  }
+
+  render() {
+    const {
+      currentUser,
+      bootcampRuns,
+      appliedRunIds,
+      createAppIsPending
+    } = this.props
+    const { selectedBootcamp, dropdownOpen } = this.state
+
+    if (!currentUser || !bootcampRuns) {
+      return null
+    }
+
+    const unappliedBootcampRuns = bootcampRuns.filter(
+      (bootcampRun: BootcampRun) => !appliedRunIds.includes(bootcampRun.id)
+    )
+    const items = unappliedBootcampRuns.map((bootcampRun: BootcampRun) => (
+      <DropdownItem
+        value={bootcampRun.run_key}
+        key={bootcampRun.id}
+        onClick={partial(this.changeSelectedRun, [bootcampRun])}
+      >
+        {bootcampRun.display_title}
+      </DropdownItem>
+    ))
+    const dropdownText = selectedBootcamp ?
+      selectedBootcamp.display_title :
+      "Select..."
+
+    return (
+      <div className="container p-0">
+        <h1 className="mb-3">Select Bootcamp</h1>
+        <p className="mb-3">
+          To apply to a bootcamp, please select from the list below and click
+          Continue.
+        </p>
+        <label className="d-block font-weight-bold">Bootcamps</label>
+        <Dropdown
+          isOpen={dropdownOpen}
+          toggle={() => this.setState({ dropdownOpen: !dropdownOpen })}
+          className="mb-3 standard-select full-width"
+        >
+          <DropdownToggle caret>{dropdownText}</DropdownToggle>
+          <DropdownMenu>{items}</DropdownMenu>
+        </Dropdown>
+        <div className="d-flex justify-content-end">
+          <button
+            className="btn btn-red btn-inverse"
+            onClick={this.handleSubmit}
+            disabled={createAppIsPending || !selectedBootcamp}
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = createStructuredSelector({
+  currentUser:        currentUserSelector,
+  bootcampRuns:       bootcampRunsSelector,
+  createAppIsPending: isQueryPending(createAppQueryKey)
+})
+
+const mapPropsToConfigs = () => [
+  users.currentUserQuery(),
+  bootcamps.bootcampRunsQuery()
+]
+
+const mapDispatchToProps = dispatch => ({
+  createNewApplication: (bootcampRunId: number) =>
+    dispatch(
+      mutateAsync(applications.createApplicationMutation(bootcampRunId))
+    ),
+  setDrawerOpen: (newState: boolean) => dispatch(setDrawerOpen(newState))
+})
+
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  connectRequest(mapPropsToConfigs)
+)(NewApplication)

--- a/static/js/components/NewApplication_test.js
+++ b/static/js/components/NewApplication_test.js
@@ -1,0 +1,98 @@
+/* global SETTINGS: false */
+import { assert } from "chai"
+import sinon from "sinon"
+import wait from "waait"
+import { last, prop } from "ramda"
+
+import NewApplication from "./NewApplication"
+import IntegrationTestHelper from "../util/integration_test_helper"
+import { makeUser } from "../factories/user"
+import { generateFakeRun } from "../factories"
+
+describe("NewApplication", () => {
+  let helper, fakeUser, fakeBootcampRuns, fakeAppliedId, renderPage
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    fakeUser = makeUser()
+    fakeBootcampRuns = [generateFakeRun(), generateFakeRun(), generateFakeRun()]
+    // Get the id of the last created run and include it in the list of ids that are already applied
+    fakeAppliedId = prop("id", last(fakeBootcampRuns))
+
+    helper.handleRequestStub
+      .withArgs("/api/bootcampruns/?available=true")
+      .returns({
+        status: 200,
+        body:   fakeBootcampRuns
+      })
+
+    renderPage = helper.configureReduxQueryRenderer(
+      NewApplication,
+      { appliedRunIds: [fakeAppliedId] },
+      {
+        entities: {
+          currentUser: fakeUser
+        }
+      }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("shows a dropdown with all available bootcamp runs that aren't already applied to", async () => {
+    const { wrapper } = await renderPage()
+    const dropdownItems = wrapper.find("DropdownItem")
+    assert.lengthOf(dropdownItems, fakeBootcampRuns.length - 1)
+    for (let i = 0; i < dropdownItems.length; i++) {
+      const dropdownItem = dropdownItems.at(i)
+      const bootcampRun = fakeBootcampRuns[i]
+      assert.equal(dropdownItem.prop("value"), bootcampRun.run_key)
+      assert.equal(dropdownItem.text(), bootcampRun.display_title)
+    }
+    assert.equal(wrapper.find("DropdownToggle").text(), "Select...")
+    // Submit/continue button should be disabled before selecting a bootcamp
+    assert.isTrue(
+      wrapper
+        .find("button")
+        .last()
+        .prop("disabled")
+    )
+  })
+
+  it("allows a user to select a bootcamp and submit the form to create a new application", async () => {
+    const fakeNewApplication = generateFakeRun()
+    const newApplicationStub = helper.handleRequestStub
+      .withArgs("/api/applications/", "POST")
+      .returns({
+        status: 201,
+        body:   fakeNewApplication
+      })
+
+    const { wrapper, store } = await renderPage()
+    await wrapper.find("Dropdown").simulate("click")
+    await wait()
+    wrapper.update()
+
+    const firstBootcampItem = wrapper.find("DropdownItem").at(0)
+    await firstBootcampItem.simulate("click")
+    await wait()
+    wrapper.update()
+
+    assert.equal(
+      wrapper.find("DropdownToggle").text(),
+      fakeBootcampRuns[0].display_title
+    )
+    const submitBtn = wrapper.find("button").last()
+    assert.isNotOk(submitBtn.prop("disabled"))
+    await submitBtn.simulate("click")
+    await wait()
+    wrapper.update()
+
+    sinon.assert.calledOnce(newApplicationStub)
+    assert.deepEqual(store.getState().entities.applications, [
+      fakeNewApplication
+    ])
+  })
+})

--- a/static/js/components/PaymentDisplay.js
+++ b/static/js/components/PaymentDisplay.js
@@ -64,8 +64,8 @@ export const PaymentDisplay = (props: Props) => {
   const cost = application.price
 
   return (
-    <div className="container">
-      <div className="payment-drawer auth-card">
+    <div className="container p-0">
+      <div className="payment-drawer">
         <h2 className="drawer-title">Make Payment</h2>
         <div className="bootcamp">
           <div className="bootcamp-title">{run.bootcamp.title}</div>

--- a/static/js/components/ViewProfileDisplay.js
+++ b/static/js/components/ViewProfileDisplay.js
@@ -39,7 +39,7 @@ export function ViewProfileDisplay(props: Props) {
   const { currentUser, countries, updateDrawer } = props
 
   return countries && currentUser ? (
-    <div className="container auth-page registration-page">
+    <div className="container p-0 view-profile">
       <MetaTags>
         <title>{formatTitle(VIEW_PROFILE_PAGE_TITLE)}</title>
       </MetaTags>

--- a/static/js/components/ViewProfileDisplay_test.js
+++ b/static/js/components/ViewProfileDisplay_test.js
@@ -32,14 +32,14 @@ describe("ViewProfileDisplay", () => {
     assert.isTrue(wrapper.find(".profile-btn").exists())
     assert.isTrue(
       wrapper
-        .find(".auth-page")
+        .find(".view-profile")
         .text()
         // $FlowFixMe: user.legal_address is not null
         .includes(user.legal_address.street_address[0])
     )
     assert.isTrue(
       wrapper
-        .find(".auth-page")
+        .find(".view-profile")
         .text()
         // $FlowFixMe: user.profile is not null
         .includes(user.profile.company)
@@ -55,7 +55,7 @@ describe("ViewProfileDisplay", () => {
     assert.isFalse(wrapper.find(".submit-row").exists())
     assert.isTrue(
       wrapper
-        .find(".auth-page")
+        .find(".view-profile")
         .text()
         .includes("You must be logged in to view your profile.")
     )

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -147,8 +147,10 @@ export const RECEIPT_PAGE_TITLE = "Receipt"
 
 export const APPLICATIONS_DASHBOARD_PAGE_TITLE = "Dashboard"
 
+export const CMS_SITE_WIDE_NOTIFICATION = "cms-site-wide-notification"
+
+// Drawer content types
 export const PROFILE_VIEW = "profileView"
 export const PROFILE_EDIT = "profileEdit"
 export const PAYMENT = "payment"
-
-export const CMS_SITE_WIDE_NOTIFICATION = "cms-site-wide-notification"
+export const NEW_APPLICATION = "newApplication"

--- a/static/js/factories/user.js
+++ b/static/js/factories/user.js
@@ -1,10 +1,10 @@
 // @flow
 import casual from "casual-browserify"
+import moment from "moment"
 
 import { incrementer } from "../util/util"
 
 import type { AnonymousUser, LoggedInUser } from "../flow/authTypes"
-import moment from "moment"
 
 const incr = incrementer()
 
@@ -54,6 +54,8 @@ export const makeCompleteUser = (username: ?string): LoggedInUser => {
   const fakeUser = makeUser(username)
   // $FlowFixMe: Profile can't be undefined
   fakeUser.profile.name = moment().format()
+  // $FlowFixMe: Profile can't be undefined
+  fakeUser.profile.updated_on = moment().format()
   // $FlowFixMe: Profile can't be undefined
   fakeUser.profile.is_complete = true
   return fakeUser

--- a/static/js/flow/bootcampTypes.js
+++ b/static/js/flow/bootcampTypes.js
@@ -51,4 +51,4 @@ export type PayableBootcampRun = {
   installments: Array<Installment>
 }
 
-export type BootcampRunsResponse = Array<PayableBootcampRun>
+export type PayableRunsResponse = Array<PayableBootcampRun>

--- a/static/js/lib/queries/applications.js
+++ b/static/js/lib/queries/applications.js
@@ -1,6 +1,8 @@
 // @flow
 import { objOf } from "ramda"
+
 import { nextState } from "./util"
+import { getCookie } from "../api"
 
 import type {
   Application,
@@ -8,8 +10,15 @@ import type {
   ApplicationDetailState
 } from "../../flow/applicationTypes"
 
+const DEFAULT_NON_GET_OPTIONS = {
+  headers: {
+    "X-CSRFTOKEN": getCookie("csrftoken")
+  }
+}
+
 const applicationsKey = "applications"
 const applicationDetailKey = "applicationDetail"
+export const createAppQueryKey = "createApplication"
 
 export const applicationsSelector = (state: any): ?Array<Application> =>
   state.entities[applicationsKey]
@@ -24,6 +33,25 @@ export default {
     transform: objOf(applicationsKey),
     update:    {
       [applicationsKey]: nextState
+    }
+  }),
+  createApplicationMutation: (bootcampRunId: number) => ({
+    queryKey: createAppQueryKey,
+    url:      "/api/applications/",
+    options:  {
+      ...DEFAULT_NON_GET_OPTIONS,
+      method: "POST"
+    },
+    body: {
+      bootcamp_run_id: bootcampRunId
+    },
+    transform: objOf(applicationsKey),
+    update:    {
+      // If successful, add the newly-created application to the list of loaded applications
+      [applicationsKey]: (
+        prev: Array<Application>,
+        newApplication: Application
+      ) => [...(prev || []), newApplication]
     }
   }),
   applicationDetailQuery: (applicationId: string) => ({

--- a/static/js/lib/queries/bootcamps.js
+++ b/static/js/lib/queries/bootcamps.js
@@ -1,16 +1,38 @@
 // @flow
-import type { BootcampRunsResponse } from "../../flow/bootcampTypes"
+import { nextState } from "./util"
+
+import type { BootcampRun, PayableRunsResponse } from "../../flow/bootcampTypes"
+
+export const bootcampRunsKey = "bootcampRuns"
+export const payableRunsEntityKey = "payableRuns"
+export const payableRunsQueryKey = payableRunsEntityKey
+
+export const bootcampRunsSelector = (state: any): ?Array<BootcampRun> =>
+  state.entities[bootcampRunsKey]
 
 export default {
-  bootcampRunQuery: (username: string) => ({
-    queryKey:  "bootcampRuns",
-    url:       `/api/v0/bootcamps/${username}/`,
-    transform: (json: ?BootcampRunsResponse) => ({
-      bootcampRuns: json
+  bootcampRunsQuery: () => ({
+    queryKey:  bootcampRunsKey,
+    url:       "/api/bootcampruns/?available=true",
+    transform: (json: Array<BootcampRun>) => ({
+      [bootcampRunsKey]: json
     }),
     update: {
-      bootcampRuns: (prev: BootcampRunsResponse, next: BootcampRunsResponse) =>
-        next
+      [bootcampRunsKey]: nextState
+    },
+    force: true
+  }),
+  payableBootcampRunsQuery: (username: string) => ({
+    queryKey:  payableRunsQueryKey,
+    url:       `/api/v0/bootcamps/${username}/`,
+    transform: (json: ?PayableRunsResponse) => ({
+      [payableRunsEntityKey]: json
+    }),
+    update: {
+      [payableRunsEntityKey]: (
+        prev: PayableRunsResponse,
+        next: PayableRunsResponse
+      ) => next
     },
     force: true
   })

--- a/static/js/lib/queries/util.js
+++ b/static/js/lib/queries/util.js
@@ -1,5 +1,23 @@
 // @flow
-import { nthArg } from "ramda"
+import { nthArg, pathOr } from "ramda"
 
-// replace the previous state with the next state without merging
+/*
+ * Replaces the previous state with the next state without merging. For use in an "update" function in a redux-query
+ * config. Using this function means that once you get data back from a query, you no longer need any data that was
+ * previously loaded for that query.
+ */
 export const nextState = nthArg(1)
+
+/*
+ * Produces a function that takes the redux state and tells you if the query with the given key is currently pending.
+ * Defaults to false.
+ */
+export const isQueryPending = (queryKey: string): boolean =>
+  pathOr(false, ["queries", queryKey, "isPending"])
+
+/*
+ * Produces a function that takes the redux state and tells you if the query with the given key is finished.
+ * Defaults to false.
+ */
+export const isQueryFinished = (queryKey: string): boolean =>
+  pathOr(false, ["queries", queryKey, "isFinished"])

--- a/static/js/lib/queries/util_test.js
+++ b/static/js/lib/queries/util_test.js
@@ -1,0 +1,45 @@
+import { assert } from "chai"
+
+import { isQueryPending, isQueryFinished } from "./util"
+
+describe("Redux-query util", () => {
+  const fakeQueryKey = "myQuery"
+
+  it("isQueryPending indicates whether or not a query is pending", () => {
+    let result,
+      state = {}
+    result = isQueryPending(fakeQueryKey)(state)
+    assert.isFalse(result)
+    state = {
+      queries: {
+        [fakeQueryKey]: {
+          isPending: false
+        }
+      }
+    }
+    result = isQueryPending(fakeQueryKey)(state)
+    assert.isFalse(result)
+    state.queries[fakeQueryKey].isPending = true
+    result = isQueryPending(fakeQueryKey)(state)
+    assert.isTrue(result)
+  })
+
+  it("isQueryFinished indicates whether or not a query is finished", () => {
+    let result,
+      state = {}
+    result = isQueryFinished(fakeQueryKey)(state)
+    assert.isFalse(result)
+    state = {
+      queries: {
+        [fakeQueryKey]: {
+          isFinished: false
+        }
+      }
+    }
+    result = isQueryFinished(fakeQueryKey)(state)
+    assert.isFalse(result)
+    state.queries[fakeQueryKey].isFinished = true
+    result = isQueryFinished(fakeQueryKey)(state)
+    assert.isTrue(result)
+  })
+})

--- a/static/js/pages/PaymentPage_test.js
+++ b/static/js/pages/PaymentPage_test.js
@@ -15,7 +15,7 @@ describe("PaymentPage", () => {
   const paymentInputSelector = 'input[id="payment-amount"]'
   const paymentBtnSelector = "button.large-cta"
 
-  let helper, bootcampRunsUrl, fakeRuns, renderPage, user
+  let helper, payableRunsUrl, fakeRuns, renderPage, user
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -24,7 +24,7 @@ describe("PaymentPage", () => {
       .withArgs("/api/v0/me/")
       .returns({ status: 200, body: user })
 
-    bootcampRunsUrl = `/api/v0/bootcamps/${user.username}/`
+    payableRunsUrl = `/api/v0/bootcamps/${user.username}/`
     fakeRuns = generateFakePayableRuns(3, {
       hasInstallment: true,
       hasPayment:     true
@@ -35,12 +35,12 @@ describe("PaymentPage", () => {
       InnerPaymentPage,
       {
         entities: {
-          bootcampRuns: fakeRuns,
-          payment:      null,
-          currentUser:  user
+          payableRuns: fakeRuns,
+          payment:     null,
+          currentUser: user
         },
         queries: {
-          bootcampRuns: {
+          payableRuns: {
             isPending:  false,
             isFinished: true
           },
@@ -303,12 +303,12 @@ describe("PaymentPage", () => {
         window.location = `/pay?status=receipt&order=missing`
         await renderPage()
         assert.equal(
-          helper.handleRequestStub.withArgs(bootcampRunsUrl).callCount,
+          helper.handleRequestStub.withArgs(payableRunsUrl).callCount,
           1
         )
         clock.tick(3501)
         assert.equal(
-          helper.handleRequestStub.withArgs(bootcampRunsUrl).callCount,
+          helper.handleRequestStub.withArgs(payableRunsUrl).callCount,
           2
         )
       })

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -31,7 +31,8 @@ import {
   APPLICATIONS_DASHBOARD_PAGE_TITLE,
   SUBMISSION_VIDEO,
   SUBMISSION_QUIZ,
-  REVIEW_STATUS_APPROVED
+  REVIEW_STATUS_APPROVED,
+  NEW_APPLICATION
 } from "../../constants"
 
 import type {
@@ -85,6 +86,18 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
         ...this.state.collapseVisible,
         [applicationId]: !this.state.collapseVisible[applicationId]
       }
+    })
+  }
+
+  onNewApplicationClick = (): void => {
+    const { applications, openDrawer } = this.props
+
+    const appliedRunIds = applications.map(
+      (application: Application) => application.bootcamp_run.id
+    )
+    openDrawer({
+      type: NEW_APPLICATION,
+      meta: { appliedRunIds }
     })
   }
 
@@ -262,18 +275,64 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
   render() {
     const { currentUser, applications } = this.props
 
-    return applications && currentUser ? (
+    if (!applications || !currentUser) {
+      return null
+    }
+
+    const hasApplications = applications.length > 0
+
+    return (
       <div className="container applications-page">
         <MetaTags>
           <title>{formatTitle(APPLICATIONS_DASHBOARD_PAGE_TITLE)}</title>
         </MetaTags>
-        <h1>{APPLICATIONS_DASHBOARD_PAGE_TITLE}</h1>
-        {currentUser.profile && currentUser.profile.name ? (
-          <h2 className="name">{currentUser.profile.name}</h2>
-        ) : null}
-        {applications && applications.map(this.renderApplicationCard)}
+        <div className="row justify-content-between">
+          <div
+            className={`col-12 ${hasApplications ? "col-md-7 col-lg-8" : ""}`}
+          >
+            <h1 className="m-0">{APPLICATIONS_DASHBOARD_PAGE_TITLE}</h1>
+            {currentUser.profile && currentUser.profile.name ? (
+              <h2 className="mt-4 mb-0 name">{currentUser.profile.name}</h2>
+            ) : null}
+          </div>
+          {hasApplications && (
+            <div className="col-12 col-md-5 col-lg-4 mt-4 mt-md-0 text-md-right">
+              <div className="mb-1 caption">
+                Interested in another bootcamp?
+              </div>
+              <button
+                className="btn btn-red btn-inverse new-application-btn"
+                onClick={this.onNewApplicationClick}
+              >
+                Select Bootcamp
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="row mt-4">
+          <div className="col-12">
+            {hasApplications ? (
+              applications.map(this.renderApplicationCard)
+            ) : (
+              <React.Fragment>
+                <p>
+                  Thank you for registering and welcome to MIT Bootcamps.
+                  <br />
+                  Please click the button below to select the bootcamp you wish
+                  to apply to.
+                </p>
+                <button
+                  className="btn btn-red btn-inverse new-application-btn"
+                  onClick={this.onNewApplicationClick}
+                >
+                  Select Bootcamp
+                </button>
+              </React.Fragment>
+            )}
+          </div>
+        </div>
       </div>
-    ) : null
+    )
   }
 }
 

--- a/static/js/pages/applications/ApplicationDashboardPage_test.js
+++ b/static/js/pages/applications/ApplicationDashboardPage_test.js
@@ -11,6 +11,7 @@ import ApplicationDashboardPage, {
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import {
   APP_STATE_TEXT_MAP,
+  NEW_APPLICATION,
   SUBMISSION_QUIZ,
   SUBMISSION_VIDEO
 } from "../../constants"
@@ -123,6 +124,24 @@ describe("ApplicationDashboardPage", () => {
         .find("img")
         .exists()
     )
+  })
+
+  it("shows a button to open the new application drawer", async () => {
+    const openDrawerStub = sinon.spy()
+    const { wrapper, store } = await renderPage({ openDrawer: openDrawerStub })
+
+    const newAppButton = wrapper.find("button.new-application-btn")
+    await newAppButton.simulate("click")
+    await wait()
+
+    const appliedRunIds = fakeApplications.map(
+      (application: Application) => application.bootcamp_run.id
+    )
+    assert.deepEqual(store.getState().drawer, {
+      drawerState: NEW_APPLICATION,
+      drawerOpen:  true,
+      drawerMeta:  { appliedRunIds: appliedRunIds }
+    })
   })
 
   it("loads detailed application data when the detail section is expanded", async () => {

--- a/static/scss/_inputs.scss
+++ b/static/scss/_inputs.scss
@@ -29,12 +29,31 @@
   }
 }
 
-a.btn {
-  display: inline-block;
-  text-decoration: none;
+.btn-red.btn-inverse {
+  color: $button-red;
+  border-color: $button-red;
+  background-color: $white;
+  border-width: 2px;
+  font-weight: 600;
 
-  &.large-cta {
-    line-height: 60px;
+  &:disabled, &[disabled] {
+    color: $med-dark-gray;
+    border-color: $med-dark-gray;
+  }
+}
+
+a.btn-text {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+a.btn-link {
+  cursor: pointer;
+  text-decoration: none;
+  color: $link-blue;
+
+  &:hover {
+    color: $link-blue;
   }
 }
 
@@ -90,6 +109,39 @@ input[type=number] {
   }
 }
 // sass-lint:enable no-vendor-prefixes
+
+.dropdown.standard-select {
+  .dropdown-toggle {
+    background-color: $white;
+    color: $default-text-color;
+    border: 1px solid $black;
+  }
+}
+
+.dropdown.full-width {
+  position: relative;
+  white-space: normal;
+
+  .dropdown-toggle {
+    width: 100%;
+    padding-right: 24px;
+  }
+
+  .dropdown-toggle::after {
+    position: absolute;
+    right: 15px;
+    top: 50%;
+    margin-top: -2.5px;
+  }
+
+  .dropdown-menu {
+    width: 100%;
+
+    .dropdown-item:first-of-type {
+      margin-top: 0;
+    }
+  }
+}
 
 // Adapted from http://codepen.io/fil_dev/pen/oZNXzw
 .styled-select-container {

--- a/static/scss/_shared.scss
+++ b/static/scss/_shared.scss
@@ -21,18 +21,6 @@ h3 {
   font-weight: 600;
 }
 
-.desc {
-  font-size: 24px;
-  line-height: 32px;
-  font-weight: 300;
-  color: $default-text-color;
-
-  @include breakpoint(phone) {
-    font-size: 20px;
-    line-height: 25px;
-  }
-}
-
 h3.section-header {
   display: flex;
   align-items: center;
@@ -53,19 +41,25 @@ h3.section-header {
   }
 }
 
-a.btn-text {
-  cursor: pointer;
-  text-decoration: none;
+.desc {
+  font-size: 24px;
+  line-height: 32px;
+  font-weight: 300;
+  color: $default-text-color;
+
+  @include breakpoint(phone) {
+    font-size: 20px;
+    line-height: 25px;
+  }
 }
 
-a.btn-link {
-  cursor: pointer;
-  text-decoration: none;
-  color: $link-blue;
+p, .std-text {
+  font-size: 16px;
+  letter-spacing: 1.73px;
+}
 
-  &:hover {
-    color: $link-blue;
-  }
+.caption {
+  font-size: 12px;
 }
 
 .text-info-page {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -10,6 +10,7 @@ $placeholder-color: #bbb;
 $input-font-size: 16px;
 
 $primary: #a31f34;
+$button-red: #ec654d;
 $medium-soft-light-gray: #e6e6e6;
 $med-gray: #b1b1b1;
 $med-dark-gray: #707070;

--- a/static/scss/application.scss
+++ b/static/scss/application.scss
@@ -4,10 +4,6 @@ $progress-circle-size: 60px;
 $checkmark-size: 34px;
 $border-style: 1px solid $black;
 
-h2.name {
-  margin: 25px 0;
-}
-
 .application-card {
   border: $border-style;
   margin-bottom: 20px;

--- a/static/scss/drawer.scss
+++ b/static/scss/drawer.scss
@@ -10,5 +10,6 @@
   .mdc-drawer__content {
     right: 0px;
     max-width: 600px;
+    padding: 25px;
   }
 }

--- a/static/scss/landing.scss
+++ b/static/scss/landing.scss
@@ -23,3 +23,12 @@
     min-height: none;
   }
 }
+
+a.btn {
+  display: inline-block;
+  text-decoration: none;
+
+  &.large-cta {
+    line-height: 60px;
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #524

#### What's this PR do?
Adds the new application UI, which is launched from the dashboard page

#### How should this be manually tested?
Click the "select bootcamp" button on the dashboard. This should open a drawer with the new application form. The select box should be populated with bootcamp runs that you have never applied to. Clicking "Continue" should make a request to create a new application and close the drawer when it succeeds. You should see the new application in your dashboard.

If you have never applied to a bootcamp, the UI should match the last screenshot

#### Screenshots (if appropriate)
<img width="1279" alt="ss 2020-06-10 at 01 04 28 " src="https://user-images.githubusercontent.com/14932219/84389977-e7da3b00-abc4-11ea-91b8-a646687d9a82.png">
<img width="612" alt="ss 2020-06-10 at 01 04 38 " src="https://user-images.githubusercontent.com/14932219/84389987-eb6dc200-abc4-11ea-82c9-6eb4954d9589.png">
<img width="612" alt="ss 2020-06-10 at 01 05 17 " src="https://user-images.githubusercontent.com/14932219/84389991-ec065880-abc4-11ea-958c-812f33977fc5.png">
<img width="1033" alt="ss 2020-06-10 at 01 05 27 " src="https://user-images.githubusercontent.com/14932219/84389995-ec065880-abc4-11ea-8b1f-6acf5a065241.png">
<img width="1033" alt="ss 2020-06-10 at 01 05 31 " src="https://user-images.githubusercontent.com/14932219/84389996-ec9eef00-abc4-11ea-8a1b-8b9cc34de8ab.png">
<img width="1128" alt="ss 2020-06-11 at 01 31 19 " src="https://user-images.githubusercontent.com/14932219/84389997-ed378580-abc4-11ea-8242-90cbbfa6ac34.png">
