### PR TITLE
Fixed CMS admissions section links and fixed template vars

### DIFF
--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -75,6 +75,7 @@ def test_derive_application_state():
         order__status=Order.FULFILLED,
         order__user=app.user,
         order__application=app,
+        order__total_price_paid=installment.amount,
         run_key=app.bootcamp_run.run_key,
         price=installment.amount,
     )

--- a/cms/models.py
+++ b/cms/models.py
@@ -1,11 +1,10 @@
 """
 Page models for the CMS
 """
-import json
-
 from django.conf import settings
 from django.db import models
 from django.http.response import Http404
+from django.urls import reverse
 from django.utils.text import slugify
 from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
 from wagtail.core.blocks import StreamBlock
@@ -26,7 +25,7 @@ from cms.blocks import (
     CatalogSectionBootcampBlock,
 )
 from cms.constants import BOOTCAMP_INDEX_SLUG
-from main.views import _serialize_js_settings
+from main.views import get_base_context
 
 
 class BootcampIndexPage(Page):
@@ -115,7 +114,7 @@ class HomePage(Page, CommonProperties):
     def get_context(self, request, *args, **kwargs):
         return {
             **super().get_context(request, *args, **kwargs),
-            "js_settings_json": json.dumps(_serialize_js_settings(request)),
+            **get_base_context(request),
             "site_name": settings.SITE_NAME,
             "title": self.title,
         }
@@ -183,9 +182,10 @@ class BootcampPage(Page, CommonProperties):
     def get_context(self, request, *args, **kwargs):
         return {
             **super().get_context(request, *args, **kwargs),
-            "js_settings_json": json.dumps(_serialize_js_settings(request)),
+            **get_base_context(request),
             "site_name": settings.SITE_NAME,
             "title": self.title,
+            "apply_url": reverse("applications"),
         }
 
     @property
@@ -202,11 +202,6 @@ class BootcampPage(Page, CommonProperties):
     def admissions_section(self):
         """Gets the admissions section child page"""
         return self._get_child_page_of_type(AdmissionsSection)
-
-    @property
-    def admissions_link(self):
-        """Gets the link to admissions page for this bootcamp run"""
-        return "/admissions"
 
     subpage_types = [
         "ThreeColumnImageTextSection",
@@ -234,13 +229,6 @@ class BootcampRunPage(BootcampPage):
     )
 
     content_panels = [FieldPanel("bootcamp_run")] + BootcampPage.content_panels
-
-    def get_context(self, request, *args, **kwargs):
-        """
-        return page context.
-        """
-        context = super().get_context(request)
-        return context
 
 
 class BootcampRunChildPage(Page):
@@ -482,7 +470,7 @@ class ResourcePage(Page):
     def get_context(self, request, *args, **kwargs):
         return {
             **super().get_context(request, *args, **kwargs),
-            "js_settings_json": json.dumps(_serialize_js_settings(request)),
+            **get_base_context(request),
             "site_name": settings.SITE_NAME,
         }
 

--- a/cms/templates/partials/admissions-section.html
+++ b/cms/templates/partials/admissions-section.html
@@ -9,7 +9,7 @@
                 <div class="row">
                     <div class="col-md-4 col-sm-12 mb-2">
                         <h2 class="section-heading">How to Apply</h2>
-                        <h2 class="admissions-heading mt-2"><a href="/admissions">Admissions</a></h2>
+                        <h2 class="admissions-heading mt-2"><a href="{{ resource_page_urls.how_to_apply }}">Admissions</a></h2>
                     </div>
                     <div class="col-md-7 col-sm-12 admissions-detail">
                         <div class="container-fluid">
@@ -21,7 +21,7 @@
                             <div class="row">
                                 <div class="col d-flex flex-row">
                                     <div class="flex-shrink-0">
-                                        <a href="{{ page.parent.admissions_link }}" class="btn btn-primary btn-apply">Apply Now</a>
+                                        <a href="{{ apply_url }}" class="btn btn-primary btn-apply">Apply Now</a>
                                     </div>
                                     <div class="notes d-flex flex-grow-1 ml-3">{{ page.notes }}</div>
                                 </div>

--- a/main/templates/footer.html
+++ b/main/templates/footer.html
@@ -30,15 +30,15 @@
           <div class="row">
             <div class="col-6">
               <ul class="list-unstyled links">
-                <li><a href="/about-us">About MIT Bootcamps</a></li>
-                <li><a href="/admissions">Admissions</a></li>
-                <li><a href="/bootcamps-programs">Bootcamps Programs</a></li>
+                <li><a href="{{ resource_page_urls.about_us }}">About MIT Bootcamps</a></li>
+                <li><a href="{{ resource_page_urls.how_to_apply }}">Admissions</a></li>
+                <li><a href="{{ resource_page_urls.bootcamps_programs }}">Bootcamps Programs</a></li>
               </ul>
             </div>
             <div class="col-6">
               <ul class="list-unstyled links">
                 <li><a href="{% url "bootcamp-tos" %}">Terms of Service</a></li>
