### PR TITLE
Add receipt email

### DIFF
--- a/ecommerce/tasks.py
+++ b/ecommerce/tasks.py
@@ -1,0 +1,9 @@
+"""Ecommerce celery tasks"""
+from ecommerce import api
+from main.celery import app
+
+
+@app.task(acks_late=True)
+def send_receipt_email(application_id):
+    """Task to send a receipt email for an application"""
+    api.send_receipt_email(application_id)

--- a/ecommerce/tasks_test.py
+++ b/ecommerce/tasks_test.py
@@ -1,0 +1,9 @@
+"""Ecommerce task tests"""
+from ecommerce.tasks import send_receipt_email
+
+
+def test_send_receipt_email(mocker):
+    """Test send_receipt_email"""
+    mock_api = mocker.patch("ecommerce.tasks.api")
+    send_receipt_email.delay(123)
+    mock_api.send_receipt_email.assert_called_once_with(123)

--- a/mail/forms.py
+++ b/mail/forms.py
@@ -1,0 +1,15 @@
+"""Mail forms"""
+from django import forms
+
+
+class EmailDebuggerForm(forms.Form):
+    """Form for email debugger"""
+
+    email_type = forms.ChoiceField(
+        choices=(
+            ("verification", "Verify Email"),
+            ("password_reset", "Password Reset"),
+            ("receipt", "Receipt"),
+        ),
+        widget=forms.Select(attrs={"class": "form-control m-2"}),
+    )

--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -29,7 +29,7 @@
     <!-- Web Font / @font-face : END -->
 
     <!-- CSS Reset : BEGIN -->
-    <style>
+    <style data-premailer="ignore">
 
         /* What it does: Remove spaces around the email design added by some email clients. */
         /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
@@ -148,7 +148,7 @@
 	<![endif]-->
 
     <!-- Progressive Enhancements : BEGIN -->
-    <style>
+    <style data-premailer="ignore">
 
 	    /* What it does: Hover styles for buttons */
 	    .button-td,
@@ -217,6 +217,45 @@
     </xml>
     <![endif]-->
 
+    <style>
+      /* these styles get inlined via premailer */
+      .row {
+        padding: 0 10px 10px;
+      }
+
+      .row-text {
+        padding: 5px 20px;
+        font-family: sans-serif;
+        font-size: 15px;
+        line-height: 20px;
+        color: #555555;
+      }
+
+      h1, h2, h3, h4, h5, h6 {
+          margin: 0 0 10px;
+          color: #03152d;
+          font-weight: bold;
+      }
+
+      h1 {
+        font-size: 25px;
+        line-height: 30px;
+      }
+      h2 {
+        font-size: 22px;
+        line-height: 25px;
+      }
+      h3 {
+        font-size: 16px;
+        line-height: 18px;
+      }
+
+      p {
+        margin: 10px 0;
+      }
+    </style>
+
+    {% block styles %}{% endblock %}
 </head>
 <body width="100%" style="margin: 0; padding: 0 !important; mso-line-height-rule: exactly; background-color: #ffffff;">
 	<center style="width: 100%; background-color: #ffffff;">
@@ -266,15 +305,6 @@
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width: 680px;">
                 <tr>
                     <td style="padding: 20px; font-family: sans-serif; font-size: 12px; line-height: 15px; color: #b0b0b0;">
-                        {% block footer %}
-                        {% if anon_token %}
-                        If you don't want to receive these emails in the future, you can
-                        <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}" style="color: #b0b0b0; text-decoration: underline;">edit your settings</a>
-                        or
-                        <a href="{{ base_url }}{% url 'settings-anon' token=anon_token %}" style="color: #b0b0b0; text-decoration: underline;">unsubscribe</a>.
-                        <br><br>
-                        {% endif %}
-                        {% endblock %}
                         {% block footer-address %}
                         MIT Open Learning, 77 Massachusetts Avenue, Cambridge, MA 02139
                         <br>

