### PR TITLE
View statement link should only show up if the user has made a payment

### DIFF
--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -10,6 +10,7 @@ from applications.constants import (
 )
 from applications.exceptions import InvalidApplicationStateException
 from applications.models import VideoInterviewSubmission
+from ecommerce.models import Order
 from ecommerce.serializers import ApplicationOrderSerializer
 from klasses.serializers import BootcampRunSerializer
 from main.utils import now_in_utc
@@ -105,10 +106,19 @@ class BootcampApplicationSerializer(serializers.ModelSerializer):
     """BootcampApplication serializer"""
 
     bootcamp_run = BootcampRunSerializer()
+    has_payments = serializers.SerializerMethodField()
+
+    def get_has_payments(self, application):
+        """Return true if the user has any fulfilled orders for this application"""
+        # IMPORTANT: orders has already been prefetched and filtered status=Order.FULFILLED
+        # If you are using this outside of BootcampApplicationViewset, you will need to
+        # use prefetch_state_data() or similarly prefetch orders with status=Order.FULFILLED.
+        # If you don't, this will count all orders instead of just the fulfilled ones.
+        return bool(application.orders.all())
 
     class Meta:
         model = models.BootcampApplication
-        fields = ["id", "state", "created_on", "bootcamp_run"]
+        fields = ["id", "state", "created_on", "bootcamp_run", "has_payments"]
 
 
 class SubmissionReviewSerializer(SubmissionSerializer):

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -128,13 +128,17 @@ def test_application_detail_serializer_nested(app_data):
     assert data["orders"] == ApplicationOrderSerializer(instance=orders, many=True).data
 
 
-def test_application_list_serializer(app_data):
+@pytest.mark.parametrize("has_payments", [True, False])
+def test_application_list_serializer(app_data, has_payments):
     """
     BootcampApplicationListSerializer should return serialized versions of all of a user's
     bootcamp applications
     """
     other_app = BootcampApplicationFactory.create(user=app_data.application.user)
     user_applications = [app_data.application, other_app]
+    if has_payments:
+        for app in user_applications:
+            OrderFactory.create(application=app, status=Order.FULFILLED)
     data = BootcampApplicationSerializer(instance=user_applications, many=True).data
     assert data == [
         {
@@ -144,6 +148,7 @@ def test_application_list_serializer(app_data):
             "bootcamp_run": BootcampRunSerializer(
                 instance=application.bootcamp_run
             ).data,
+            "has_payments": has_payments
         }
         for application in user_applications
     ]

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -148,7 +148,7 @@ def test_application_list_serializer(app_data, has_payments):
             "bootcamp_run": BootcampRunSerializer(
                 instance=application.bootcamp_run
             ).data,
-            "has_payments": has_payments
+            "has_payments": has_payments,
         }
         for application in user_applications
     ]

