### PR TITLE
Product page feedback: hero section updates

### DIFF
--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -9,10 +9,10 @@
   <div class="product-page">
     <div class="header">
       {% image page.header_image fill-1920x1080 %}
-      <div class="d-flex flex-column container-fluid">
+      <div class="d-flex flex-column container min-vh-100">
           <div class="row flex-grow-1"></div>
           <div class="row">
-              <div class="col-md-10 offset-md-2 title">
+              <div class="col-md-10 title">
                   <h1>{{ page.title }}</h1>
                   <h2>{{ page.subhead }}</h2>
                   <h3>{{ page.bootcamp_run.start_date|date }} - {{ page.bootcamp_run.end_date|date }}</h3>
@@ -20,9 +20,9 @@
           </div>
           <div class="row flex-grow-1"></div>
           <div class="row">
-              <div class="col-md-8 col-sm-12 bg-white py-5">
+              <div class="col-md-8 col-sm-12 bg-white py-5 left-screen">
                   <div class="row">
-                      <div class="col-md-10 offset-md-2 col-sm-12 border-left">
+                      <div class="col-sm-12 border-left">
                           {{ page.description|richtext }}
                       </div>
                   </div>

--- a/main/templates/navbar.html
+++ b/main/templates/navbar.html
@@ -1,4 +1,5 @@
 {% load static %}
+<header class="container">
   <nav class="navbar" role="navigation">
       <div class="navbar-header">
         <div class="pull-left">
@@ -23,3 +24,4 @@
         </div>
       </div>
   </nav>
+</header>

--- a/main/templates/top_nav.html
+++ b/main/templates/top_nav.html
@@ -1,31 +1,33 @@
 {% load static %}
-<nav class="navbar navbar-expand-sm navbar-light bg-light" role="navigation">
-    <div class="navbar-brand d-flex align-items-center">
-        <a class="brand-logo-svg border-right border-dark" href="https://www.mit.edu"></a>
-        <div class="bootcamp-link border-left border-dark">
-            <a href="/">Bootcamp</a>
+<header class="container">
+    <nav class="navbar navbar-expand-sm navbar-light" role="navigation">
+        <div class="navbar-brand d-flex align-items-center">
+            <a class="brand-logo-svg border-right border-dark" href="https://www.mit.edu"></a>
+            <div class="bootcamp-link border-left border-dark">
+                <a href="/">Bootcamp</a>
+            </div>
         </div>
-    </div>
-    <button class="navbar-toggler ml-auto" type="button" data-toggle="collapse" data-target="#navbarLinks" aria-controls="navbarLinks" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarLinks">
-        <ul class="navbar-nav align-items-center ml-auto">
-            <li class="nav-item">
-                <a class="nav-link" href="/">Home</a>
-            </li>
-            <!-- Bootcamps dropdown here -->
-            <li class="nav-item">
-                <a class="nav-link" href="/admissions">Admissions</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" href="/team">Team</a>
-            </li>
-            {% if not user.is_anonymous %}
+        <button class="navbar-toggler ml-auto" type="button" data-toggle="collapse" data-target="#navbarLinks" aria-controls="navbarLinks" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarLinks">
+            <ul class="navbar-nav align-items-center ml-auto">
                 <li class="nav-item">
-                    <!-- User dropdown here -->
+                    <a class="nav-link" href="/">Home</a>
                 </li>
-            {% endif %}
-        </ul>
-    </div>
-</nav>
+                <!-- Bootcamps dropdown here -->
+                <li class="nav-item">
+                    <a class="nav-link" href="/admissions">Admissions</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/team">Team</a>
+                </li>
+                {% if not user.is_anonymous %}
+                    <li class="nav-item">
+                        <!-- User dropdown here -->
+                    </li>
+                {% endif %}
+            </ul>
+        </div>
+    </nav>
+</header>

--- a/static/scss/cms/product.scss
+++ b/static/scss/cms/product.scss
@@ -2,9 +2,8 @@
 .product-page {
   .header {
     position: relative;
-    height: 100vh;
 
-    .container-fluid {
+    .container {
       height: 100%;
     }
 
@@ -18,9 +17,11 @@
     }
 
     .title {
-      h1, h2, h3 {
+      h1,
+      h2,
+      h3 {
         color: white;
-    }
+      }
 
       h1 {
         font-size: 3.5em;
@@ -33,6 +34,26 @@
       h3 {
         font-size: 1.5em;
       }
+
+      @include media-breakpoint-only(xs) {
+        h1 {
+          font-size: 2.5em;
+        }
+      }
+    }
+  }
+
+  .left-screen {
+    position: relative;
+
+    &::after {
+      position: absolute;
+      background-color: white;
+      content: "";
+      width: 9999px;
+      height: 100%;
+      top: 0;
+      right: 100%;
     }
   }
 }

--- a/static/scss/footer.scss
+++ b/static/scss/footer.scss
@@ -89,9 +89,10 @@
 
   .address-area {
     margin: 0 auto;
-    max-width: 200px;
+    max-width: 270px;
     @include media-breakpoint-down(sm) {
       margin: 0 0 15px;
+      max-width: 100%;
     }
 
     .mit-open-learning {

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -66,12 +66,11 @@ body .standard-layout.deprecated-styling {
 .navbar {
   background-color: $white;
   border-radius: 0;
-  border-bottom: 1px solid $black;
   min-height: $toolbar-height;
-  padding: 3px 27px 3px 33px;
+  padding: 3px 0px 3px 0px;
 
   @include breakpoint(phone) {
-    padding: 3px 18px;
+    padding: 3px 0px;
   }
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?
#672 

#### What's this PR do?
fixes #672 
- Bootcamp title should be left-aligned with “hero text” (See InVision)
- Bootcamp title in hero section is clipped at narrow widths
- Footer: "Massachusetts Institute of Technology" breaks onto two lines when it doesn't need to

#### How should this be manually tested?
Visit the product page hero section and the footer section

#### Screenshots (if appropriate)
**Desktop**

<img width="1031" alt="Screenshot 2020-06-17 at 18 37 33" src="https://user-images.githubusercontent.com/4043989/84906854-eaa8c480-b0cb-11ea-9907-310e15ba16b1.png">
<img width="1033" alt="Screenshot 2020-06-17 at 18 37 40" src="https://user-images.githubusercontent.com/4043989/84906874-f1373c00-b0cb-11ea-9240-4db7f6d0a20f.png">

**Tablet**

<img width="770" alt="Screenshot 2020-06-17 at 18 37 59" src="https://user-images.githubusercontent.com/4043989/84906996-162baf00-b0cc-11ea-9fb9-2e5701f240b2.png">
<img width="776" alt="Screenshot 2020-06-17 at 18 37 51" src="https://user-images.githubusercontent.com/4043989/84907012-1a57cc80-b0cc-11ea-8864-c97c6da6a82a.png">

**Mobile**

<img width="430" alt="Screenshot 2020-06-17 at 18 39 38" src="https://user-images.githubusercontent.com/4043989/84907057-2c396f80-b0cc-11ea-9152-e23c6313ab0f.png">
<img width="443" alt="Screenshot 2020-06-17 at 18 39 44" src="https://user-images.githubusercontent.com/4043989/84907071-3196ba00-b0cc-11ea-9b83-390a188321e3.png">