--- a/mail/templates/email_debugger.html
+++ b/mail/templates/email_debugger.html
@@ -8,84 +8,56 @@
       white-space: -pre-wrap;      /* Opera 4-6 */
       white-space: -o-pre-wrap;    /* Opera 7 */
       word-wrap: break-word;       /* Internet Explorer 5.5+ */
+      line-height: 15px;
     }
   </style>
-  <script type="text/javascript">
-  (function() {
-    document.addEventListener("DOMContentLoaded", function() {
-      document.querySelector('form').addEventListener('submit', function(event) {
-        // Set up our HTTP request
-        event.preventDefault();
-        var form = event.target;
-        var data = new FormData(form);
-        fetch(new Request(form.action, {
-          'method': form.method,
-          'body': data
-        })).then(function (response) {
-          response.json().then(function(res) {
-            var output = document.getElementById('output');
-            var error = document.getElementById('error');
-
-            // reset display styles
-            output.style.display = 'none';
-            error.style.display = 'none';
-
-            // Process our return data
-            if (response.status >= 200 && response.status < 300) {
-              // show the output and u
-              output.style.display = 'block';
-
-              // update
-              document.getElementById('subject').innerHTML = res.subject;
-              var iframe = document.getElementById('html-body')
-              iframe.contentWindow.document.write(res.html_body);
-              iframe.contentWindow.document.close();
-              iframe.style.height = iframe.contentWindow.document.body.scrollHeight + 'px';
-              document.getElementById('text-body').innerHTML = res.text_body;
-            } else {
-              // show the error and update it
-              error.style.display = 'block';
-              error.innerHTML = res.error;
-            }
-          });
-
-        });
-      });
-    });
-  })();
-</script>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css" rel="stylesheet"/>
+  {% load render_bundle %}
+  {% render_bundle 'style' %}
+  {% render_bundle "third_party" %}
 </head>
 <body>
-  <form method="POST" action="{% url 'email-debugger' %}">
-    {{ form }}
-    <span id="error" style="color: red; display: none;"></span>
-    <button type="submit">Render</button>
-  </form>
+<div class="container-fluid">
+  <div class="card mt-2">
+    <form method="POST" action="{% url 'email-debugger' %}" class="form-inline m-0">
+      {% for field in form %}
+        <label class="m-2" for="{{ field.name }}">{{ field.label }}</label>
+        {{ field }}
+      {% endfor %}
+      <button type="submit" class="btn btn-primary m-2">Render</button>
+    </form>
+  </div>
 
-  <table id="output" border="1" cellpadding="10" cellspacing="0" style="display: none;">
-    <tr>
-      <td width="10%">Subject:</td>
-      <td width="90%"><span id="subject"></span></td>
-    </tr>
-    <tr>
-      <td colspan="2">
-        HTML Body:
-      </td>
-    </tr>
-    <tr>
-      <td colspan="2" cellpadding="0">
-        <iframe id="html-body" frameborder="0" scrolling="no" width="100%"></iframe>
-      </td>
-    </tr>
-    <tr>
-      <td colspan="2">
-        Plaintext Body:
-      </td>
-    </tr>
-    <tr>
-      <td colspan="2"><pre id="text-body"></pre></td>
-    </tr>
-  </table>
+  {% if subject %}
 
+  <div class="card mt-2" style="height:85%;">
+    <div class="card-header">
+      <ul id="tabnav" class="nav nav-pills card-header-pills">
+        <li class="nav-item">
+          <a class="nav-link active" data-toggle="tab" href="#html-body">HTML</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" data-toggle="tab" href="#plain-body">Plaintext</a>
+        </li>
+      </ul>
+    </div>
+    <div class="card-content" style="height:100%;">
+      <div class="tab-content" style="height:100%;">
+        <div id="html-body" class="tab-pane active" style="height:100%;">
+          <iframe frameborder="0" width="100%" height="100%" src="data:text/html,{{ html_body|urlencode }}"></iframe>
+        </div>
+        <div id="plain-body" class="tab-pane"><pre class="p-1">{{ text_body }}</pre></div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+</div>
 </body>
+<script>
+$('#tabnav a').on('click', function (e) {
+  e.preventDefault();
+  $(this).tab('show');
+});
+</script>
 </html>

