### PR TITLE
Allow submission review decisions to be reversed

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -219,6 +219,18 @@ class BootcampApplication(TimestampedModel):
     def reject_submission(self):
         """Reject application submission"""
 
+    @transition(
+        field=state,
+        source=[
+            AppStates.REJECTED.value,
+            AppStates.AWAITING_PAYMENT.value,
+            AppStates.AWAITING_USER_SUBMISSIONS.value,
+        ],
+        target=AppStates.AWAITING_SUBMISSION_REVIEW.value,
+    )
+    def revert_decision(self):
+        """Revert previous submission decision"""
+
     def all_application_steps_submitted(self):
         """
         Check if the user has submissions for all application steps.

--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -131,11 +131,15 @@ class SubmissionReviewSerializer(SubmissionSerializer):
         bootcamp_application = self.instance.bootcamp_application
 
         if "review_status" in attrs:
-            if bootcamp_application.state not in (
-                AppStates.AWAITING_SUBMISSION_REVIEW.value,
-                AppStates.AWAITING_USER_SUBMISSIONS.value,
-                AppStates.AWAITING_PAYMENT.value,
-                AppStates.REJECTED.value,
+            if (
+                bootcamp_application.state
+                not in (
+                    AppStates.AWAITING_SUBMISSION_REVIEW.value,
+                    AppStates.AWAITING_USER_SUBMISSIONS.value,
+                    AppStates.AWAITING_PAYMENT.value,
+                    AppStates.REJECTED.value,
+                )
+                or bootcamp_application.total_paid > 0
             ):
                 # HTTP 409 error
                 raise InvalidApplicationStateException(

--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -7,6 +7,7 @@ from applications.constants import (
     AppStates,
     REVIEW_STATUS_APPROVED,
     REVIEW_STATUS_REJECTED,
+    REVIEW_STATUS_WAITLISTED,
 )
 from applications.exceptions import InvalidApplicationStateException
 from applications.models import VideoInterviewSubmission
@@ -130,7 +131,12 @@ class SubmissionReviewSerializer(SubmissionSerializer):
         bootcamp_application = self.instance.bootcamp_application
 
         if "review_status" in attrs:
-            if bootcamp_application.state != AppStates.AWAITING_SUBMISSION_REVIEW.value:
+            if bootcamp_application.state not in (
+                AppStates.AWAITING_SUBMISSION_REVIEW.value,
+                AppStates.AWAITING_USER_SUBMISSIONS.value,
+                AppStates.AWAITING_PAYMENT.value,
+                AppStates.REJECTED.value,
+            ):
                 # HTTP 409 error
                 raise InvalidApplicationStateException(
                     detail="The BootcampApplication is not awaiting submission review (id: {}, state: {})".format(
@@ -147,6 +153,10 @@ class SubmissionReviewSerializer(SubmissionSerializer):
 
         if "review_status" in validated_data:
             bootcamp_application = instance.bootcamp_application
+            if bootcamp_application.state != AppStates.AWAITING_SUBMISSION_REVIEW.value:
+                bootcamp_application.revert_decision()
+                if instance.review_status == REVIEW_STATUS_WAITLISTED:
+                    bootcamp_application.save()
             if instance.review_status == REVIEW_STATUS_APPROVED:
                 bootcamp_application.approve_submission()
                 bootcamp_application.save()

--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -142,11 +142,7 @@ class SubmissionReviewSerializer(SubmissionSerializer):
                 or bootcamp_application.total_paid > 0
             ):
                 # HTTP 409 error
-                raise InvalidApplicationStateException(
-                    detail="The BootcampApplication is not awaiting submission review (id: {}, state: {})".format(
-                        bootcamp_application.id, bootcamp_application.state
-                    )
-                )
+                raise InvalidApplicationStateException()
             attrs["review_status_date"] = now_in_utc()
 
         return attrs

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -373,6 +373,4 @@ def test_submission_review_serializer_validation(app_state, total_paid):
     )
     with pytest.raises(InvalidApplicationStateException) as ex:
         serializer.is_valid()
-    assert (
-        "The BootcampApplication is not awaiting submission review" in ex.value.detail
-    )
+    assert ex.value.detail == "Bootcamp application is in invalid state"

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -347,16 +347,22 @@ def test_submission_review_serializer_reverse_decision(
 
 
 @pytest.mark.parametrize(
-    "app_state",
+    "app_state,total_paid",
     [
-        AppStates.AWAITING_RESUME,
-        AppStates.COMPLETE,
-        AppStates.AWAITING_PROFILE_COMPLETION,
+        [AppStates.AWAITING_RESUME, 0],
+        [AppStates.COMPLETE, 0],
+        [AppStates.AWAITING_PROFILE_COMPLETION, 0],
+        [AppStates.AWAITING_SUBMISSION_REVIEW, 40],
     ],
 )
-def test_submission_review_serializer_validation(app_state):
+def test_submission_review_serializer_validation(app_state, total_paid):
     """Test that status changes are invalidated if the application state is incorrect"""
     bootcamp_application = BootcampApplicationFactory.create(state=app_state)
+    if total_paid > 0:
+        OrderFactory.create(
+            application=bootcamp_application, total_price_paid=total_paid
+        )
+
     submission = ApplicationStepSubmissionFactory.create(
         review_status=REVIEW_STATUS_PENDING,
         bootcamp_application=bootcamp_application,

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -273,9 +273,7 @@ def test_submission_review_serializer_update(
         )
 
     serializer = SubmissionReviewSerializer(submission, {"review_status": review})
-    serializer.is_valid()
-
-    assert serializer.errors == {}
+    assert serializer.is_valid() is True
 
     serializer.save()
 
@@ -333,9 +331,7 @@ def test_submission_review_serializer_reverse_decision(
     )
 
     serializer = SubmissionReviewSerializer(submission, {"review_status": new_status})
-    serializer.is_valid()
-
-    assert serializer.errors == {}
+    assert serializer.is_valid() is True
 
     serializer.save()
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #634 - specifically this part:

> New application state transitions added to support the reversal of a review
Technical note: It would probably be easiest to add "rejected" -> "awaiting review" and "accepted" -> "awaiting review". If an admin wanted to reverse a decision from "rejected", for example, we could transition from "rejected" to "awaiting review", then immediately set the review status for the given submission to "approved" (an action which applies its own changes to the overall application state)

#### What's this PR do?
Allows a submission review decision to be reversed after acceptance/rejection, and updates application state accordingly

#### How should this be manually tested?
Go to a pending submission review detail page (`../review/<submission_id>`).  
- Accept the submission.  Confirm the application state is `AWAITING_PAYMENT`
- Reject the submission. Confirm the application state is `REJECTED`
- Waitlist the submission.  Confirm the application state is `AWAITING_SUBMISSION_REVIEW`
- In django admin, manually change the application state to `AWAITING_RESUME`.  Try to change the submission status again, you should get an error message.
- In django admin, manually change the application state back to `AWAITING_SUBMISSION_REVIEW`.  But also add a fulfilled order for the application with an amount greater than 0. Try to change the submission status again, you should get an error message.
