### PR TITLE
home page feedback: show full date, rather than its abbreviations

### DIFF
--- a/cms/templates/partials/home-page-catalog.html
+++ b/cms/templates/partials/home-page-catalog.html
@@ -13,12 +13,12 @@
                         <div class="info d-flex flex-column flex-grow-1">
                             <a href="{% pageurl block.page %}"><h2>{{ block.page.title }}</h2></a>
                             <span class="dates">
-                                {{ block.format }} <br>{{ block.page.bootcamp_run.start_date|date:"M, j" }} - {{ block.page.bootcamp_run.end_date|date }}
+                                {{ block.format }} <br>{{ block.page.bootcamp_run.start_date|date:"F, Y" }} - {{ block.page.bootcamp_run.end_date|date:"F, Y" }}
                             </span>
                             <div class="flex-grow-1">
                                 {{ block.page.description|richtext }}
                             </div>
-                            <strong class="deadline-text">Application Deadline {{ block.application_deadline|date }}</strong>
+                            <strong class="deadline-text">Application Deadline {{ block.application_deadline|date:"F j, Y" }}</strong>
                         </div>
                     </div>
                 {% endwith %}


### PR DESCRIPTION
#### What are the relevant tickets?
#734 

#### What's this PR do?
fixes #734, show full date

#### How should this be manually tested?
Just visit the home page, catalog section

#### Screenshots (if appropriate)
<img width="895" alt="Screenshot 2020-06-23 at 18 22 10" src="https://user-images.githubusercontent.com/4043989/85408973-a7909a80-b57e-11ea-93c3-1faf8bff6f7d.png">