-                <li><a href="/privacy-policy">Privacy Policy</a></li>
+                <li><a href="{{ resource_page_urls.privacy_policy }}">Privacy Policy</a></li>
               </ul>
             </div>
           </div>

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -3,17 +3,79 @@ Test end to end django views.
 """
 import json
 import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
 from cms import factories
+from main import features
+from main.views import get_base_context
+from profiles.factories import UserFactory
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("is_authed", [True, False])
+@pytest.mark.parametrize("feat_social_auth", [True, False])
+def test_get_base_context(settings, mocker, is_authed, feat_social_auth):
+    """Verify the context that is provided to all Django templates inheriting from the base template"""
+    settings.FEATURES[features.SOCIAL_AUTH_API] = feat_social_auth
+    fake_js_settings = {"js": "settings"}
+    patched_json_settings = mocker.patch(
+        "main.views._serialize_js_settings", return_value=fake_js_settings
+    )
+    user = UserFactory.create() if is_authed else AnonymousUser()
+
+    request = RequestFactory().get("/")
+    request.user = user
+    context = get_base_context(request)
+    assert context == {
+        "js_settings_json": json.dumps(fake_js_settings),
+        "resource_page_urls": {
+            "how_to_apply": "/apply",
+            "about_us": "/about-us",
+            "bootcamps_programs": "/bootcamps-programs",
+            "privacy_policy": "/privacy-policy",
+        },
+        "authenticated": is_authed,
+        "social_auth_enabled": feat_social_auth,
+    }
+    patched_json_settings.assert_called_once_with(request)
+
+
+def test_get_context_js_settings(settings):
+    """Verify the specific JS settings in the base context dictionary"""
+    settings.USE_WEBPACK_DEV_SERVER = False
+    settings.ENVIRONMENT = "TEST"
+    settings.VERSION = "9.9.9"
+    settings.RECAPTCHA_SITE_KEY = "SITE_KEY"
+    settings.SUPPORT_URL = "http://example.com/support"
+    settings.SENTRY_DSN = "http://example.com/sentry"
+    settings.ZENDESK_CONFIG = {
+        "HELP_WIDGET_ENABLED": False,
+        "HELP_WIDGET_KEY": "fake_key",
+    }
+
+    request = RequestFactory().get("/")
+    request.user = AnonymousUser()
+    context = get_base_context(request)
+    js_settings = json.loads(context["js_settings_json"])
+    assert js_settings == {
+        "environment": settings.ENVIRONMENT,
+        "release_version": settings.VERSION,
+        "sentry_dsn": settings.SENTRY_DSN,
+        "public_path": "/static/bundles/",
+        "zendesk_config": {
+            "help_widget_enabled": settings.ZENDESK_CONFIG["HELP_WIDGET_ENABLED"],
+            "help_widget_key": settings.ZENDESK_CONFIG["HELP_WIDGET_KEY"],
+        },
+        "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
+        "support_url": settings.SUPPORT_URL,
+    }
 
 
 @pytest.mark.django_db
 def test_index_anonymous(settings, mocker, client):
     """Verify the index view is as expected when user is anonymous"""
     settings.USE_WEBPACK_DEV_SERVER = False
-    settings.ZENDESK_CONFIG = {
-        "HELP_WIDGET_ENABLED": False,
-        "HELP_WIDGET_KEY": "fake_key",
-    }
 
     patched_get_bundle = mocker.patch("main.templatetags.render_bundle._get_bundle")
     root_page = factories.HomePageFactory(parent=None)
@@ -24,19 +86,6 @@ def test_index_anonymous(settings, mocker, client):
 
     bundles = [bundle[0][1] for bundle in patched_get_bundle.call_args_list]
     assert set(bundles) == {"header", "sentry_client", "style", "third_party"}
-    js_settings = json.loads(resp.context["js_settings_json"])
-    assert js_settings == {
-        "environment": settings.ENVIRONMENT,
-        "release_version": settings.VERSION,
-        "sentry_dsn": "",
-        "public_path": "/static/bundles/",
-        "zendesk_config": {
-            "help_widget_enabled": settings.ZENDESK_CONFIG["HELP_WIDGET_ENABLED"],
-            "help_widget_key": settings.ZENDESK_CONFIG["HELP_WIDGET_KEY"],
-        },
-        "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
-        "support_url": settings.SUPPORT_URL,
-    }
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket – fixes an issue introduced in #527 

#### What's this PR do?
- Fixes the links in the admissions section of a bootcamp run page
- Adds a helper function to get context variables that are needed across all Django templates, and adds required resource page URLs to those vars
- Changes footer links to use those resource page URLs

#### How should this be manually tested?
- Create a bootcamp run page for some bootcamp run. Confirm that the "Admissions" and "Apply Now" links go to `/applications/` and `/apply`. Keep in mind that `/apply` will 404 if you don't have a CMS resource page entitled "Apply"
- Check that the footer links are the same as before on every page you visit
