### PR TITLE
"Instructors" and "Alumni" headers should be the same size (and same element) as the "How to Apply" header.

### DIFF
--- a/static/scss/cms/admissions-section.scss
+++ b/static/scss/cms/admissions-section.scss
@@ -15,7 +15,7 @@
 
   .section-heading {
     font-weight: 800;
-    font-size: 3em;
+    font-size: 36px;
     color: $matterhorn;
   }
 

--- a/static/scss/cms/alumni.scss
+++ b/static/scss/cms/alumni.scss
@@ -51,7 +51,8 @@
 
       h2 {
         margin-bottom: 10px;
-        font-weight: 700;
+        font-weight: 800;
+        font-size: 36px;
       }
 
       .rich-text {

--- a/static/scss/cms/instructor.scss
+++ b/static/scss/cms/instructor.scss
@@ -148,7 +148,8 @@
 
     h2 {
       margin-bottom: 10px;
-      font-weight: 700;
+      font-weight: 800;
+      font-size: 36px;
     }
 
     .rich-text {


### PR DESCRIPTION
#### What are the relevant tickets?
#721 

#### What's this PR do?
fixes #721, "Instructors" and "Alumni" headers should be the same size (and same element) as the "How to Apply" header.

#### How should this be manually tested?
Just visit the product page
#### Screenshots (if appropriate)
**Desktop**
<img width="1437" alt="Screenshot 2020-06-22 at 19 15 42" src="https://user-images.githubusercontent.com/4043989/85298780-ef032200-b4bd-11ea-881d-dc8cb23b54ac.png">
<img width="1440" alt="Screenshot 2020-06-22 at 19 15 47" src="https://user-images.githubusercontent.com/4043989/85298831-fb877a80-b4bd-11ea-829f-d9645814b5e3.png">
<img width="1429" alt="Screenshot 2020-06-22 at 19 15 57" src="https://user-images.githubusercontent.com/4043989/85298848-004c2e80-b4be-11ea-9363-cb398457f9f5.png">

**Tablet**
<img width="777" alt="Screenshot 2020-06-22 at 19 16 43" src="https://user-images.githubusercontent.com/4043989/85298852-0215f200-b4be-11ea-937e-03e8f37458dc.png">
<img width="780" alt="Screenshot 2020-06-22 at 19 17 16" src="https://user-images.githubusercontent.com/4043989/85298929-16f28580-b4be-11ea-8308-bdb0f4435939.png">
<img width="785" alt="Screenshot 2020-06-22 at 19 17 39" src="https://user-images.githubusercontent.com/4043989/85298936-18bc4900-b4be-11ea-8cc2-91a98657faed.png">

**Mobile**

<img width="443" alt="Screenshot 2020-06-22 at 19 17 22" src="https://user-images.githubusercontent.com/4043989/85298932-178b1c00-b4be-11ea-9bf5-79c8592d8ca3.png">
<img width="452" alt="Screenshot 2020-06-22 at 19 17 47" src="https://user-images.githubusercontent.com/4043989/85298940-1a860c80-b4be-11ea-8ad5-76463df03ca0.png">
<img width="444" alt="Screenshot 2020-06-22 at 19 16 57" src="https://user-images.githubusercontent.com/4043989/85298923-15c15880-b4be-11ea-8c1b-1b48a824686e.png">