--- a/mail/templates/receipt/body.html
+++ b/mail/templates/receipt/body.html
@@ -1,0 +1,141 @@
+{% extends "email_base.html" %}
+{% load collections dollar_format countries mathfilters parse_date %}
+
+{% block styles %}
+  <style type="text/css">
+    table.receipt-table td {
+      padding: 10px;
+      vertical-align: top;
+    }
+    tr.row-dark {
+      background: #f5f5f5;
+    }
+    td.row-value {
+      color: #000000;
+    }
+    td.total-label {
+      font-weight: bold;
+      color: #000000;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+<!-- 1 Column Text + Button : BEGIN -->
+  <tr>
+      <td style="background-color: #ffffff;">
+          <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+              <tr>
+                  <td class="row-text">
+                      <p>Dear {{ application.user.profile.name }},</p>
+                      <p>
+                        You have been accepted into the {{ application.bootcamp_run.title }} Bootcamp,
+                        {{ application.bootcamp_run.start_date|date:"F j, Y" }} - {{ application.bootcamp_run.end_date|date:"F j, Y" }}.
+                        You can access your payment statements here on your <a href="{% url "applications" %}">{{ site_name }} Dashboard</a>.
+                      </p>
+                      <p>Below you will find a copy of your receipt:</p>
+                  </td>
+              </tr>
+              <tr>
+                  <td class="row-text">
+                    <h1>Receipt</h1>
+                  </td>
+              </tr>
+              <tr>
+                <td class="row-text">
+                  <table width="100%" class="receipt-table">
+                    <tr>
+                      <td colspan="2">
+                        <h3>Order Information</h3>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Bootcamp:</td>
+                      <td class="row-value">{{ application.bootcamp_run.title }}</td>
+                    </tr>
+                    <tr>
+                      <td>Dates:</td>
+                      <td class="row-value">
+                        {{ application.bootcamp_run.start_date|parse_iso_datetime|date:"F j, Y" }} -
+                        {{ application.bootcamp_run.end_date|parse_iso_datetime|date:"F j, Y" }}</td>
+                    </tr>
+                    <tr class="row-dark">
+                      <td colspan="2">
+                        <h3>Order Information</h3>
+                      </td>
+                    </tr>
+                    {% for order in application.orders %}
+                    {% cumulative_field_total application.orders "total_price_paid" forloop.counter as running_total %}
+                    <tr class="row-dark">
+                      <td>Payment Date:</td>
+                      <td class="row-value">{{ order.updated_on|parse_iso_datetime|date:"F j, Y" }}</td>
+                    </tr>
+                    <tr class="row-dark">
+                      <td>Amount Paid:</td>
+                      <td class="row-value">{{ order.total_price_paid|dollar_format }}</td>
+                    </tr>
+                    <tr class="row-dark">
+                      <td>Balance:</td>
+                      <td class="row-value">{{ application.price|sub:running_total|dollar_format }}</td>
+                    </tr>
+                    <tr class="row-dark">
+                      <td>Payment Method:</td>
+                      <td class="row-value">{{ order.payment_method }}</td>
+                    </tr>
+                    <tr class="row-dark">
+                      <td colspan="2"><hr/></td>
+                    </tr>
+                    {% endfor %}
+
+                    {% cumulative_field_total application.orders "total_price_paid" as total_paid %}
+
+                    <tr class="row-dark">
+                      <td class="total-label">Total Amount Paid:</td>
+                      <td class="row-value">{{ total_paid|dollar_format }}</td>
+                    </tr>
+                    <tr class="row-dark">
+                      <td class="total-label">Balance Due:</td>
+                      <td class="row-value">{{ application.price|sub:total_paid|dollar_format }}</td>
+                    </tr>
+                    <tr class="row-dark">
+                      <td class="total-label">Total Amount Due:</td>
+                      <td class="row-value">{{ application.price|dollar_format }}</td>
+                    </tr>
+
+                    <tr>
+                      <td colspan="2">
+                        <h3>Customer Information</h3>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Name:</td>
+                      <td class="row-value">{{ application.user.profile.name }}</td>
+                    </tr>
+                    <tr>
+                      <td>Email:</td>
+                      <td class="row-value">{{ application.user.email }}</td>
+                    </tr>
+                    <tr>
+                      <td>Address:</td>
+                      <td class="row-value">
+                        {% for line in application.user.legal_address.street_address %}
+                        {{ line }}<br/>
+                        {% endfor %}
+                        {% if application.user.legal_address.state_or_territory %}
+                          {{ application.user.legal_address.city }}, {{ application.user.legal_address.state_or_territory|state_or_territory_name }}
+                          {% if application.user.legal_address.postal_code %}{{ application.user.legal_address.postal_code }}{% endif %}
+                        {% else %}
+                          {{ application.user.legal_address.city }}
+                        {% endif %}<br/>
+                        {{ application.user.legal_address.country|country_name }}<br/>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+          </table>
+      </td>
+  </tr>
+<!-- 1 Column Text + Button : END -->
+{% endblock %}

--- a/mail/templates/receipt/subject.txt
+++ b/mail/templates/receipt/subject.txt
@@ -1,0 +1,1 @@
+{{ site_name }} Receipt

--- a/mail/templates/sample/body.html
+++ b/mail/templates/sample/body.html
@@ -3,4 +3,9 @@ a {
   color: red;
 }
 </style>
+<style type="text/css" data-premailer="ignore">
+p {
+  color: blue;
+}
+</style>
 <a href="{{ url }}">html link</a>

--- a/mail/urls.py
+++ b/mail/urls.py
@@ -1,0 +1,12 @@
+"""URL configurations for mail"""
+from django.conf import settings
+from django.conf.urls import url
+
+from mail.views import EmailDebuggerView
+
+urlpatterns = []
+
+if settings.DEBUG:
+    urlpatterns += [
+        url(r"^__emaildebugger__/$", EmailDebuggerView.as_view(), name="email-debugger")
+    ]

--- a/mail/v2/api_test.py
+++ b/mail/v2/api_test.py
@@ -66,12 +66,15 @@ def test_render_email_templates(user):
     assert subject == "Welcome Jane Smith"
     assert text_body == "html link (http://example.com)"
     assert html_body == (
+        "<html><head>"
         '<style type="text/css">\n'
-        "a {\n"
-        "  color: red;\n"
+        "p {\n"
+        "  color: blue;\n"
         "}\n"
         "</style>\n"
-        '<a href="http://example.com">html link</a>\n'
+        "</head><body>"
+        '<a href="http://example.com" style="color:red">html link</a>'
+        "</body></html>"
     )
 
 

--- a/mail/v2/constants.py
+++ b/mail/v2/constants.py
@@ -2,20 +2,14 @@
 
 EMAIL_VERIFICATION = "verification"
 EMAIL_PW_RESET = "password_reset"
-EMAIL_BULK_ENROLL = "bulk_enroll"
-EMAIL_COURSE_RUN_ENROLLMENT = "course_run_enrollment"
-EMAIL_COURSE_RUN_UNENROLLMENT = "course_run_unenrollment"
-EMAIL_B2B_RECEIPT = "b2b_receipt"
-EMAIL_PRODUCT_ORDER_RECEIPT = "product_order_receipt"
 EMAIL_CHANGE_EMAIL = "change_email"
+EMAIL_RECEIPT = "receipt"
 
 EMAIL_TYPE_DESCRIPTIONS = {
     EMAIL_VERIFICATION: "Verify Email",
     EMAIL_PW_RESET: "Password Reset",
-    EMAIL_BULK_ENROLL: "Bulk Enrollment",
-    EMAIL_COURSE_RUN_ENROLLMENT: "Course Run Enrollment",
-    EMAIL_B2B_RECEIPT: "Enrollment Code Purchase Receipt",
     EMAIL_CHANGE_EMAIL: "Change Email",
+    EMAIL_RECEIPT: "Receipt Email",
 }
 
 MAILGUN_API_DOMAIN = "api.mailgun.net"

--- a/mail/views.py
+++ b/mail/views.py
@@ -1,0 +1,106 @@
+"""Mail views"""
+from datetime import timedelta
+
+from django.conf import settings
+from django.shortcuts import render
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
+
+from mail.v2 import api
+from mail.v2.constants import EMAIL_RECEIPT, EMAIL_PW_RESET, EMAIL_VERIFICATION
+from mail.forms import EmailDebuggerForm
+from main.test_utils import drf_datetime
+from main.utils import now_in_utc
+
+
+def _render_email(email_type):
+    """Render the email with dummy data"""
+    context = {"base_url": settings.SITE_BASE_URL, "site_name": settings.SITE_NAME}
+
+    # static, dummy data
+    if email_type == EMAIL_PW_RESET:
+        context.update({"uid": "abc-def", "token": "abc-def"})
+    elif email_type == EMAIL_VERIFICATION:
+        context.update({"confirmation_url": "http://www.example.com/comfirm/url"})
+    elif email_type == EMAIL_RECEIPT:
+        context.update(
+            {
+                "application": dict(
+                    price=5000.0,
+                    user=dict(
+                        email="janedoe@example.com",
+                        profile=dict(name="Jane Doe"),
+                        legal_address=dict(
+                            street_address=["795 Massachusetts Ave", "2nd Floor"],
+                            city="Cambridge",
+                            state_or_territory="US-MA",
+                            country="US",
+                            postal_code="02139",
+                        ),
+                    ),
+                    bootcamp_run=dict(
+                        title="Artificial Intelligence",
+                        start_date=drf_datetime(now_in_utc() + timedelta(days=15)),
+                        end_date=drf_datetime(now_in_utc() + timedelta(days=30)),
+                    ),
+                    orders=[
+                        dict(
+                            updated_on=drf_datetime(now_in_utc() - timedelta(days=21)),
+                            total_price_paid=800.0,
+                            payment_method="Credit Card",
+                        ),
+                        dict(
+                            updated_on=drf_datetime(now_in_utc() - timedelta(days=14)),
+                            total_price_paid=200.67,
+                            payment_method="Wire Transfer",
+                        ),
+                        dict(
+                            updated_on=drf_datetime(now_in_utc() - timedelta(days=7)),
+                            total_price_paid=729.85,
+                            payment_method="Credit Card",
+                        ),
+                    ],
+                )
+            }
+        )
+
+    return api.render_email_templates(email_type, context)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class EmailDebuggerView(View):
+    """Email debugger view"""
+
+    form_cls = EmailDebuggerForm
+    initial = {}
+    template_name = "email_debugger.html"
+
+    def get(self, request):
+        """
+        Dispalys the debugger UI
+        """
+        form = self.form_cls(initial=self.initial)
+        return render(request, self.template_name, {"form": form})
+
+    def post(self, request):
+        """
+        Renders a test email
+        """
+        form = self.form_cls(request.POST)
+
+        if not form.is_valid():
+            return render(request, self.template_name, {"form": form})
+
+        subject, text_body, html_body = _render_email(form.cleaned_data["email_type"])
+
+        return render(
+            request,
+            self.template_name,
+            {
+                "form": form,
+                "subject": subject,
+                "html_body": html_body,
+                "text_body": text_body,
+            },
+        )

--- a/main/settings.py
+++ b/main/settings.py
@@ -104,6 +104,7 @@ INSTALLED_APPS = (
     "rest_framework.authtoken",
     "server_status",
     "social_django",
+    "mathfilters",
     # Hijack
     "hijack",
     "compat",

--- a/main/templatetags/collections.py
+++ b/main/templatetags/collections.py
@@ -1,0 +1,32 @@
+"""Template tags for collections of objects"""
+from classytags.arguments import Argument, IntegerArgument
+from classytags.core import Options
+from classytags.helpers import AsTag
+from django.template import Library
+
+register = Library()
+
+
+class CumulativeFieldTotal(AsTag):
+    """Template tag for summing field values of a collection"""
+
+    name = "cumulative_field_total"
+
+    options = Options(
+        Argument("items", required=True),
+        Argument("field", required=True),
+        IntegerArgument("offset", required=False),
+        "as",
+        Argument("varname", required=False, resolve=False),
+    )
+
+    def get_value(
+        self, context, items, field, offset
+    ):  # pylint: disable=arguments-differ
+        """Sums up a field on a list of objects"""
+        if offset is not None:
+            items = items[:offset]
+        return sum(item[field] for item in items)
+
+
+register.tag(CumulativeFieldTotal)

--- a/main/templatetags/countries.py
+++ b/main/templatetags/countries.py
@@ -1,0 +1,36 @@
+"""Templatetags for pycountry formatting"""
+from django.template import Library
+from django.template.defaultfilters import stringfilter
+import pycountry
+
+register = Library()
+
+
+@stringfilter
+def country_name(alpha_2):
+    """
+    Args:
+        alpha_2(str): An IS-3166 alpha-2 country code
+    Returns:
+        str: The country name
+    """
+    country = pycountry.countries.get(alpha_2=alpha_2)
+    return country.name if country else ""
+
+
+register.filter(country_name)
+
+
+@stringfilter
+def state_or_territory_name(code):
+    """
+    Args:
+        code(str): An IS-3166-2 subdivision (state or territory) code
+    Returns:
+        str: The state or territory name
+    """
+    state_or_territory = pycountry.subdivisions.get(code=code)
+    return state_or_territory.name if state_or_territory else ""
+
+
+register.filter(state_or_territory_name)

--- a/main/urls.py
+++ b/main/urls.py
@@ -41,6 +41,7 @@ urlpatterns = (
         url("", include("ecommerce.urls")),
         url("", include("social_django.urls", namespace="social")),
         path("", include("authentication.urls")),
+        path("", include("mail.urls")),
         path("", include("profiles.urls")),
         path("", include("klasses.urls")),
         url("", include("jobma.urls")),

--- a/requirements.in
+++ b/requirements.in
@@ -4,11 +4,13 @@ boto3==1.12.42
 dj-database-url==0.3.0
 django-anymail[mailgun]==6.1.0
 dj-static==0.0.6
+django-classy-tags==1.0.0
 django-compat==1.0.15
 django-hijack==2.1.10
 django-hijack-admin==2.1.7
 django-filter==2.2.0
 django-fsm==2.6.1
+django-mathfilters==1.0.0
 django-redis==4.7.0
 django-server-status==0.5.0
 django-webpack-loader==0.5.0
@@ -21,6 +23,7 @@ html5lib==0.999999999
 django-storages==1.9.1
 ipython
 newrelic
+premailer==3.7.0
 psycopg2==2.7.3.2
 pycountry==19.8.18
 PyNaCl==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,20 +12,25 @@ billiard==3.6.3.0         # via celery
 boto3==1.12.42            # via -r requirements.in
 botocore==1.15.42         # via boto3, s3transfer
 cached-property==1.5.1    # via zeep
+cachetools==4.1.0         # via premailer
 celery==4.3.0             # via -r requirements.in, django-server-status
 certifi==2018.10.15       # via requests, sentry-sdk
 cffi==1.14.0              # via pynacl
 chardet==3.0.4            # via requests
+cssselect==1.1.0          # via premailer
+cssutils==1.0.2           # via premailer
 decorator==4.0.11         # via ipython, traitlets
 defusedxml==0.5.0         # via python3-openid, social-auth-core, zeep
 dj-database-url==0.3.0    # via -r requirements.in
 dj-static==0.0.6          # via -r requirements.in
 django-anymail[mailgun]==6.1.0  # via -r requirements.in
+django-classy-tags==1.0.0  # via -r requirements.in
 django-compat==1.0.15     # via -r requirements.in, django-hijack, django-hijack-admin
 django-filter==2.2.0      # via -r requirements.in
 django-fsm==2.6.1         # via -r requirements.in
 django-hijack-admin==2.1.7  # via -r requirements.in
 django-hijack==2.1.10     # via -r requirements.in, django-hijack-admin
+django-mathfilters==1.0.0  # via -r requirements.in
 django-modelcluster==5.0.1  # via wagtail
 django-redis==4.7.0       # via -r requirements.in
 django-server-status==0.5.0  # via -r requirements.in
@@ -34,7 +39,7 @@ django-taggit==1.2.0      # via wagtail
 django-templated-mail==1.1.1  # via djoser
 django-treebeard==4.3.1   # via wagtail
 django-webpack-loader==0.5.0  # via -r requirements.in
-django==2.2.13            # via -r requirements.in, django-anymail, django-filter, django-storages, django-taggit, django-treebeard, dynamic-rest, wagtail
+django==2.2.13            # via -r requirements.in, django-anymail, django-classy-tags, django-filter, django-storages, django-taggit, django-treebeard, dynamic-rest, wagtail
 djangorestframework-serializer-extensions==2.0.0  # via -r requirements.in
 djangorestframework==3.9.2  # via -r requirements.in, dynamic-rest, wagtail
 djoser==1.7.0             # via -r requirements.in
@@ -55,12 +60,13 @@ jedi==0.10.2              # via ipython
 jmespath==0.9.5           # via boto3, botocore
 kombu==4.6.7              # via celery, django-server-status
 l18n==2018.5              # via wagtail
-lxml==4.5.0               # via zeep
+lxml==4.5.0               # via premailer, zeep
 newrelic==2.86.3.70       # via -r requirements.in
 oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 pillow==6.2.2             # via wagtail
+premailer==3.7.0          # via -r requirements.in
 prompt-toolkit==1.0.14    # via ipython
 psycopg2==2.7.3.2         # via -r requirements.in, django-server-status
 ptyprocess==0.5.1         # via pexpect
@@ -75,11 +81,11 @@ pytz==2019.3              # via -r requirements.in, celery, django, django-model
 redis==3.2.0              # via -r requirements.in, django-redis, django-server-status
 requests-oauthlib==0.8.0  # via social-auth-core
 requests-toolbelt==0.9.1  # via zeep
-requests==2.20.1          # via -r requirements.in, django-anymail, dynamic-rest, edx-api-client, requests-oauthlib, requests-toolbelt, social-auth-core, wagtail, zeep
+requests==2.20.1          # via -r requirements.in, django-anymail, dynamic-rest, edx-api-client, premailer, requests-oauthlib, requests-toolbelt, social-auth-core, wagtail, zeep
 s3transfer==0.3.3         # via boto3
 sentry-sdk==0.14.3        # via -r requirements.in
 simplegeneric==0.8.1      # via ipython
-six==1.15.0               # via django-anymail, django-compat, django-server-status, edx-api-client, html5lib, isodate, l18n, prompt-toolkit, pynacl, python-dateutil, social-auth-app-django, social-auth-core, traitlets, zeep
+six==1.15.0               # via django-anymail, django-classy-tags, django-compat, django-server-status, edx-api-client, html5lib, isodate, l18n, prompt-toolkit, pynacl, python-dateutil, social-auth-app-django, social-auth-core, traitlets, zeep
 social-auth-app-django==2.1.0  # via -r requirements.in
 social-auth-core==1.4.0   # via social-auth-app-django
 sqlparse==0.3.1           # via django


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #557 

#### What's this PR do?
- Adds a receipt email when a payment is successfully made
- Updated/cleaned up the email debugger to be more robust

#### How should this be manually tested?
To fully test this, you'd need to get cybersource up and running locally, but for the sake of keeping testing simple, i'd suggest setting up an application with one or two `Order` records manually and then running this code:

```python
from applications.models import *
from ecommerce import api
app = BootcampApplication.objects.prefetch_state_data().last()
api.send_receipt_email(app.id)
```

#### Any background context you want to provide?
I originally approached this wanting to roll up the computations for running balance and other values into the model/query, but that ended up looking like a larger footprint, particularly on the regression testing side. The approach here means we have similar code in both React and django templates, but it delivers this faster and without the possibility of regressions (thus requiring more testing).

#### Screenshots (if appropriate)
![Firefox_Screenshot_2020-06-23T01-50-19 769Z](https://user-images.githubusercontent.com/28598/85351724-680c7480-b4d2-11ea-8ac4-9f8d3d3568bc.png)
