### PR TITLE
product page feedback: insturctor carousel item title fixes

### DIFF
--- a/static/scss/cms/instructor.scss
+++ b/static/scss/cms/instructor.scss
@@ -100,8 +100,6 @@
   }
 
   .text-holder {
-    overflow-y: auto;
-    height: 78px;
     padding: 0 10px;
     word-wrap: break-word;
     text-align: left;
@@ -113,7 +111,8 @@
 
     .title {
       font-size: 14px;
-      margin: -5px 0 5px;
+      margin: 0 0 5px;
+      line-height: 18px;
     }
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?
#749 

#### What's this PR do?
fixes #749, fixes line-height for instructors' title is too large (almost double-spaced) and remove Scrollbars.

#### How should this be manually tested?
Just make sure you have the CMS Product Page with Instructor Section
Just add more content in instructor title in Product Page -> Instructor Section

#### Screenshots (if appropriate)
**Before**
<img width="1440" alt="Screenshot 2020-06-24 at 17 42 56" src="https://user-images.githubusercontent.com/4043989/85558949-ae80e100-b642-11ea-8da0-52534e1e6d67.png">

**After**
<img width="1440" alt="Screenshot 2020-06-24 at 17 47 37" src="https://user-images.githubusercontent.com/4043989/85559102-d4a68100-b642-11ea-8221-1c02201a6380.png">
