### PR TITLE
set letter-spacing normal

### DIFF
--- a/static/scss/cms/instructor.scss
+++ b/static/scss/cms/instructor.scss
@@ -151,6 +151,7 @@
       margin-bottom: 10px;
       font-weight: 800;
       font-size: 36px;
+      letter-spacing: normal;
     }
 
     .rich-text {


### PR DESCRIPTION
#### What are the relevant tickets?
#749, Instructors: line-height for instructors' title is too large (almost double-spaced).

#### What's this PR do?
fixes #749, remove double spacing 

#### How should this be manually tested?
Instruction section title "Instructors"

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2020-06-24 at 13 44 31" src="https://user-images.githubusercontent.com/4043989/85523825-e545ff80-b620-11ea-8a53-fbc51fcadff5.png">
