### PR TITLE
home page feedback: add global community link

### DIFF
--- a/cms/templates/partials/homepage-alumni.html
+++ b/cms/templates/partials/homepage-alumni.html
@@ -7,7 +7,7 @@
       <div class="row">
           <div class="col-md-6">
               <div class="text-holder">
-                  <h2><a href="#">{{ page.heading }}</a></h2>
+                  <h2><a href="https://open.mit.edu/c/bootcamps" target="_blank" rel="noopener noreferrer">{{ page.heading }}</a></h2>
                   <p> {{page.text|richtext}}</p>
               </div>
           </div>


### PR DESCRIPTION
#### What are the relevant tickets?
#732 

#### What's this PR do?
fixes #732 , Home Page Feedback: add global community link

#### How should this be manually tested?
Just click the link it should go to https://open.mit.edu/c/bootcamps in new tab

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2020-06-23 at 14 40 44" src="https://user-images.githubusercontent.com/4043989/85388504-9a17e800-b55f-11ea-85aa-b7b8e4728715.png">
<img width="1440" alt="Screenshot 2020-06-23 at 14 40 58" src="https://user-images.githubusercontent.com/4043989/85388522-a00dc900-b55f-11ea-8466-6a75899a2e65.png">
