### PR TITLE
Fix resume link on review page

### DIFF
--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -72,7 +72,7 @@ class SubmissionSerializer(serializers.ModelSerializer):
 class BootcampApplicationDetailSerializer(serializers.ModelSerializer):
     """Detailed BootcampApplication serializer"""
 
-    resume_filepath = serializers.SerializerMethodField()
+    resume_url = serializers.SerializerMethodField()
     payment_deadline = serializers.SerializerMethodField()
     run_application_steps = serializers.SerializerMethodField()
     submissions = SubmissionSerializer(many=True, read_only=True)
@@ -80,12 +80,12 @@ class BootcampApplicationDetailSerializer(serializers.ModelSerializer):
     bootcamp_run = BootcampRunSerializer(read_only=True)
     user = UserSerializer()
 
-    def get_resume_filepath(self, bootcamp_application):
-        """Gets the resume filename (without the path) if one exists"""
+    def get_resume_url(self, bootcamp_application):
+        """Gets the resume url if one exists"""
         return (
             None
             if not bootcamp_application.resume_file
-            else bootcamp_application.resume_file.name
+            else bootcamp_application.resume_file.url
         )
 
     def get_payment_deadline(self, bootcamp_application):
@@ -106,7 +106,7 @@ class BootcampApplicationDetailSerializer(serializers.ModelSerializer):
             "id",
             "bootcamp_run",
             "state",
-            "resume_filepath",
+            "resume_url",
             "linkedin_url",
             "resume_upload_date",
             "created_on",

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -78,7 +78,7 @@ def test_application_detail_serializer(app_data, has_resume):
         "id": application.id,
         "bootcamp_run": BootcampRunSerializer(application.bootcamp_run).data,
         "state": application.state,
-        "resume_filepath": application.resume_file.name if has_resume else None,
+        "resume_url": application.resume_file.url if has_resume else None,
         "linkedin_url": application.linkedin_url,
         "resume_upload_date": serializer_date_format(application.resume_upload_date),
         "payment_deadline": serializer_date_format(app_data.installment.deadline),

