### PR TITLE
Fix miscellaneous account login/registration issues

### DIFF
--- a/static/js/pages/login/LoginPasswordPage.js
+++ b/static/js/pages/login/LoginPasswordPage.js
@@ -13,6 +13,7 @@ import users from "../../lib/queries/users"
 import { routes } from "../../lib/urls"
 import { STATE_ERROR, handleAuthResponse } from "../../lib/auth"
 import { formatTitle } from "../../util/util"
+import { removeUserNotification } from "../../actions"
 
 import LoginPasswordForm from "../../components/forms/LoginPasswordForm"
 
@@ -32,7 +33,8 @@ type Props = {
     password: string,
     partialToken: string
   ) => Promise<HttpAuthResponse<AuthResponse>>,
-  getCurrentUser: () => Promise<HttpAuthResponse<User>>
+  getCurrentUser: () => Promise<HttpAuthResponse<User>>,
+  removeUserNotification: Function
 }
 
 export class LoginPasswordPage extends React.Component<Props> {
@@ -44,6 +46,11 @@ export class LoginPasswordPage extends React.Component<Props> {
       // this page was navigated to directly and login needs to be started over
       history.push(routes.login.begin)
     }
+  }
+
+  componentWillUnmount() {
+    const { removeUserNotification } = this.props
+    removeUserNotification("account-exists")
   }
 
   async onSubmit(
@@ -128,7 +135,8 @@ const getCurrentUser = () =>
 
 const mapDispatchToProps = {
   loginPassword,
-  getCurrentUser
+  getCurrentUser,
+  removeUserNotification
 }
 
 export default compose(connect(mapStateToProps, mapDispatchToProps))(

--- a/static/js/pages/login/LoginPasswordPage_test.js
+++ b/static/js/pages/login/LoginPasswordPage_test.js
@@ -33,6 +33,11 @@ describe("LoginPasswordPage", () => {
       {
         entities: {
           auth
+        },
+        ui: {
+          userNotifications: {
+            "account-exists": "your account exists"
+          }
         }
       },
       {}
@@ -47,6 +52,12 @@ describe("LoginPasswordPage", () => {
     const { inner } = await renderPage()
 
     assert.ok(inner.find("LoginPasswordForm").exists())
+  })
+
+  it("removes notification for existing account to enter password", async () => {
+    const { inner, store } = await renderPage()
+    inner.unmount()
+    assert.deepEqual(store.getState().ui.userNotifications, {})
   })
 
   it("handles onSubmit for an error response", async () => {

--- a/static/js/pages/register/RegisterConfirmPage.js
+++ b/static/js/pages/register/RegisterConfirmPage.js
@@ -72,11 +72,13 @@ export class RegisterConfirmPage extends React.Component<Props> {
         <div className="row">
           <div className="col">
             {auth && auth.state === STATE_INVALID_EMAIL ? (
-              <React.Fragment>
-                <p>No confirmation code was provided or it has expired.</p>
-                <Link to={routes.register.begin}>Click here</Link> to register
-                again.
-              </React.Fragment>
+              <p>
+                This email has already been verified. If you completed your
+                profile, you can{" "}
+                <Link to={routes.login.begin}>sign in now</Link>. If you have
+                not, you will need to{" "}
+                <Link to={routes.register.begin}>register again</Link>.
+              </p>
             ) : (
               <p>Confirming...</p>
             )}


### PR DESCRIPTION
#### What are the relevant tickets?
Part of https://github.com/mitodl/bootcamp-ecommerce/issues/645

#### What's this PR do?
Fixes a few things in the account creation / login flow based on feedback.

#### How should this be manually tested?

- Create a new user account, click the confirmation link twice. You should see the updated error message on the second click through.
- Attempt to create an account for a user who already exists, verify after entering your password that the notification is removed