### PR TITLE
Fixed new application issues (available runs, empty message)

### DIFF
--- a/klasses/views.py
+++ b/klasses/views.py
@@ -18,7 +18,7 @@ class BootcampViewSet(ListModelMixin, GenericViewSet):
         """Make a queryset which optionally shows what runs are available for enrollment"""
         queryset = BootcampRun.objects.all().select_related("bootcamp")
         if self.request.query_params.get("available") == "true":
-            queryset = queryset.filter(start_date__lt=Now()).exclude(
+            queryset = queryset.filter(start_date__gt=Now()).exclude(
                 applications__user=self.request.user
             )
         return queryset.order_by("id")

--- a/static/js/components/NewApplication.js
+++ b/static/js/components/NewApplication.js
@@ -22,6 +22,9 @@ import { isQueryPending } from "../lib/queries/util"
 import type { User } from "../flow/authTypes"
 import type { BootcampRun } from "../flow/bootcampTypes"
 
+const noAvailableBootcampsMsg =
+  "There are no bootcamps that are currently open for application."
+
 type Props = {
   currentUser: User,
   bootcampRuns: ?Array<BootcampRun>,
@@ -94,28 +97,34 @@ export class NewApplication extends React.Component<Props, State> {
     return (
       <div className="container p-0">
         <h1 className="mb-3">Select Bootcamp</h1>
-        <p className="mb-3">
-          To apply to a bootcamp, please select from the list below and click
-          Continue.
-        </p>
-        <label className="d-block font-weight-bold">Bootcamps</label>
-        <Dropdown
-          isOpen={dropdownOpen}
-          toggle={() => this.setState({ dropdownOpen: !dropdownOpen })}
-          className="mb-3 standard-select full-width"
-        >
-          <DropdownToggle caret>{dropdownText}</DropdownToggle>
-          <DropdownMenu>{items}</DropdownMenu>
-        </Dropdown>
-        <div className="d-flex justify-content-end">
-          <button
-            className="btn-red btn-inverse"
-            onClick={this.handleSubmit}
-            disabled={createAppIsPending || !selectedBootcamp}
-          >
-            Continue
-          </button>
-        </div>
+        {unappliedBootcampRuns.length === 0 ? (
+          <p className="mb-3">{noAvailableBootcampsMsg}</p>
+        ) : (
+          <React.Fragment>
+            <p className="mb-3">
+              To apply to a bootcamp, please select from the list below and
+              click Continue.
+            </p>
+            <label className="d-block font-weight-bold">Bootcamps</label>
+            <Dropdown
+              isOpen={dropdownOpen}
+              toggle={() => this.setState({ dropdownOpen: !dropdownOpen })}
+              className="mb-3 standard-select full-width"
+            >
+              <DropdownToggle caret>{dropdownText}</DropdownToggle>
+              <DropdownMenu>{items}</DropdownMenu>
+            </Dropdown>
+            <div className="d-flex justify-content-end">
+              <button
+                className="btn-red btn-inverse"
+                onClick={this.handleSubmit}
+                disabled={createAppIsPending || !selectedBootcamp}
+              >
+                Continue
+              </button>
+            </div>
+          </React.Fragment>
+        )}
       </div>
     )
   }

--- a/static/js/components/NewApplication_test.js
+++ b/static/js/components/NewApplication_test.js
@@ -10,6 +10,7 @@ import { makeUser } from "../factories/user"
 import { generateFakeRun } from "../factories"
 
 describe("NewApplication", () => {
+  const getBootcampsUrl = "/api/bootcampruns/?available=true"
   let helper, fakeUser, fakeBootcampRuns, fakeAppliedId, renderPage
 
   beforeEach(() => {
@@ -19,12 +20,10 @@ describe("NewApplication", () => {
     // Get the id of the last created run and include it in the list of ids that are already applied
     fakeAppliedId = prop("id", last(fakeBootcampRuns))
 
-    helper.handleRequestStub
-      .withArgs("/api/bootcampruns/?available=true")
-      .returns({
-        status: 200,
-        body:   fakeBootcampRuns
-      })
+    helper.handleRequestStub.withArgs(getBootcampsUrl).returns({
+      status: 200,
+      body:   fakeBootcampRuns
+    })
 
     renderPage = helper.configureReduxQueryRenderer(
       NewApplication,
@@ -58,6 +57,21 @@ describe("NewApplication", () => {
         .find("button")
         .last()
         .prop("disabled")
+    )
+  })
+
+  it("shows a message if no bootcamps are available for application", async () => {
+    helper.handleRequestStub.withArgs(getBootcampsUrl).returns({
+      status: 200,
+      body:   []
+    })
+
+    const { wrapper } = await renderPage()
+    assert.isFalse(wrapper.find("Dropdown").exists())
+    const message = wrapper.find("p")
+    assert.equal(
+      message.text(),
+      "There are no bootcamps that are currently open for application."
     )
   })
 


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
Fixes 2 issues with new applications:
1. Shows a message when there are no bootcamps available for application
1. Corrects the boolean logic for available bootcamps API endpoint (it was returning past bootcamp runs when it should return future bootcamp runs)

#### How should this be manually tested?
Set all bootcamp runs to the past and check the new application drawer from `/applications/`. You should see a message instead of a select box & submit button

#### Screenshots (if appropriate)
<img width="1239" alt="ss 2020-06-22 at 12 41 49 " src="https://user-images.githubusercontent.com/14932219/85314326-5782dc80-b487-11ea-9ea7-05207cb37f59.png">

