### PR TITLE
product page feedback: the margins between sections should be consistent, and larger

### DIFF
--- a/cms/templates/partials/admissions-section.html
+++ b/cms/templates/partials/admissions-section.html
@@ -3,7 +3,7 @@
     <div class="row">
         <img class="admissions-image" src="{% image_version_url page.admissions_image 'fill-1920x540' %}" alt="Admissions" />
     </div>
-    <div class="row mb-4">
+    <div class="row adminssion-header">
         <div class="col-md-10 offset-md-2 col-sm-12 offset-sm-0 pt-5 bg-white">
             <div class="container-fluid admissions-section">
                 <div class="row">

--- a/static/scss/cms/admissions-section.scss
+++ b/static/scss/cms/admissions-section.scss
@@ -13,6 +13,10 @@
     }
   }
 
+  .adminssion-header {
+    margin-bottom: 60px;
+  }
+
   .section-heading {
     font-weight: 800;
     font-size: 36px;
@@ -62,6 +66,7 @@
 
   .light-grey-bg {
     background-color: $very-light-gray;
+    padding-bottom: 60px !important;
   }
 
   .text-med-dark-grey {

--- a/static/scss/cms/alumni.scss
+++ b/static/scss/cms/alumni.scss
@@ -38,7 +38,7 @@
     background: white;
     padding: 50px;
     margin-top: -90px;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
     position: relative;
     z-index: 2;
 

--- a/static/scss/cms/instructor.scss
+++ b/static/scss/cms/instructor.scss
@@ -1,5 +1,6 @@
 .instructor-block {
   color: $matterhorn;
+  padding-bottom: 60px;
 
   .subheading {
     margin: 10px 0;

--- a/static/scss/cms/learning_resources.scss
+++ b/static/scss/cms/learning_resources.scss
@@ -1,6 +1,6 @@
 .learning-block {
   background: $white-smoke;
-  padding: 50px 0;
+  padding: 60px 0;
 
   h2 {
     @include media-breakpoint-down(sm) {

--- a/static/scss/cms/program-description.scss
+++ b/static/scss/cms/program-description.scss
@@ -2,6 +2,7 @@
 
 .program-block {
   overflow: hidden;
+  padding-bottom: 40px;
 
   .gray-box {
     background: $white-smoke;

--- a/static/scss/cms/three-column-image-section.scss
+++ b/static/scss/cms/three-column-image-section.scss
@@ -5,13 +5,10 @@ html {
 }
 
 .three-column-image-text-section {
-
   .section-row {
-
-    padding-bottom: 40px;
+    padding-bottom: 60px;
 
     .col-sm-4 {
-
       .col-border-padding {
         padding-left: 30px;
         padding-right: 30px;
@@ -42,7 +39,8 @@ html {
     }
   }
 
-  h5, p {
+  h5,
+  p {
     color: dimgray;
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?
#713 

#### What's this PR do?
fixes #713, the margins between sections should be consistent, and larger => 60px

#### How should this be manually tested?
Just visit the product page

#### Screenshots (if appropriate)
**Whole page**
![screencapture-bc-odl-local-8099-enterpreneur-bootcamp-bootcamp-13-2020-06-23-18_37_31](https://user-images.githubusercontent.com/4043989/85410569-b11b0200-b580-11ea-82a2-6d39dc109bf6.jpg)

**Desktop**

<img width="1386" alt="Screenshot 2020-06-22 at 15 39 27" src="https://user-images.githubusercontent.com/4043989/85278737-c28bdd80-b49e-11ea-96a0-4e5f73c57666.png">
<img width="1391" alt="Screenshot 2020-06-22 at 15 39 41" src="https://user-images.githubusercontent.com/4043989/85278756-c9b2eb80-b49e-11ea-8019-e1e266df6c0d.png">
<img width="1394" alt="Screenshot 2020-06-22 at 15 39 51" src="https://user-images.githubusercontent.com/4043989/85278758-ca4b8200-b49e-11ea-88c8-987874d347c1.png">
<img width="1388" alt="Screenshot 2020-06-22 at 15 40 00" src="https://user-images.githubusercontent.com/4043989/85278762-cc154580-b49e-11ea-9c5e-a469eb46a603.png">
<img width="1390" alt="Screenshot 2020-06-22 at 15 40 14" src="https://user-images.githubusercontent.com/4043989/85278769-cddf0900-b49e-11ea-9900-0c584f718b52.png">
<img width="1390" alt="Screenshot 2020-06-22 at 15 40 22" src="https://user-images.githubusercontent.com/4043989/85278772-cf103600-b49e-11ea-9f73-99e80a4cee5f.png">
<img width="1392" alt="Screenshot 2020-06-22 at 15 40 31" src="https://user-images.githubusercontent.com/4043989/85278776-d0d9f980-b49e-11ea-9360-77edcbfececf.png">

**Tablet**

<img width="777" alt="Screenshot 2020-06-22 at 15 41 24" src="https://user-images.githubusercontent.com/4043989/85278873-01219800-b49f-11ea-8161-6f9c06a9d2bb.png">
<img width="771" alt="Screenshot 2020-06-22 at 15 41 33" src="https://user-images.githubusercontent.com/4043989/85278881-054db580-b49f-11ea-929d-ff9929203a04.png">
<img width="778" alt="Screenshot 2020-06-22 at 15 41 40" src="https://user-images.githubusercontent.com/4043989/85278884-067ee280-b49f-11ea-804b-04ea42469e29.png">
<img width="771" alt="Screenshot 2020-06-22 at 15 41 47" src="https://user-images.githubusercontent.com/4043989/85278887-07177900-b49f-11ea-88f3-ecde85a18ca8.png">
<img width="774" alt="Screenshot 2020-06-22 at 15 41 54" src="https://user-images.githubusercontent.com/4043989/85278889-07b00f80-b49f-11ea-9955-5665c89e446f.png">
<img width="776" alt="Screenshot 2020-06-22 at 15 42 00" src="https://user-images.githubusercontent.com/4043989/85278890-08e13c80-b49f-11ea-8661-aa45547b2826.png">
<img width="776" alt="Screenshot 2020-06-22 at 15 42 07" src="https://user-images.githubusercontent.com/4043989/85278893-0979d300-b49f-11ea-8cf1-2d7620d87eb4.png">

**Mobile**

<img width="434" alt="Screenshot 2020-06-22 at 15 42 57" src="https://user-images.githubusercontent.com/4043989/85279136-61183e80-b49f-11ea-8608-05a843ccf633.png">
<img width="429" alt="Screenshot 2020-06-22 at 15 43 09" src="https://user-images.githubusercontent.com/4043989/85279146-65dcf280-b49f-11ea-906f-685c7ce3b513.png">
<img width="435" alt="Screenshot 2020-06-22 at 15 43 17" src="https://user-images.githubusercontent.com/4043989/85279148-66758900-b49f-11ea-8738-4af923a92b86.png">
<img width="420" alt="Screenshot 2020-06-22 at 15 43 23" src="https://user-images.githubusercontent.com/4043989/85279152-670e1f80-b49f-11ea-83ce-8cf502be564a.png">
<img width="432" alt="Screenshot 2020-06-22 at 15 43 32" src="https://user-images.githubusercontent.com/4043989/85279154-67a6b600-b49f-11ea-84b3-74775383d93b.png">
<img width="433" alt="Screenshot 2020-06-22 at 15 43 41" src="https://user-images.githubusercontent.com/4043989/85279157-68d7e300-b49f-11ea-96a8-dfa4e86cf3e3.png">
<img width="442" alt="Screenshot 2020-06-22 at 15 43 49" src="https://user-images.githubusercontent.com/4043989/85279159-69707980-b49f-11ea-8feb-5eb5cb4753d3.png">
