### PR TITLE
Added feature flag for root/home page view

### DIFF
--- a/main/features.py
+++ b/main/features.py
@@ -3,6 +3,7 @@ from functools import wraps
 from django.conf import settings
 
 SOCIAL_AUTH_API = "SOCIAL_AUTH_API"
+CMS_HOME_PAGE = "CMS_HOME_PAGE"
 
 
 def is_enabled(name, default=None):

--- a/main/urls.py
+++ b/main/urls.py
@@ -14,74 +14,81 @@ from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.images.views.serve import ServeView
 
-from main.views import react, BackgroundImagesCSSView
+from main import features
+from main.views import react, BackgroundImagesCSSView, index
 
+root_urlpatterns = [url("", include(wagtail_urls))]
+if not features.is_enabled(features.CMS_HOME_PAGE):
+    root_urlpatterns = [path("", index, name="deprecated-home")] + root_urlpatterns
 
-urlpatterns = [
-    url(r"^pay/$", react, name="pay"),
-    url(
-        r"^terms_of_service/$",
-        TemplateView.as_view(template_name="bootcamp/tos.html"),
-        name="bootcamp-tos",
-    ),
-    url(
-        r"^terms_and_conditions/$",
-        TemplateView.as_view(template_name="bootcamp/tac.html"),
-        name="bootcamp-tac",
-    ),
-    url(r"^status/", include("server_status.urls")),
-    url(r"^admin/", admin.site.urls),
-    url(r"^hijack/", include("hijack.urls", namespace="hijack")),
-    url("", include("applications.urls")),
-    url("", include("ecommerce.urls")),
-    url("", include("social_django.urls", namespace="social")),
-    path("", include("authentication.urls")),
-    path("", include("profiles.urls")),
-    path("", include("klasses.urls")),
-    url("", include("jobma.urls")),
-    url(r"^logout/$", auth_views.LogoutView.as_view(), name="logout"),
-    url(
-        r"^background-images\.css$",
-        BackgroundImagesCSSView.as_view(),
-        name="background-images-css",
-    ),
-    # named routes mapped to the react app
-    path("signin/", react, name="login"),
-    path("signin/password/", react, name="login-password"),
-    re_path(r"^signin/forgot-password/$", react, name="password-reset"),
-    re_path(
-        r"^signin/forgot-password/confirm/(?P<uid>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$",
-        react,
-        name="password-reset-confirm",
-    ),
-    re_path(
-        r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
-        ServeView.as_view(),
-        name="wagtailimages_serve",
-    ),
-    path("create-account/", react, name="signup"),
-    path("create-account/details/", react, name="signup-details"),
-    path("create-account/extra/", react, name="signup-extra"),
-    path("create-account/denied/", react, name="signup-denied"),
-    path("create-account/error/", react, name="signup-error"),
-    path("create-account/confirm/", react, name="register-confirm"),
-    path("account/inactive/", react, name="account-inactive"),
-    path("account/confirm-email/", react, name="account-confirm-email-change"),
-    path("account-settings/", react, name="account-settings"),
-    path("applications/", react, name="applications"),
-    re_path(r"^review/", react, name="review"),
-    # Wagtail
-    re_path(
-        r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
-        ServeView.as_view(),
-        name="wagtailimages_serve",
-    ),
-    re_path(r"^cms/", include(wagtailadmin_urls)),
-    re_path(r"^documents/", include(wagtaildocs_urls)),
-    url("", include(wagtail_urls)),
-] + (
-    static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-    + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+urlpatterns = (
+    [
+        url(r"^pay/$", react, name="pay"),
+        url(
+            r"^terms_of_service/$",
+            TemplateView.as_view(template_name="bootcamp/tos.html"),
+            name="bootcamp-tos",
+        ),
+        url(
+            r"^terms_and_conditions/$",
+            TemplateView.as_view(template_name="bootcamp/tac.html"),
+            name="bootcamp-tac",
+        ),
+        url(r"^status/", include("server_status.urls")),
+        url(r"^admin/", admin.site.urls),
+        url(r"^hijack/", include("hijack.urls", namespace="hijack")),
+        url("", include("applications.urls")),
+        url("", include("ecommerce.urls")),
+        url("", include("social_django.urls", namespace="social")),
+        path("", include("authentication.urls")),
+        path("", include("profiles.urls")),
+        path("", include("klasses.urls")),
+        url("", include("jobma.urls")),
+        url(r"^logout/$", auth_views.LogoutView.as_view(), name="logout"),
+        url(
+            r"^background-images\.css$",
+            BackgroundImagesCSSView.as_view(),
+            name="background-images-css",
+        ),
+        # named routes mapped to the react app
+        path("signin/", react, name="login"),
+        path("signin/password/", react, name="login-password"),
+        re_path(r"^signin/forgot-password/$", react, name="password-reset"),
+        re_path(
+            r"^signin/forgot-password/confirm/(?P<uid>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$",
+            react,
+            name="password-reset-confirm",
+        ),
+        re_path(
+            r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
+            ServeView.as_view(),
+            name="wagtailimages_serve",
+        ),
+        path("create-account/", react, name="signup"),
+        path("create-account/details/", react, name="signup-details"),
+        path("create-account/extra/", react, name="signup-extra"),
+        path("create-account/denied/", react, name="signup-denied"),
+        path("create-account/error/", react, name="signup-error"),
+        path("create-account/confirm/", react, name="register-confirm"),
+        path("account/inactive/", react, name="account-inactive"),
+        path("account/confirm-email/", react, name="account-confirm-email-change"),
+        path("account-settings/", react, name="account-settings"),
+        path("applications/", react, name="applications"),
+        re_path(r"^review/", react, name="review"),
+        # Wagtail
+        re_path(
+            r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
+            ServeView.as_view(),
+            name="wagtailimages_serve",
+        ),
+        re_path(r"^cms/", include(wagtailadmin_urls)),
+        re_path(r"^documents/", include(wagtaildocs_urls)),
+    ]
+    + root_urlpatterns
+    + (
+        static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+        + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    )
 )
 
 handler404 = "main.views.page_404"

--- a/main/urls_test.py
+++ b/main/urls_test.py
@@ -1,5 +1,9 @@
 """Tests for URLs"""
-from django.urls import reverse
+from django.urls import reverse, resolve
+
+from main.features import CMS_HOME_PAGE
+from main.test_utils import reload_urlconf, patched_feature_enabled
+from main.views import index as deprecated_index
 
 
 def test_urls():
@@ -7,3 +11,24 @@ def test_urls():
     assert reverse("pay") == "/pay/"
     assert reverse("create-payment") == "/api/v0/payment/"
     assert reverse("order-fulfillment") == "/api/v0/order_fulfillment/"
+
+
+def test_cms_home_page_feature_flag(mocker):
+    """Tests that the CMS home page feature flag correctly sets the view to handle the root URL"""
+    feature_enabled_patch = mocker.patch(
+        "main.features.is_enabled",
+        side_effect=patched_feature_enabled({CMS_HOME_PAGE: False}),
+    )
+    reload_urlconf()
+    view = resolve("/")
+    assert view.func == deprecated_index  # pylint: disable=comparison-with-callable
+    feature_enabled_patch.assert_called_once_with(CMS_HOME_PAGE)
+    feature_enabled_patch.reset_mock()
+    feature_enabled_patch = mocker.patch(
+        "main.features.is_enabled",
+        side_effect=patched_feature_enabled({CMS_HOME_PAGE: True}),
+    )
+    reload_urlconf()
+    view = resolve("/")
+    assert view.view_name == "wagtail_serve"
+    feature_enabled_patch.assert_called_once_with(CMS_HOME_PAGE)

--- a/static/scss/_inputs.scss
+++ b/static/scss/_inputs.scss
@@ -9,7 +9,6 @@
     background-image: linear-gradient(to right, $mit-brand 0%, $red-fade-to 100%);
     border-radius: 3px;
     font-size: 16px;
-    height: 60px;
     font-weight: 400;
     letter-spacing: 2px;
   }


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
Adds a feature flag which sets our root route to serve the deprecated home page if False, or the CMS home page if True

#### How should this be manually tested?
Set the feature flag in your `.env` to true/false, check the root route to make sure it shows the expected page

#### Any background context you want to provide?
This is going to unblock releases while we figure out the home page contents
