### PR TITLE
remove gray backgroun from social media icons

### DIFF
--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -59,4 +59,3 @@ $twitter: #55acee;
 $youtube: #cd201f;
 $instagram: #a17357;
 $soundcloud: #ff5600;
-$social-icons-background: #cccccc;

--- a/static/scss/footer.scss
+++ b/static/scss/footer.scss
@@ -189,7 +189,6 @@
       width: 30px;
       height: 30px;
       position: relative;
-      background: $social-icons-background;
       transition: all .25s ease-in-out;
 
       &:after {


### PR DESCRIPTION
#### What are the relevant tickets?
https://trello.com/c/YdgAtdjh/185-footer-feedback

#### What's this PR do?
fixes #681, remove the gray background form the social media buttons

#### How should this be manually tested?
Just see the footer

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2020-06-19 at 12 25 48" src="https://user-images.githubusercontent.com/4043989/85107843-0c1ec300-b228-11ea-85af-b382762a4596.png">
