### PR TITLE
Fix recaptcha visibility

### DIFF
--- a/static/js/components/forms/RegisterEmailForm.js
+++ b/static/js/components/forms/RegisterEmailForm.js
@@ -47,7 +47,7 @@ const RegisterEmailForm = ({ onSubmit }: Props) => (
           <ErrorMessage name="email" component={FormError} />
         </div>
         {SETTINGS.recaptchaKey ? (
-          <div className="form-group recaptcha-container">
+          <div className="form-group">
             <ScaledRecaptcha
               onRecaptcha={value => setFieldValue("recaptcha", value)}
               recaptchaKey={SETTINGS.recaptchaKey}

--- a/static/scss/_inputs.scss
+++ b/static/scss/_inputs.scss
@@ -194,11 +194,3 @@ input[type=number] {
     }
   }
 }
-
-.recaptcha-container {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: center;
-}


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #704 

#### What's this PR do?
Removes the flex css style for the recaptcha that centered it, which seemed to be the cause of the problem.

#### How should this be manually tested?
Open `../create-account` in Chrome, FF, and Safari if you have a Mac, in regular and incognito browser windows.  The recaptcha should appear every time (but will no longer be centered).