--- a/applications/views.py
+++ b/applications/views.py
@@ -47,10 +47,7 @@ class BootcampApplicationViewset(
             return (
                 BootcampApplication.objects.prefetch_related(
                     Prefetch(
-                        "orders",
-                        queryset=Order.objects.filter(
-                            status=Order.FULFILLED
-                        ).select_related("user__profile"),
+                        "orders", queryset=Order.objects.filter(status=Order.FULFILLED)
                     )
                 )
                 .filter(user=self.request.user)

--- a/applications/views.py
+++ b/applications/views.py
@@ -47,7 +47,6 @@ class BootcampApplicationViewset(
             return (
                 BootcampApplication.objects.prefetch_state_data()
                 .filter(user=self.request.user)
-                .annotate(num_orders=Count("orders", status=Order.FULFILLED))
                 .select_related("bootcamp_run__bootcamprunpage")
                 .order_by("-created_on")
             )
@@ -55,7 +54,7 @@ class BootcampApplicationViewset(
     def get_serializer_context(self):
         added_context = {}
         if self.action == "list":
-            added_context = {"include_page": True}
+            added_context = {"include_page": True, "filtered_orders": True}
         return {**super().get_serializer_context(), **added_context}
 
     def get_serializer_class(self):

--- a/applications/views.py
+++ b/applications/views.py
@@ -21,7 +21,6 @@ from applications.serializers import (
 from applications.api import get_or_create_bootcamp_application
 from applications.filters import ApplicationStepSubmissionFilterSet
 from applications.models import BootcampApplication, ApplicationStepSubmission
-from ecommerce.models import Order
 from klasses.models import BootcampRun, Bootcamp
 from main.permissions import UserIsOwnerPermission, UserIsOwnerOrAdminPermission
 

--- a/applications/views.py
+++ b/applications/views.py
@@ -1,7 +1,7 @@
 """Views for bootcamp applications"""
 from collections import OrderedDict
 
-from django.db.models import Count, Subquery, OuterRef, IntegerField
+from django.db.models import Count, Subquery, OuterRef, IntegerField, Prefetch
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets, mixins, status
 from rest_framework.authentication import SessionAuthentication
@@ -21,6 +21,7 @@ from applications.serializers import (
 from applications.api import get_or_create_bootcamp_application
 from applications.filters import ApplicationStepSubmissionFilterSet
 from applications.models import BootcampApplication, ApplicationStepSubmission
+from ecommerce.models import Order
 from klasses.models import BootcampRun, Bootcamp
 from main.permissions import UserIsOwnerPermission, UserIsOwnerOrAdminPermission
 
@@ -44,7 +45,14 @@ class BootcampApplicationViewset(
             return BootcampApplication.objects.prefetch_state_data()
         else:
             return (
-                BootcampApplication.objects.prefetch_state_data()
+                BootcampApplication.objects.prefetch_related(
+                    Prefetch(
+                        "orders",
+                        queryset=Order.objects.filter(
+                            status=Order.FULFILLED
+                        ).select_related("user__profile"),
+                    )
+                )
                 .filter(user=self.request.user)
                 .select_related("bootcamp_run__bootcamprunpage")
                 .order_by("-created_on")

--- a/applications/views.py
+++ b/applications/views.py
@@ -21,6 +21,7 @@ from applications.serializers import (
 from applications.api import get_or_create_bootcamp_application
 from applications.filters import ApplicationStepSubmissionFilterSet
 from applications.models import BootcampApplication, ApplicationStepSubmission
+from ecommerce.models import Order
 from klasses.models import BootcampRun, Bootcamp
 from main.permissions import UserIsOwnerPermission, UserIsOwnerOrAdminPermission
 
@@ -44,7 +45,9 @@ class BootcampApplicationViewset(
             return BootcampApplication.objects.prefetch_state_data()
         else:
             return (
-                BootcampApplication.objects.filter(user=self.request.user)
+                BootcampApplication.objects.prefetch_state_data()
+                .filter(user=self.request.user)
+                .annotate(num_orders=Count("orders", status=Order.FULFILLED))
                 .select_related("bootcamp_run__bootcamprunpage")
                 .order_by("-created_on")
             )

--- a/main/settings.py
+++ b/main/settings.py
@@ -511,7 +511,7 @@ LOG_LEVEL = get_string(
     "BOOTCAMP_LOG_LEVEL", "INFO", description="The logging level for the application"
 )
 DJANGO_LOG_LEVEL = get_string(
-    "DJANGO_LOG_LEVEL", "INFO", description="The log level for Django"
+    "DJANGO_LOG_LEVEL", "DEBUG", description="The log level for Django"
 )
 ES_LOG_LEVEL = get_string(
     "ES_LOG_LEVEL", "INFO", description="The log level for elasticsearch"

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -33,7 +33,8 @@ export const makeApplication = (): Application => ({
   id:           incr.next().value,
   state:        casual.random_element(Object.keys(APP_STATE_TEXT_MAP)),
   created_on:   moment().format(),
-  bootcamp_run: generateFakeRun()
+  bootcamp_run: generateFakeRun(),
+  has_payments: casual.boolean
 })
 
 export const makeApplicationRunStep = (

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -14,7 +14,8 @@ export type Application = {
   id:           number,
   state:        string,
   created_on:   any,
-  bootcamp_run: BootcampRun
+  bootcamp_run: BootcampRun,
+  has_payments: boolean,
 }
 
 export type ValidAppStepType = SUBMISSION_VIDEO | SUBMISSION_QUIZ

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -253,15 +253,17 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
             </div>
             <div className="row mt-2">
               <div className="col-7 text-left text-sm-right view-statement">
-                <a
-                  className="btn-link"
-                  href={reverse(routes.applications.paymentHistory.self, {
-                    applicationId: application.id
-                  })}
-                >
-                  <span className="material-icons">printer</span>
-                  View Statement
-                </a>
+                {application.has_payments ? (
+                  <a
+                    className="btn-link"
+                    href={reverse(routes.applications.paymentHistory.self, {
+                      applicationId: application.id
+                    })}
+                  >
+                    <span className="material-icons">printer</span>
+                    View Statement
+                  </a>
+                ) : null}
               </div>
               <div className="col-5 text-right collapse-link">
                 <a

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -253,7 +253,7 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
             </div>
             <div className="row mt-2">
               <div className="col-7 text-left text-sm-right view-statement">
-                {application.has_payments ? (
+                {application.has_payments && (
                   <a
                     className="btn-link"
                     href={reverse(routes.applications.paymentHistory.self, {
@@ -263,7 +263,7 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
                     <span className="material-icons">printer</span>
                     View Statement
                   </a>
-                ) : null}
+                )}
               </div>
               <div className="col-5 text-right collapse-link">
                 <a

--- a/static/js/pages/applications/ApplicationDashboardPage_test.js
+++ b/static/js/pages/applications/ApplicationDashboardPage_test.js
@@ -348,14 +348,26 @@ describe("ApplicationDashboardPage", () => {
       })
     })
   })
+  ;[true, false].forEach(hasPayments => {
+    it(`${
+      hasPayments ? "has" : "doesn't have"
+    } a view statement link if hasPayments=${String(
+      hasPayments
+    )}`, async () => {
+      fakeApplications.forEach(application => {
+        application.has_payments = hasPayments
+      })
+      const { wrapper } = await renderPage()
 
-  it("renders a view statement link", async () => {
-    const { wrapper } = await renderPage()
-
-    const link = wrapper.find(".view-statement a").at(0)
-    assert.equal(
-      link.prop("href"),
-      `/applications/${fakeApplicationDetail.id}/payment-history/`
-    )
+      const link = wrapper.find(".view-statement a").at(0)
+      if (hasPayments) {
+        assert.equal(
+          link.prop("href"),
+          `/applications/${fakeApplicationDetail.id}/payment-history/`
+        )
+      } else {
+        assert.isFalse(link.exists())
+      }
+    })
   })
 })

--- a/static/js/pages/applications/ApplicationDashboardPage_test.js
+++ b/static/js/pages/applications/ApplicationDashboardPage_test.js
@@ -35,6 +35,7 @@ import type {
   Application,
   ApplicationDetail
 } from "../../flow/applicationTypes"
+import { shouldIf } from "../../lib/test_utils"
 
 describe("ApplicationDashboardPage", () => {
   let helper,
@@ -349,9 +350,9 @@ describe("ApplicationDashboardPage", () => {
     })
   })
   ;[true, false].forEach(hasPayments => {
-    it(`${
-      hasPayments ? "has" : "doesn't have"
-    } a view statement link if hasPayments=${String(
+    it(`${shouldIf(
+      hasPayments
+    )} have a view statement link if hasPayments=${String(
       hasPayments
     )}`, async () => {
       fakeApplications.forEach(application => {

--- a/static/js/pages/applications/ApplicationDashboardPage_test.js
+++ b/static/js/pages/applications/ApplicationDashboardPage_test.js
@@ -30,12 +30,12 @@ import {
   makeIncompleteUser,
   makeUser
 } from "../../factories/user"
+import { shouldIf } from "../../lib/test_utils"
 
 import type {
   Application,
   ApplicationDetail
 } from "../../flow/applicationTypes"
-import { shouldIf } from "../../lib/test_utils"
 
 describe("ApplicationDashboardPage", () => {
   let helper,


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Hides the "View Statement" link if the user has not yet made any payments for that application

#### How should this be manually tested?
 - Go to `/applications`. Get to a state where you have made one payment. You should see the "View Statement" link in the UI.
 - Find the `Order` for that `BootcampApplication` and set `status='created'`. Go to `/applications` again and the view statements link should not show up. The rest of the UI should look the same as before.

