### PR TITLE
Catalog grid spacing, alignment and notches - fixes #718 #709

### DIFF
--- a/cms/templates/partials/home-page-catalog.html
+++ b/cms/templates/partials/home-page-catalog.html
@@ -1,15 +1,18 @@
 {% load static wagtailimages_tags image_version_url wagtailcore_tags %}
 <div class="catalog-section">
     <div class="container">
-        <div class="row">
+        <div class="row justify-content-center">
             {% for page_block in page.contents %}
                 {% with block=page_block.value %}
-                    <div class="col-sm-6 col-lg-4 p-0 d-flex flex-column">
-                        {% if block.page.thumbnail_image %}
-                            <img src="{% image_version_url block.page.thumbnail_image "fill-475x300" %}" alt="{{ block.page.title }}">
-                        {% else %}
-                            <img src="{% static 'images/mit-dome.png' %}" alt="{{ block.page.title }}">
-                        {% endif %}
+                    <div class="col-sm-6 col-lg-6 d-flex flex-column catalog-card">
+                        <div class="image-holder position-relative">
+                            {% if block.page.thumbnail_image %}
+                                <img class="w-100" src="{% image_version_url block.page.thumbnail_image "fill-475x300" %}" alt="{{ block.page.title }}">
+                            {% else %}
+                                <img class="w-100" src="{% static 'images/mit-dome.png' %}" alt="{{ block.page.title }}">
+                            {% endif %}
+                            <div class="bg-white image-notch position-absolute"></div>
+                        </div>
                         <div class="info d-flex flex-column flex-grow-1">
                             <a href="{% pageurl block.page %}"><h2>{{ block.page.title }}</h2></a>
                             <span class="dates">

--- a/static/scss/cms/catalog-section.scss
+++ b/static/scss/cms/catalog-section.scss
@@ -1,63 +1,75 @@
 // sass-lint:disable mixins-before-declarations
 .catalog-section {
-  .col-sm-6 {
+  .catalog-card {
+    padding: 0px 0.5px;
     margin-bottom: 90px;
-  }
 
-  img {
-    display: block;
-    width: 100%;
-    height: auto;
-    margin: 0 0 28px;
-  }
 
-  .info {
-    position: relative;
-    padding: 0 15px 0 60px;
-    color: $dark-gray;
-    font-size: 20px;
-    line-height: 25px;
-
-    @include media-breakpoint-down(sm) {
-      padding: 0 15px;
-      font-size: 15px;
-    }
-
-    h2 {
-      font-size: 30px;
-      line-height: 30px;
-      margin: 0 0 40px;
-      color: $matterhorn;
-      font-weight: 700;
-
-      @include media-breakpoint-down(sm) {
-        font-size: 20px;
-        margin: unset;
-      }
-    }
-
-    p {
-      font-weight: 300;
+    .image-holder {
       margin: 0 0 28px;
-    }
 
-    .dates {
-      color: $med-dark-gray;
-      display: block;
-      margin: 0 0 40px;
+      .image-notch {
+        width: 60px;
+        height: 60px;
+        left: 0px;
+        bottom: 0px;
 
-      @include media-breakpoint-down(sm) {
-        font-size: 15px;
-        margin-bottom: 20px;
+        @include media-breakpoint-down(sm) {
+          height: 30px;
+          left: unset;
+          right: 0px;
+        }
       }
     }
 
-    .deadline-text {
-      color: $tundora;
-      display: block;
+    .info {
+      position: relative;
+      padding: 0 15px 0 60px;
+      color: $dark-gray;
+      font-size: 20px;
+      line-height: 25px;
 
       @include media-breakpoint-down(sm) {
-        font-size: 12px;
+        padding: 0 15px;
+        font-size: 15px;
+      }
+
+      h2 {
+        font-size: 30px;
+        line-height: 30px;
+        margin: 0 0 40px;
+        color: $matterhorn;
+        font-weight: 700;
+
+        @include media-breakpoint-down(sm) {
+          font-size: 20px;
+          margin: unset;
+        }
+      }
+
+      p {
+        font-weight: 300;
+        margin: 0 0 28px;
+      }
+
+      .dates {
+        color: $med-dark-gray;
+        display: block;
+        margin: 0 0 40px;
+
+        @include media-breakpoint-down(sm) {
+          font-size: 15px;
+          margin-bottom: 20px;
+        }
+      }
+
+      .deadline-text {
+        color: $tundora;
+        display: block;
+
+        @include media-breakpoint-down(sm) {
+          font-size: 12px;
+        }
       }
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?
#709 
#718 

#### What's this PR do?
Catalog grid now automatically aligns cards in the middle. Columns changed from 3 to 2. White notch (60x60 desktop, 60x30 mobile) added in cards as well as `1px` gap between cards.

#### How should this be manually tested?
Visit home page with different number of catalog cards. Verify the section behaves as expected.

#### Screenshots (if appropriate)
Desktop
![screencapture-bc-odl-local-8099-2020-06-24-13_03_14](https://user-images.githubusercontent.com/6387678/85519688-4e2a7900-b61b-11ea-80cf-e18175d10979.png)

Tablet
![screencapture-bc-odl-local-8099-2020-06-24-13_04_13](https://user-images.githubusercontent.com/6387678/85519693-51256980-b61b-11ea-8877-e80f430bdb89.png)


Mobile
![screencapture-bc-odl-local-8099-2020-06-22-16_23_21](https://user-images.githubusercontent.com/6387678/85282386-15689380-b4a5-11ea-89b2-250e3e36874c.png)

