### PR TITLE
Fix typo in Massachusetts

### DIFF
--- a/main/templates/footer.html
+++ b/main/templates/footer.html
@@ -37,7 +37,7 @@
             </div>
             <div class="col-6">
               <ul class="list-unstyled links">
-                <li><a href="/terms-of-service">Terms of Service</a></li>
+                <li><a href="{% url "bootcamp-tos" %}">Terms of Service</a></li>
                 <li><a href="/privacy-policy">Privacy Policy</a></li>
               </ul>
             </div>

--- a/main/templates/footer.html
+++ b/main/templates/footer.html
@@ -37,7 +37,7 @@
             </div>
             <div class="col-6">
               <ul class="list-unstyled links">
-                <li><a href="/terms-of-service">Term of Service</a></li>
+                <li><a href="/terms-of-service">Terms of Service</a></li>
                 <li><a href="/privacy-policy">Privacy Policy</a></li>
               </ul>
             </div>
@@ -48,7 +48,7 @@
             <h3>MIT Bootcamps</h3>
             <address>
                 <b>Massachusetts Institute Of Technology </br>
-                77 Massachusetts Ave Cambridge, MA 02139, USA</b>
+                77 Massachusetts Ave, Cambridge, MA 02139, USA</b>
             </address>
             <a class="mit-open-learning" href="https://openlearning.mit.edu">MIT Open Learning</a>
           </div>

--- a/main/templates/footer.html
+++ b/main/templates/footer.html
@@ -47,8 +47,8 @@
           <div class="address-area">
             <h3>MIT Bootcamps</h3>
             <address>
-                <b>Massachusettes Institute Of Technology </br>
-                77 Massachusettes Ave Cambridge, MA 02139, USA</b>
+                <b>Massachusetts Institute Of Technology </br>
+                77 Massachusetts Ave Cambridge, MA 02139, USA</b>
             </address>
             <a class="mit-open-learning" href="https://openlearning.mit.edu">MIT Open Learning</a>
           </div>


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes spelling of Massachusetts in footer, and makes a few other small changes to fix the terms of service link and a couple grammar fixes

#### How should this be manually tested?
Should have correct spelling when you view the footer
