### PR TITLE
add submissions dashboard page

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "style-loader": "^1.1.3",
     "styled-components": "^4.2.0",
     "urijs": "^1.19.2",
+    "url-assembler": "^2.1.1",
     "url-join": "^4.0.1",
     "url-loader": "^4.1.0",
     "waait": "^1.0.5",

--- a/pytest_minimal.ini
+++ b/pytest_minimal.ini
@@ -1,3 +1,6 @@
 [pytest]
-addopts = --ds=main.settings
+addopts = --ds=main.settings --reuse-db
 norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg selenium_tests
+env =
+  ZENDESK_HELP_WIDGET_ENABLED=False
+  ZENDESK_HELP_WIDGET_KEY=abcdefg

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -1,0 +1,8 @@
+require("@babel/register")
+
+R = require("ramda")
+moment = require("moment")
+S = require("sanctuary")
+sinon = require("sinon")
+assert = require("chai").assert
+casual = require("casual-browserify")

--- a/static/js/components/SubmissionFacets.js
+++ b/static/js/components/SubmissionFacets.js
@@ -1,0 +1,98 @@
+// @flow
+import React, { useCallback } from "react"
+import qs from "query-string"
+import urljoin from "url-join"
+import { prop, omit } from "ramda"
+import { useLocation, useHistory } from "react-router"
+import { identity } from "ramda"
+
+import {
+  STATUS_FACET_KEY,
+  BOOTCAMP_FACET_KEY,
+  FACET_DISPLAY_NAMES,
+  FACET_OPTION_LABEL_KEYS,
+  FACET_ORDER,
+  REVIEW_STATUS_DISPLAY_MAP
+} from "../constants"
+
+import type { FacetOption, SubmissionFacetData } from "../flow/applicationTypes"
+
+export const facetOptionSerialization = {
+  [STATUS_FACET_KEY]: {
+    qsKey:      "review_status",
+    getQSValue: prop("review_status")
+  },
+  [BOOTCAMP_FACET_KEY]: {
+    qsKey:      "bootcamp_id",
+    getQSValue: prop("id")
+  }
+}
+
+export const facetOptionLabels = {
+  [STATUS_FACET_KEY]:   status => REVIEW_STATUS_DISPLAY_MAP[status][0],
+  [BOOTCAMP_FACET_KEY]: identity
+}
+
+type OptionProps = {
+  option: FacetOption,
+  facetKey: string
+}
+
+export function Option({ option, facetKey }: OptionProps) {
+  const labelKey = FACET_OPTION_LABEL_KEYS[facetKey]
+  const { qsKey, getQSValue } = facetOptionSerialization[facetKey]
+
+  const location = useLocation()
+  const history = useHistory()
+
+  const facetIsActive =
+    qs.parse(location.search)[qsKey] === String(getQSValue(option))
+
+  const cb = useCallback(
+    e => {
+      e.preventDefault()
+
+      const updatedParams = facetIsActive ?
+        omit([qsKey], qs.parse(location.search)) :
+        {
+          ...qs.parse(location.search),
+          [qsKey]: getQSValue(option)
+        }
+
+      const url = urljoin(location.pathname, `/?${qs.stringify(updatedParams)}`)
+      history.push(url)
+    },
+    [option, facetKey, location]
+  )
+
+  const className = `facet-option my-3 ${
+    facetIsActive ? "font-weight-bold" : ""
+  }`.trim()
+
+  return (
+    <div className={className} onClick={cb}>
+      {facetOptionLabels[facetKey](option[labelKey])}
+    </div>
+  )
+}
+
+type Props = {
+  facets: SubmissionFacetData
+}
+
+export default function SubmissionFacets({ facets }: Props) {
+  return (
+    <div className="submission-facets">
+      {FACET_ORDER.map((facetKey, i) => (
+        <div className="facet mb-4" key={i}>
+          <h3 className="title font-weight-bold">
+            {FACET_DISPLAY_NAMES[facetKey]}
+          </h3>
+          {facets[facetKey].map((option, i) => (
+            <Option option={option} key={i} facetKey={facetKey} />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -123,11 +123,18 @@ export const REVIEW_STATUS_REJECTED = "rejected"
 export const REVIEW_STATUS_PENDING = "pending"
 export const REVIEW_STATUS_WAITLISTED = "waitlisted"
 
+export const REVIEW_STATUS_DISPLAY_MAP = {
+  [REVIEW_STATUS_APPROVED]:   ["Approved", "text-primary"],
+  [REVIEW_STATUS_REJECTED]:   ["Rejected", "text-warning"],
+  [REVIEW_STATUS_PENDING]:    ["Not Reviewed", "text-secondary"],
+  [REVIEW_STATUS_WAITLISTED]: ["Waitlisted", "text-secondary"]
+}
+
 export const REVIEW_STATUS_TEXT_MAP = {
-  REVIEW_STATUS_APPROVED:   REVIEW_STATUS_APPROVED,
-  REVIEW_STATUS_REJECTED:   REVIEW_STATUS_REJECTED,
-  REVIEW_STATUS_PENDING:    REVIEW_STATUS_PENDING,
-  REVIEW_STATUS_WAITLISTED: REVIEW_STATUS_WAITLISTED
+  [REVIEW_STATUS_APPROVED]:   REVIEW_STATUS_APPROVED,
+  [REVIEW_STATUS_REJECTED]:   REVIEW_STATUS_REJECTED,
+  [REVIEW_STATUS_PENDING]:    REVIEW_STATUS_PENDING,
+  [REVIEW_STATUS_WAITLISTED]: REVIEW_STATUS_WAITLISTED
 }
 
 export const SUBMISSION_STATUS_PENDING = "pending"
@@ -183,3 +190,19 @@ export const JOBMA_SITE = "jobma.com"
 export const ALLOWED_FILE_EXTENTIONS = {
   pdf: "application/pdf"
 }
+
+// Submission facets
+export const STATUS_FACET_KEY = "review_statuses"
+export const BOOTCAMP_FACET_KEY = "bootcamps"
+
+export const FACET_DISPLAY_NAMES = {
+  [STATUS_FACET_KEY]:   "Application Status",
+  [BOOTCAMP_FACET_KEY]: "Bootcamp"
+}
+
+export const FACET_OPTION_LABEL_KEYS = {
+  [STATUS_FACET_KEY]:   "review_status",
+  [BOOTCAMP_FACET_KEY]: "title"
+}
+
+export const FACET_ORDER = [BOOTCAMP_FACET_KEY, STATUS_FACET_KEY]

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -10,6 +10,8 @@ import {
   REVIEW_STATUS_TEXT_MAP,
   REVIEW_STATUS_APPROVED,
   REVIEW_STATUS_PENDING,
+  REVIEW_STATUS_REJECTED,
+  REVIEW_STATUS_WAITLISTED,
   SUBMISSION_QUIZ,
   SUBMISSION_VIDEO,
   SUBMISSION_STATUS_TEXT_MAP
@@ -22,7 +24,8 @@ import type {
   ApplicationRunStep,
   ApplicationSubmission,
   SubmissionReview,
-  ValidAppStepType
+  ValidAppStepType,
+  SubmissionFacetData
 } from "../flow/applicationTypes"
 
 const incr = incrementer()
@@ -62,6 +65,27 @@ export const makeApplicationSubmission = (): ApplicationSubmission => ({
   ),
   interview_url: casual.url
 })
+
+export const makeApplicationFacets = (): SubmissionFacetData => {
+  const facets = {
+    review_statuses: [
+      REVIEW_STATUS_APPROVED,
+      REVIEW_STATUS_REJECTED,
+      REVIEW_STATUS_PENDING,
+      REVIEW_STATUS_WAITLISTED
+    ].map(status => ({
+      review_status: status,
+      count:         casual.integer(1, 10)
+    })),
+    bootcamps: [1, 2, 3].map(id => ({
+      id,
+      title: casual.title,
+      count: casual.integer(1, 10)
+    }))
+  }
+
+  return facets
+}
 
 export const setSubmissionToPending = (
   submission: ApplicationSubmission

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -43,15 +43,15 @@ export type ApplicationSubmission = {
 }
 
 export type LegacyOrderPartial = {
-  id:               number,
-  status:           string,
-  created_on:       string,
-  updated_on:       string
+  id:         number,
+  status:     string,
+  created_on: string,
+  updated_on: string
 }
 
 export type ApplicationOrder = {
   total_price_paid: number,
-  payment_method: string,
+  payment_method:   string
 } & LegacyOrderPartial
 
 export type ApplicationDetail = {
@@ -68,7 +68,7 @@ export type ApplicationDetail = {
   orders:                Array<ApplicationOrder>,
   created_on:            string,
   price:                 number,
-  user:                  User,
+  user:                  User
 }
 
 export type SubmissionReview = {
@@ -88,6 +88,24 @@ export type ApplicationDetailState = {
 
 export type SubmissionReviewState ={
   [string]: SubmissionReview
+}
+
+type BootcampFacetOption = {
+  id:    number,
+  title: string,
+  count: number
+}
+
+type ReviewStatusFacetOption = {
+  review_status: string,
+  count:         number
+}
+
+export type FacetOption = BootcampFacetOption | ReviewStatusFacetOption
+
+export type SubmissionFacetData = {
+  bootcamps:       Array<BootcampFacetOption>,
+  review_statuses: Array<ReviewStatusFacetOption>
 }
 
 export type VideoInterviewResponse = {

--- a/static/js/lib/queries/applications.js
+++ b/static/js/lib/queries/applications.js
@@ -5,12 +5,12 @@ import { nextState } from "./util"
 import { getCookie } from "../api"
 
 import { DEFAULT_POST_OPTIONS } from "../redux_query"
+import { applicationsAPI, applicationDetailAPI } from "../urls"
+
 import type {
   Application,
   ApplicationDetail,
   ApplicationDetailState,
-  SubmissionReview,
-  SubmissionReviewState,
   VideoInterviewResponse
 } from "../../flow/applicationTypes"
 
@@ -24,9 +24,6 @@ const applicationsKey = "applications"
 const applicationDetailKey = "applicationDetail"
 export const createAppQueryKey = "createApplication"
 
-const submissionDetailKey = "submissionReview"
-const submissionsApiUrl = "/api/submissions/"
-
 export const applicationsSelector = (state: any): ?Array<Application> =>
   state.entities[applicationsKey]
 
@@ -34,13 +31,9 @@ export const applicationDetailSelector = (
   state: any
 ): { [string]: ApplicationDetail } => state.entities[applicationDetailKey]
 
-export const submissionDetailSelector = (
-  state: any
-): { [string]: SubmissionReview } => state.entities[submissionDetailKey]
-
 export default {
   applicationsQuery: () => ({
-    url:       "/api/applications/",
+    url:       applicationsAPI.toString(),
     transform: objOf(applicationsKey),
     update:    {
       [applicationsKey]: nextState
@@ -66,7 +59,7 @@ export default {
     }
   }),
   applicationDetailQuery: (applicationId: string) => ({
-    url:       `/api/applications/${applicationId}/`,
+    url:       applicationDetailAPI.param({ applicationId }).toString(),
     transform: (json: ?ApplicationDetail) => {
       return {
         [applicationDetailKey]: {
@@ -82,51 +75,6 @@ export default {
         ...prev,
         ...transformed
       })
-    }
-  }),
-  submissionReviewQuery: (submissionId: number) => ({
-    url:       `${submissionsApiUrl}${submissionId}/`,
-    transform: (json: ?SubmissionReview) => {
-      return {
-        [submissionDetailKey]: {
-          [submissionId]: json
-        }
-      }
-    },
-    update: {
-      [submissionDetailKey]: (
-        prev: SubmissionReviewState,
-        transformed: SubmissionReviewState
-      ) => ({
-        ...prev,
-        ...transformed
-      })
-    }
-  }),
-  submissionReviewMutation: (submission: SubmissionReview) => ({
-    url:       `${submissionsApiUrl}${submission.id}/`,
-    body:      submission,
-    transform: (json: ?SubmissionReview) => {
-      return {
-        [submissionDetailKey]: {
-          [submission.id]: json
-        }
-      }
-    },
-    update: {
-      [submissionDetailKey]: (
-        prev: SubmissionReviewState,
-        transformed: SubmissionReviewState
-      ) => ({
-        ...prev,
-        ...transformed
-      })
-    },
-    options: {
-      method:  "PATCH",
-      headers: {
-        "X-CSRFTOKEN": getCookie("csrftoken")
-      }
     }
   }),
   createVideoInterviewMutation: (applicationId: number, stepId: number) => ({

--- a/static/js/lib/queries/submissions.js
+++ b/static/js/lib/queries/submissions.js
@@ -1,0 +1,117 @@
+// @flow
+import { createSelector } from "reselect"
+import { compose, objOf, pick, merge, curry, propOr } from "ramda"
+import qs from "query-string"
+
+import { submissionsAPI, submissionDetailAPI } from "../urls"
+import { getCookie } from "../api"
+
+import type {
+  SubmissionReview,
+  SubmissionFacetData
+} from "../../flow/applicationTypes"
+
+const submissionsFacetsKey = "submissionsFacets"
+const submissionKey = "submissions"
+
+const submissionDetailTransform = curry((submissionId, json) => ({
+  [submissionKey]: {
+    [submissionId]: json
+  }
+}))
+
+export const submissionQuery = (submissionId: number) => ({
+  url:       submissionDetailAPI.param({ submissionId }).toString(),
+  transform: submissionDetailTransform(submissionId),
+  update:    {
+    [submissionKey]: merge
+  }
+})
+
+export const submissionsSelector = createSelector(
+  state => state.entities,
+  propOr({}, submissionKey)
+)
+
+type SubmissionReviewState = {
+  [string]: SubmissionReview
+}
+
+export const submissionReviewMutation = (submission: SubmissionReview) => ({
+  url:       submissionDetailAPI.param({ submissionId: submission.id }).toString(),
+  body:      submission,
+  transform: submissionDetailTransform(submission.id),
+  update:    {
+    [submissionKey]: (
+      prev: SubmissionReviewState,
+      transformed: SubmissionReviewState
+    ) => ({
+      ...prev,
+      ...transformed
+    })
+  },
+  options: {
+    method:  "PATCH",
+    headers: {
+      "X-CSRFTOKEN": getCookie("csrftoken")
+    }
+  }
+})
+
+const facetTransform = compose(
+  objOf(submissionsFacetsKey),
+  pick(["count", "next", "previous", "results", "facets"])
+)
+
+type FacetState = {
+  count: number,
+  next: string,
+  previous: string,
+  facets: SubmissionFacetData,
+  results: Array<SubmissionReview>
+}
+
+export const submissionsQuery = (params: string) => {
+  const url =
+    params === "" ?
+      submissionsAPI.toString() :
+      submissionsAPI.query(qs.parse(params)).toString()
+
+  return {
+    queryKey:  params ? `submissions__${params}` : "submissions",
+    url,
+    transform: facetTransform,
+    update:    {
+      [submissionsFacetsKey]: (
+        prevState: { [string]: FacetState },
+        nextState: FacetState
+      ) => {
+        const { count, next, previous, facets, results } = nextState
+
+        // need to store the result of each request with different parameters
+        // in order to deal with the situation where the user selects and then
+        // unselects a given facet
+        return {
+          ...prevState,
+          [params === "" ? "defaultSearch" : params]: {
+            count,
+            next,
+            previous,
+            facets,
+            results
+          }
+        }
+      }
+    }
+  }
+}
+
+export const submissionFacetsSelector = createSelector(
+  state => state.entities,
+  entities => {
+    if (!entities[submissionsFacetsKey]) {
+      return {}
+    }
+    return entities[submissionsFacetsKey]
+  }
+)

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -1,5 +1,6 @@
 // @flow
 import { include } from "named-urls"
+import UrlAssembler from "url-assembler"
 import qs from "query-string"
 
 export const getNextParam = (search: string) => qs.parse(search).next || "/"
@@ -49,7 +50,7 @@ export const routes = {
 
   review: include("/review/", {
     dashboard: "",
-    detail:    ":id/"
+    detail:    ":submissionId/"
   }),
 
   resourcePages: include("", {
@@ -57,3 +58,11 @@ export const routes = {
     terms:      "terms-and-conditions/"
   })
 }
+
+const api = UrlAssembler().prefix("/api/")
+
+export const submissionsAPI = api.segment("submissions/")
+export const submissionDetailAPI = submissionsAPI.segment(":submissionId/")
+
+export const applicationsAPI = api.segment("applications/")
+export const applicationDetailAPI = applicationsAPI.segment(":applicationId/")

--- a/static/js/pages/applications/ReviewAdminPages.js
+++ b/static/js/pages/applications/ReviewAdminPages.js
@@ -1,15 +1,21 @@
 // @flow
 import React from "react"
-import { Switch, Route } from "react-router-dom"
+import { Route } from "react-router-dom"
 
 import { routes } from "../../lib/urls"
 
-import { ReviewDetailPage } from "./ReviewDetailPage"
+import ReviewDetailPage from "./ReviewDetailPage"
+import ReviewDashboardPage from "./ReviewDashboardPage"
 
-const ReviewAdminPages = () => (
-  <Switch>
-    <Route exact path={routes.review.detail} component={ReviewDetailPage} />
-  </Switch>
-)
-
-export default ReviewAdminPages
+export default function ReviewAdminPages() {
+  return (
+    <>
+      <Route
+        exact
+        path={routes.review.dashboard}
+        component={ReviewDashboardPage}
+      />
+      <Route exact path={routes.review.detail} component={ReviewDetailPage} />
+    </>
+  )
+}

--- a/static/js/pages/applications/ReviewDashboardPage.js
+++ b/static/js/pages/applications/ReviewDashboardPage.js
@@ -1,0 +1,95 @@
+// @flow
+import React from "react"
+import { useSelector } from "react-redux"
+import { useRequest } from "redux-query-react"
+import { useLocation } from "react-router"
+import { Link } from "react-router-dom"
+import { path } from "ramda"
+import { reverse } from "named-urls"
+
+import SubmissionFacets from "../../components/SubmissionFacets"
+
+import {
+  submissionsQuery,
+  submissionFacetsSelector
+} from "../../lib/queries/submissions"
+import { REVIEW_STATUS_DISPLAY_MAP } from "../../constants"
+import { routes } from "../../lib/urls"
+import type { SubmissionReview } from "../../flow/applicationTypes"
+
+/* eslint-disable camelcase */
+type RowProps = {
+  submission: SubmissionReview
+}
+export function SubmissionRow({ submission }: RowProps) {
+  const {
+    review_status, // eslint-disable-line camelcase
+    learner: { profile }
+  } = submission
+
+  const [label, className] = REVIEW_STATUS_DISPLAY_MAP[review_status]
+
+  return (
+    <div className="submission-row row my-3">
+      <Link
+        className="col-8 name"
+        to={reverse(routes.review.detail, { submissionId: submission.id })}
+      >
+        {profile ? profile.name : ""}
+      </Link>
+      <Link
+        className={`col-4 status ${className}`}
+        to={reverse(routes.review.detail, { submissionId: submission.id })}
+      >
+        {label}
+      </Link>
+    </div>
+  )
+}
+/* eslint-enable camelcase */
+
+export default function ReviewDashboardPage() {
+  const location = useLocation()
+  const [{ isFinished }] = useRequest(submissionsQuery(location.search))
+
+  const submissions = useSelector(submissionFacetsSelector)
+
+  const results = path(
+    [location.search || "defaultSearch", "results"],
+    submissions
+  )
+  const facets = path(
+    [location.search || "defaultSearch", "facets"],
+    submissions
+  )
+
+  return (
+    <div className="review-dashboard-page container-lg">
+      <div className="row">
+        <div className="col-12">
+          <h1>ADMISSION SYSTEM</h1>
+        </div>
+      </div>
+      {isFinished && results ? (
+        <div className="row mt-3">
+          <div className="col-4">
+            <SubmissionFacets facets={facets} />
+          </div>
+          <div className="container col-8">
+            <div className="row">
+              <div className="font-weight-bold text-uppercase col-8">
+                Applicants
+              </div>
+              <div className="font-weight-bold text-uppercase col-4">
+                Status
+              </div>
+            </div>
+            {results.map((submission, i) => (
+              <SubmissionRow key={i} submission={submission} />
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/static/js/pages/applications/ReviewDashboardPage_test.js
+++ b/static/js/pages/applications/ReviewDashboardPage_test.js
@@ -1,0 +1,66 @@
+// @flow
+import { assert } from "chai"
+import { times } from "ramda"
+import { reverse } from "named-urls"
+
+import ReviewDashboardPage from "./ReviewDashboardPage"
+
+import IntegrationTestHelper from "../../util/integration_test_helper"
+import { submissionsAPI } from "../../lib/urls"
+import {
+  makeApplicationFacets,
+  makeSubmissionReview
+} from "../../factories/application"
+import { REVIEW_STATUS_DISPLAY_MAP } from "../../constants"
+import { routes } from "../../lib/urls"
+
+describe("ReviewDashboardPage", () => {
+  let helper, render, facets, submissions
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    facets = makeApplicationFacets()
+    submissions = times(makeSubmissionReview, 4)
+    helper.handleRequestStub.withArgs(submissionsAPI.toString()).returns({
+      status: 200,
+      body:   {
+        count:    submissions.length,
+        next:     "next",
+        previous: "previous",
+        facets,
+        results:  submissions
+      }
+    })
+    render = helper.configureReduxQueryRenderer(ReviewDashboardPage)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render submissions, pass facets down", async () => {
+    const { wrapper } = await render()
+    const submissionRows = wrapper.find("SubmissionRow")
+    submissions.forEach((submission, idx) => {
+      assert.deepEqual(submission, submissionRows.at(idx).prop("submission"))
+    })
+    assert.deepEqual(wrapper.find("SubmissionFacets").prop("facets"), facets)
+  })
+
+  it("should show status, have link to submission detail page", async () => {
+    const { wrapper } = await render()
+    const row = wrapper.find("SubmissionRow").at(0)
+    const [label, className] = REVIEW_STATUS_DISPLAY_MAP[
+      submissions[0].review_status
+    ]
+    const statusDiv = row.find(".status").at(0)
+    assert.equal(statusDiv.text(), label)
+    assert.include(statusDiv.prop("className"), className)
+    const link = row.find("Link").at(0)
+    assert.equal(
+      link.prop("to"),
+      reverse(routes.review.detail, { submissionId: submissions[0].id })
+    )
+    assert.equal(link.text(), submissions[0].learner.profile.name)
+  })
+})

--- a/static/js/pages/applications/ReviewDetailPage.js
+++ b/static/js/pages/applications/ReviewDetailPage.js
@@ -6,10 +6,12 @@ import { useRequest, useMutation } from "redux-query-react"
 import { MetaTags } from "react-meta-tags"
 
 import queries from "../../lib/queries"
+import { applicationDetailSelector } from "../../lib/queries/applications"
 import {
-  applicationDetailSelector,
-  submissionDetailSelector
-} from "../../lib/queries/applications"
+  submissionQuery,
+  submissionReviewMutation,
+  submissionsSelector
+} from "../../lib/queries/submissions"
 import { formatTitle, getFilenameFromPath, isNilOrBlank } from "../../util/util"
 
 import {
@@ -62,7 +64,7 @@ const ReviewPanelRight = (props: FormProps) => {
 
   const [{ isPending }, updateStatus] = useMutation(status =>
     // $FlowFixMe
-    queries.applications.submissionReviewMutation({
+    submissionReviewMutation({
       ...submission,
       review_status: status
     })
@@ -120,7 +122,6 @@ const ReviewPanelRight = (props: FormProps) => {
             Reject
           </label>
         </div>
-
         <div className="form-check radio-status">
           <input
             className="form-check-input"
@@ -135,7 +136,6 @@ const ReviewPanelRight = (props: FormProps) => {
             Waitlist
           </label>
         </div>
-
         <div className="form-check radio-status">
           <input
             className="form-check-input"
@@ -244,21 +244,14 @@ const ReviewPanelLeft = (props: DetailProps) => {
   )
 }
 
-export const ReviewDetailPage = (props: PageProps) => {
+export default function ReviewDetailPage(props: PageProps) {
   const { match } = props
-  const submissionId = match.params.id
+  const { submissionId } = match.params
 
-  const submissions = useSelector(submissionDetailSelector)
+  useRequest(submissionQuery(submissionId))
+  const submissions = useSelector(submissionsSelector)
   const submission = submissions ? submissions[submissionId] : null
 
-  const applications = useSelector(applicationDetailSelector)
-  const application =
-    applications && submission ?
-      applications[submission.bootcamp_application.id] :
-      null
-  const user = submission ? submission.learner : null
-
-  useRequest(queries.applications.submissionReviewQuery(submissionId))
   useRequest(
     submission ?
       queries.applications.applicationDetailQuery(
@@ -266,6 +259,13 @@ export const ReviewDetailPage = (props: PageProps) => {
       ) :
       null
   )
+
+  const applications = useSelector(applicationDetailSelector)
+  const application =
+    applications && submission ?
+      applications[submission.bootcamp_application.id] :
+      null
+  const user = submission ? submission.learner : null
 
   if (!submission || !application || !user) {
     return null

--- a/static/js/pages/applications/ReviewDetailPage_test.js
+++ b/static/js/pages/applications/ReviewDetailPage_test.js
@@ -13,7 +13,7 @@ import {
   REVIEW_STATUS_PENDING,
   REVIEW_STATUS_REJECTED
 } from "../../constants"
-import { ReviewDetailPage } from "./ReviewDetailPage"
+import ReviewDetailPage from "./ReviewDetailPage"
 
 import { shouldIf } from "../../lib/test_utils"
 import { getFilenameFromPath, isNilOrBlank } from "../../util/util"
@@ -67,7 +67,7 @@ describe("ReviewDetailPage", () => {
       {
         match: {
           params: {
-            id: fakeSubmissionReview.id
+            submissionId: fakeSubmissionReview.id
           }
         }
       },

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -33,6 +33,7 @@
 @import "cms/admissions-section";
 @import "cms/homepage-alumni";
 @import "cms/catalog-section";
+@import "submission-facets";
 
 body {
   margin: 0;

--- a/static/scss/review.scss
+++ b/static/scss/review.scss
@@ -1,5 +1,4 @@
 .review-card {
-
   &.review-panel-right {
     border-left: 1px solid black;
   }
@@ -27,6 +26,16 @@
       font-size: 18px;
       line-height: 35px;
       padding-left: 10px;
+    }
+  }
+}
+
+.review-dashboard-page {
+  .submission-row {
+    display: flex;
+
+    a {
+      color: black;
     }
   }
 }

--- a/static/scss/submission-facets.scss
+++ b/static/scss/submission-facets.scss
@@ -1,0 +1,7 @@
+.submission-facets {
+  .facet {
+    .facet-option {
+      cursor: pointer;
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5109,6 +5109,11 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+extend@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-2.0.2.tgz#1b74985400171b85554894459c978de6ef453ab7"
+  integrity sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ==
+
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -8806,6 +8811,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.5.1:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
+
 qs@^6.9.1:
   version "6.9.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.3.tgz#bfadcd296c2d549f1dffa560619132c977f5008e"
@@ -11002,6 +11012,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-assembler@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/url-assembler/-/url-assembler-2.1.1.tgz#d6c720b124b56c6eeb08dd75ca693f651ccf181d"
+  integrity sha512-ZSxMU+MdIE+tHYfXNTyvxfXp42zuhco2DEUpNt6nCO+rVNbsIuj0BsrX+Ji2Kmg946WzPPvWmqRH2OvbZozcFQ==
+  dependencies:
+    extend "^2.0.2"
+    qs "^6.5.1"
 
 url-join@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
#### What are the relevant tickets?

#549

#### What's this PR do?

this PR implements the first part of the application review dashboard, at `/review`.

#### How should this be manually tested?

You'll need to create some fake data so you have some applications to review. Try to get a good variety of `review_status` and attach them to two or more different bootcamps so you can try out the facets. basically, you should be able to click the facets to change what the search results are.

I haven't yet added the sorting - just wanted to get this up for review before I did any more work :sweat_smile: 

#### Screenshots (if appropriate)

![Screenshot from 2020-06-18 15-44-44](https://user-images.githubusercontent.com/6207644/85065129-a4f70500-b17a-11ea-8e62-ea1957d49c98.png)
![Screenshot from 2020-06-18 15-44-24](https://user-images.githubusercontent.com/6207644/85065130-a4f70500-b17a-11ea-8dcc-283ffbb8ee3f.png)
![Screenshot from 2020-06-18 15-44-18](https://user-images.githubusercontent.com/6207644/85065131-a4f70500-b17a-11ea-8c0a-89a434d45bed.png)
