### PR TITLE
product page feedback: carousel fixes

### DIFF
--- a/static/scss/slick.scss
+++ b/static/scss/slick.scss
@@ -117,10 +117,14 @@
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  outline: none;
+  outline: none !important;
   box-shadow: 5px 5px 10px 0 rgba(0, 0, 0, 0.1);
-  margin: -75px 0 0;
+  margin: -85px 0 0;
   cursor: pointer;
+
+  @include media-breakpoint-down(lg) {
+    margin: -70px 0 0;
+  }
 
   @include media-breakpoint-up(md) {
     left: -25px;
@@ -138,7 +142,7 @@
   }
 
   &:hover {
-    color: white;
+    color: $primary;
     background: black;
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?
#653 

#### What's this PR do?
fixes #653
product page feedback: carousel fixes
- Carousel: on rollover, arrow turns white and seems to disappear
- Carousel: hit area for arrows doesn't align with graphic;

#### How should this be manually tested?
Product Page Alumni Section Carousel fixes

#### Screenshots

**Desktop**

<img width="1124" alt="Screenshot 2020-06-17 at 17 37 55" src="https://user-images.githubusercontent.com/4043989/84898913-6a7d6180-b0c1-11ea-8188-396b39d3c2c3.png">

<img width="1124" alt="Screenshot 2020-06-17 at 17 38 23" src="https://user-images.githubusercontent.com/4043989/84898935-70734280-b0c1-11ea-8a77-4d693524c203.png">

**Tablet**

<img width="611" alt="Screenshot 2020-06-17 at 17 41 59" src="https://user-images.githubusercontent.com/4043989/84899315-ef687b00-b0c1-11ea-8baa-373034448334.png">

<img width="756" alt="Screenshot 2020-06-17 at 17 42 23" src="https://user-images.githubusercontent.com/4043989/84899328-f4c5c580-b0c1-11ea-9e66-544514b36077.png">

**Mobile**

<img width="430" alt="Screenshot 2020-06-17 at 17 44 02" src="https://user-images.githubusercontent.com/4043989/84899498-2b034500-b0c2-11ea-8fc6-77fc6727f80d.png">

<img width="345" alt="Screenshot 2020-06-17 at 17 43 24" src="https://user-images.githubusercontent.com/4043989/84899440-18890b80-b0c2-11ea-8aa7-bd5e8b4647e3.png">
