### PR TITLE
404 and 500 page design

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,7 +6,7 @@ services:
       - .:/src
       - django_media:/var/media
     environment:
-      DEBUG: 'True'
+      DEBUG: ${DEBUG:-True}
       NODE_ENV: 'development'
       BOOTCAMP_USE_WEBPACK_DEV_SERVER: 'True'
 

--- a/main/templates/404.html
+++ b/main/templates/404.html
@@ -1,22 +1,25 @@
 {% extends "base.html" %}
 {% load i18n render_bundle %}
 
-{% block title %}MIT Bootcamps - Page Not Found{% endblock %}
+{% block title %}{{ site_name }} - Page Not Found{% endblock %}
 
 {% block headercontent %}
 <div id="header"></div>
 {% render_bundle 'header' %}
 {% endblock %}
 
+
 {% block content %}
 <div class="body-content">
-  <div class="photo-bg photo-2 top-content-container">
-    <div id="error" class="text-info-page">
-      <h1>Page not found</h1>
-      <p class="desc">
-        Whatever you were looking for isn't here. <br/>
-        Please <a href="{{ support_url }}" target="_blank" rel="noopener noreferrer">contact us</a> if you need support.
-      </p>
+  <div class="container text-center">
+    <h1 class="text-capitalize">Oops!</h1>
+      <h3 class="text-uppercase">
+          It looks like you have encountered an error. We are unable to find the page you are looking for.
+      </h3>
+    <div class="errorcode">404</div>
+    <div class="bottom-holder">
+      <h3 class="text-uppercase">Here's a helpful link to get you back on track:</h3>
+      <p><a href="{% url 'wagtail_serve' '' %}" class="btn btn-danger large-font">Home</a></p>
     </div>
   </div>
 </div>

--- a/main/templates/500.html
+++ b/main/templates/500.html
@@ -10,10 +10,15 @@
 
 {% block content %}
 <div class="body-content">
-  <div class="photo-bg photo-2 top-content-container">
-    <div id="error" class="text-info-page">
-      <h1>There has been an error (500).</h1>
-      <p class="desc">Please <a href="{{ support_url }}" target="_blank" rel="noopener noreferrer">contact us</a> if this continues to happen</p>
+  <div class="container text-center">
+    <h1 class="text-capitalize">Oops!</h1>
+    <h3 class="text-uppercase">Internal Server Error</h3>
+    <div class="errorcode">500</div>
+    <div class="bottom-holder">
+      <h3 class="text-uppercase">Here's a helpful link to get you back on track:</h3>
+      <a class="text-capitalize" href="{{ support_url }}" target="_blank" rel="noopener noreferrer">
+          Contact customer support
+      </a>
     </div>
   </div>
 </div>

--- a/static/scss/_shared.scss
+++ b/static/scss/_shared.scss
@@ -116,3 +116,7 @@ p, .std-text {
   font-weight: bold;
   width: 100%;
 }
+
+.bottom-holder {
+  margin-bottom: 50px;
+}

--- a/static/scss/_shared.scss
+++ b/static/scss/_shared.scss
@@ -108,3 +108,11 @@ p, .std-text {
 .form-error {
   color: red;
 }
+
+.errorcode {
+  color: $placeholder-color;
+  font-family: Helvetica;
+  font-size: 200px;
+  font-weight: bold;
+  width: 100%;
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #608

#### What's this PR do?
Changes the appearance of 404 and 500 pages

#### How should this be manually tested?
- Set `DEBUG=False` in your .env file
- Go to a URL that doesn't exist, you should see the 404 page and it should look reasonably like the new design.
- Temporarily change the `main.views.react` view to always raise an exception
- Go to `/applications` and you should see the 500 page and it should look reasonably like the new design.

#### Screenshots (if appropriate)
<img width="1055" alt="Screen Shot 2020-06-23 at 1 52 20 PM" src="https://user-images.githubusercontent.com/187676/85438674-363ef080-b55a-11ea-9159-5c4521f2e19d.png">

<img width="1057" alt="Screen Shot 2020-06-23 at 1 30 10 PM" src="https://user-images.githubusercontent.com/187676/85438678-36d78700-b55a-11ea-80b6-7f1045c4d383.png">

