### PR TITLE
enable slugs on product page - fixes #687

### DIFF
--- a/cms/factories.py
+++ b/cms/factories.py
@@ -33,6 +33,7 @@ class BootcampRunPageFactory(wagtail_factories.PageFactory):
     """BootcampRunPage factory class"""
 
     bootcamp_run = factory.SubFactory(BootcampRunFactory)
+    title = factory.fuzzy.FuzzyText(prefix="Bootcamp: ", length=64)
     description = factory.fuzzy.FuzzyText()
     subhead = factory.fuzzy.FuzzyText(prefix="Sub-heading - ")
     header_image = factory.SubFactory(wagtail_factories.ImageFactory)

--- a/cms/models.py
+++ b/cms/models.py
@@ -242,13 +242,6 @@ class BootcampRunPage(BootcampPage):
         context = super().get_context(request)
         return context
 
-    def save(self, *args, **kwargs):
-        # autogenerate a unique slug so we don't hit a ValidationError
-        if not self.title:
-            self.title = self.__class__._meta.verbose_name.title()
-        self.slug = slugify("bootcamp-{}".format(self.bootcamp_run.run_key))
-        super().save(*args, **kwargs)
-
 
 class BootcampRunChildPage(Page):
     """


### PR DESCRIPTION
#### What are the relevant tickets?
#687 

#### What's this PR do?
Disables auto-generation of slugs for product page so it can be set manually. Also updates factories accordingly.

#### How should this be manually tested?
Edit a bootcamp run page's slug manually from the "promote" tab when editing the page. Once done, click on "view live" and make sure the page is served at the correct slug.
