### PR TITLE
Add link to bootcamp page on catalog card - #191

### DIFF
--- a/cms/templates/partials/home-page-catalog.html
+++ b/cms/templates/partials/home-page-catalog.html
@@ -11,7 +11,7 @@
                             <img src="{% static 'images/mit-dome.png' %}" alt="{{ block.page.title }}">
                         {% endif %}
                         <div class="info d-flex flex-column flex-grow-1">
-                            <h2>{{ block.page.title }}</h2>
+                            <a href="{% pageurl block.page %}"><h2>{{ block.page.title }}</h2></a>
                             <span class="dates">
                                 {{ block.format }} <br>{{ block.page.bootcamp_run.start_date|date:"M, j" }} - {{ block.page.bootcamp_run.end_date|date }}
                             </span>


### PR DESCRIPTION
#### What are the relevant tickets?
[Trello](https://trello.com/c/o19T8O3s/191-catalog-cards-do-not-link-to-bootcamprunpage)

#### What's this PR do?
Adds an anchor tag on catalog card title so that the card is linked to the bootcamp run page.

#### How should this be manually tested?
Add catalog to home page with contents, make sure title is clickable and routes correctly to the bootcamp run page.
