### PR TITLE
Fixed flaky test

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -125,6 +125,7 @@ class ReviewSubmissionPagination(LimitOffsetPagination):
             Bootcamp.objects.values("id", "title")
             .annotate(count=Subquery(qs, output_field=IntegerField()))
             .filter(count__gte=1)
+            .distinct()
         )
         return {"review_statuses": statuses, "bootcamps": bootcamps}
 

--- a/applications/views_test.py
+++ b/applications/views_test.py
@@ -295,6 +295,12 @@ def test_review_submission_list_query_review_status_in(
     assert resp.status_code == status.HTTP_200_OK
     json = resp.json()
     json["results"] = sorted(json["results"], key=lambda s: s["id"])
+    json["facets"]["bootcamps"] = sorted(
+        json["facets"]["bootcamps"], key=lambda b: b["id"]
+    )
+    json["facets"]["review_statuses"] = sorted(
+        json["facets"]["review_statuses"], key=lambda s: s["review_status"]
+    )
     assert json == {
         "count": len(review_statuses),
         "next": None,


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a flaky test `

#### How should this be manually tested?
You can manually test this by applying this diff and running that test file via tox:

```
diff --git i/applications/views_test.py w/applications/views_test.py
index db7e46e..5f5f205 100644
--- i/applications/views_test.py
+++ w/applications/views_test.py
@@ -273,11 +273,12 @@ def test_review_submission_list_query_review_status(admin_drf_client, review_sta
     ],
 )
 def test_review_submission_list_query_review_status_in(
-    admin_drf_client, review_statuses
+    admin_drf_client, review_statuses, attempt
 ):
     """
     The review submission list view should return a list of all submissions filtered by multiple review statuses
     """
+    print(attempt)
     submissions = [
         ApplicationStepSubmissionFactory.create(is_pending=True),
         ApplicationStepSubmissionFactory.create(is_approved=True),
```