--- a/applications/views.py
+++ b/applications/views.py
@@ -203,7 +203,9 @@ class UploadResumeView(GenericAPIView):
 
         return Response(
             {
-                "resume_filepath": application.resume_file.name,
+                "resume_url": (
+                    application.resume_file.url if application.resume_file else None
+                ),
                 "linkedin_url": application.linkedin_url,
                 "resume_upload_date": serializer_date_format(
                     application.resume_upload_date

--- a/static/js/components/ResumeLinkedIn.js
+++ b/static/js/components/ResumeLinkedIn.js
@@ -165,7 +165,7 @@ export class ResumeLinkedIn extends React.Component<Props> {
       return null
     }
 
-    const resumeFilename = getFilenameFromMediaPath(application.resume_filepath)
+    const resumeFilename = getFilenameFromMediaPath(application.resume_url)
     const initialFormValues: ResumeLinkedInForm = {
       linkedInUrl:    application.linkedin_url || "",
       resumeFilename: resumeFilename

--- a/static/js/components/ResumeLinkedIn_test.js
+++ b/static/js/components/ResumeLinkedIn_test.js
@@ -15,12 +15,12 @@ import { applicationDetailKey } from "../lib/queries/applications"
 
 describe("ResumeLinkedIn", () => {
   const fakeResumeFilename = "my_resume.pdf",
-    fakeResumeFilepath = `resumes/1/fd07666e-f546-4c86-8099-825628e68de8_${fakeResumeFilename}`
+    fakeResumeUrl = `https://foo.edu/resumes/1/fd07666e-f546-4c86-8099-825628e68de8_${fakeResumeFilename}`
   let helper, renderPage, applicationDetail, resumeUrl
 
   beforeEach(() => {
     applicationDetail = makeApplicationDetail()
-    applicationDetail.resume_filepath = fakeResumeFilepath
+    applicationDetail.resume_url = fakeResumeUrl
     resumeUrl = `/api/applications/${applicationDetail.id}/resume/`
     helper = new IntegrationTestHelper()
     renderPage = helper.configureHOCRenderer(

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -115,7 +115,7 @@ export const makeApplicationDetail = (): ApplicationDetail => {
     id:                    incr.next().value,
     state:                 casual.random_element(Object.keys(APP_STATE_TEXT_MAP)),
     bootcamp_run:          run,
-    resume_filepath:       casual.url,
+    resume_url:            casual.url,
     linkedin_url:          casual.url,
     resume_upload_date:    moment().format(),
     payment_deadline:      moment().format(),
@@ -133,7 +133,7 @@ export const setToAwaitingResume = (
   appDetail: ApplicationDetail
 ): ApplicationDetail => {
   appDetail.resume_upload_date = undefined
-  appDetail.resume_filepath = undefined
+  appDetail.resume_url = undefined
   appDetail.linkedin_url = undefined
   appDetail.submissions = []
   return appDetail
@@ -144,7 +144,7 @@ export const setToAwaitingSubmission = (
 ): ApplicationDetail => {
   appDetail = setToAwaitingResume(appDetail)
   appDetail.resume_upload_date = moment().format()
-  appDetail.resume_filepath = casual.url
+  appDetail.resume_url = casual.url
   appDetail.submissions = []
   return appDetail
 }

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -58,7 +58,7 @@ export type ApplicationDetail = {
   id:                    number,
   state:                 string,
   bootcamp_run:          BootcampRun,
-  resume_filepath:       ?string,
+  resume_url:            ?string,
   linkedin_url:          ?string,
   resume_upload_date:    ?string,
   payment_deadline:      string,

--- a/static/js/pages/applications/ReviewDetailPage.js
+++ b/static/js/pages/applications/ReviewDetailPage.js
@@ -91,7 +91,7 @@ const ReviewPanelRight = (props: FormProps) => {
   const currentSelection = selection || submission.review_status
 
   return (
-    <div className="col-4 review-card review-panel-right">
+    <div className="col-3 review-card review-panel-right">
       <div className="status">
         <h3>STATUS</h3>
         <div className="form-check radio-status">
@@ -208,16 +208,26 @@ const ReviewPanelLeft = (props: DetailProps) => {
       <div className="row section">
         <UserDetails user={user} />
       </div>
-      {application.resume_filepath ? (
+      {application.resume_url ? (
         <div className="row section resume">
           <div className="col">
             <div className="row">
               <h3>Resume</h3>
             </div>
             <div className="row">
-              <a href={application.resume_filepath}>
-                {getFilenameFromPath(application.resume_filepath)}
+              <a
+                href={application.resume_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {getFilenameFromPath(application.resume_url)}
               </a>
+              <embed
+                type="application/pdf"
+                src={application.resume_url}
+                width="100%"
+                height="375"
+              />
             </div>
           </div>
         </div>

--- a/static/js/pages/applications/ReviewDetailPage_test.js
+++ b/static/js/pages/applications/ReviewDetailPage_test.js
@@ -95,18 +95,22 @@ describe("ReviewDetailPage", () => {
     )} render the resume section if resume_file is ${String(
       resumeFile
     )}`, async () => {
-      fakeApplicationDetail.resume_filepath = resumeFile
+      fakeApplicationDetail.resume_url = resumeFile
       const { wrapper } = await renderPage()
       const resumeDiv = wrapper.find(".resume")
       assert.equal(resumeDiv.exists(), !isNilOrBlank(resumeFile))
       if (!isNilOrBlank(resumeFile)) {
         assert.equal(
           resumeDiv.find("a").prop("href"),
-          fakeApplicationDetail.resume_filepath
+          fakeApplicationDetail.resume_url
+        )
+        assert.equal(
+          resumeDiv.find("embed").prop("src"),
+          fakeApplicationDetail.resume_url
         )
         assert.equal(
           resumeDiv.find("a").text(),
-          getFilenameFromPath(fakeApplicationDetail.resume_filepath)
+          getFilenameFromPath(fakeApplicationDetail.resume_url)
         )
       }
     })
@@ -193,7 +197,7 @@ describe("ReviewDetailPage", () => {
         helper.handleRequestStub,
         `/api/submissions/${fakeSubmissionReview.id}/`,
         "PATCH",
-        { body, credentials: undefined, headers: { "X-CSRFTOKEN": "" } }
+        { body, credentials: undefined, headers: sinon.match.any }
       )
       assert.equal(wrapper.find("Alert").text(), `Submission ${status}`)
     })


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #743 

#### What's this PR do?
- Uses the file url instead of path in the serializer
- Also embeds the resume
- Fixes a layout bug on Mac Safari
- Renames 'resume_filepath' to 'resume_url' in the application serializer.

#### How should this be manually tested?
- As an applicant, upload a resume.  It should still work as before.
- As a reviewer, open a submission review page (`../review/<submission_id>`) for an application that has an uploaded resume.  The link should work and the resume should also display in an embed.


#### Screenshots (if appropriate)
<img width="595" alt="Screen Shot 2020-06-23 at 4 26 25 PM" src="https://user-images.githubusercontent.com/187676/85457709-59739b00-b56e-11ea-87d8-c5ec0dca92cb.png">

