### PR TITLE
Product Page feedback: add minor changes in program, alumni and admission section

### DIFF
--- a/static/scss/cms/admissions-section.scss
+++ b/static/scss/cms/admissions-section.scss
@@ -7,7 +7,6 @@
     height: 540px;
     margin-bottom: -4rem;
 
-
     @include media-breakpoint-down(sm) {
       height: 240px;
       margin-bottom: unset;
@@ -27,6 +26,10 @@
 
   .admissions-detail {
     border-left: 1px solid $matterhorn;
+
+    p {
+      margin-bottom: 30px;
+    }
 
     @include media-breakpoint-down(sm) {
       border-left: unset;

--- a/static/scss/cms/alumni.scss
+++ b/static/scss/cms/alumni.scss
@@ -74,11 +74,11 @@
       }
 
       .name {
-        font-size: 20px;
+        font-size: 25px;
       }
 
       .title {
-        font-size: 12px;
+        font-size: 17px;
       }
     }
   }
@@ -124,7 +124,11 @@
         padding: 0;
       }
 
-      padding: 0 30px;
+      @include media-breakpoint-down(lg) {
+        padding: 0 8px 0 7px;
+      }
+
+      padding: 0 38px 0 37px;
 
       img {
         display: block;

--- a/static/scss/cms/program-description.scss
+++ b/static/scss/cms/program-description.scss
@@ -63,12 +63,12 @@
 
       p {
         margin: 0;
+        font-size: 25px;
       }
     }
   }
 
   .program-content {
-
     .img-holder {
       max-width: 575px;
       margin: 0 0 20px;
@@ -111,7 +111,7 @@
 
           &[aria-expanded="true"] {
             font-weight: bold;
-         }
+          }
         }
 
         .slide {
@@ -124,7 +124,6 @@
 }
 
 .program-element {
-
   .banner-img {
     min-height: 270px;
     position: relative;
@@ -221,7 +220,7 @@
           &[aria-expanded="true"] {
             font-weight: bold;
             color: $dodger-blue;
-         }
+          }
         }
 
         .rich-text {


### PR DESCRIPTION
#### What are the relevant tickets?
#711 

#### What's this PR do?
fixes #711, 
- Program description: Make the "Statement" font size larger, 25px
- Admission section: there should be a 30px margin between the columns of text
- Alumni section: make the headshot 230x230px. Increase the size of the title and subtitle both +5px.

#### How should this be manually tested?
Just visit the product page

#### Screenshots (if appropriate)
- Program description: Make the "Statement" font size larger, 25px

**Desktop**

<img width="1440" alt="Screenshot 2020-06-22 at 13 50 16" src="https://user-images.githubusercontent.com/4043989/85268174-9ddc3980-b48f-11ea-82e7-7f43cb89f169.png">
<img width="1030" alt="Screenshot 2020-06-22 at 13 50 39" src="https://user-images.githubusercontent.com/4043989/85268192-a2a0ed80-b48f-11ea-933d-853b591df7b8.png">

**Tablet**

<img width="778" alt="Screenshot 2020-06-22 at 13 50 58" src="https://user-images.githubusercontent.com/4043989/85268197-a3d21a80-b48f-11ea-9386-51a4f5ada8be.png">

**Mobile**

<img width="332" alt="Screenshot 2020-06-22 at 13 51 14" src="https://user-images.githubusercontent.com/4043989/85268200-a46ab100-b48f-11ea-86e8-d6cf712b6632.png">

- Admission section: there should be a 30px margin between the columns of text
**Desktop**
<img width="1297" alt="Screenshot 2020-06-22 at 13 56 24" src="https://user-images.githubusercontent.com/4043989/85268664-3d013100-b490-11ea-992f-e883637a94b3.png">
<img width="1031" alt="Screenshot 2020-06-22 at 13 56 12" src="https://user-images.githubusercontent.com/4043989/85268662-3c689a80-b490-11ea-9904-aa1cdce25e80.png">

**Tablet**
<img width="783" alt="Screenshot 2020-06-22 at 13 56 02" src="https://user-images.githubusercontent.com/4043989/85268657-3b376d80-b490-11ea-8f33-b0851d140928.png">

**Mobile**
<img width="325" alt="Screenshot 2020-06-22 at 13 55 49" src="https://user-images.githubusercontent.com/4043989/85268645-37a3e680-b490-11ea-9202-e643b81d85f2.png">

- Alumni section: make the headshot 230x230px. Increase the size of the title and subtitle both +5px.
**Desktop**
<img width="1302" alt="Screenshot 2020-06-22 at 13 57 19" src="https://user-images.githubusercontent.com/4043989/85268842-805b9f80-b490-11ea-8b39-ed95efab7849.png">
<img width="1031" alt="Screenshot 2020-06-22 at 13 57 30" src="https://user-images.githubusercontent.com/4043989/85268862-86518080-b490-11ea-9789-fc3c0e2f2d3c.png">

**Tablet**
<img width="775" alt="Screenshot 2020-06-22 at 13 57 38" src="https://user-images.githubusercontent.com/4043989/85268868-8782ad80-b490-11ea-96fb-4d9ed4606faf.png">

**Mobile**
<img width="437" alt="Screenshot 2020-06-22 at 13 57 45" src="https://user-images.githubusercontent.com/4043989/85268874-881b4400-b490-11ea-9aca-c7dc21c0dae4.png">