### PR TITLE
Sync product (bootcamp run) on transaction commit

### DIFF
--- a/applications/signals.py
+++ b/applications/signals.py
@@ -1,4 +1,5 @@
 """Signals for application models"""
+from django.db.transaction import on_commit
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -14,7 +15,7 @@ from hubspot.task_helpers import sync_hubspot_application
 def sync_deal_application(sender, instance, created, **kwargs):
     """Sync application to hubspot"""
     if not created:
-        sync_hubspot_application(instance)
+        on_commit(lambda: sync_hubspot_application(instance))
 
 
 @receiver(
@@ -25,4 +26,4 @@ def sync_deal_application(sender, instance, created, **kwargs):
 def sync_deal_on_submission(sender, instance, created, **kwargs):
     """Sync application to hubspot when a submission is created"""
     if created:
-        sync_hubspot_application(instance.bootcamp_application)
+        on_commit(lambda: sync_hubspot_application(instance.bootcamp_application))

--- a/applications/signals_test.py
+++ b/applications/signals_test.py
@@ -12,22 +12,23 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def mock_hubspot(mocker):
+def mock_hubspot_on_commit(mocker):
     """ Mock sync_hubspot_application"""
-    return mocker.patch("applications.signals.sync_hubspot_application")
+    return mocker.patch("applications.signals.on_commit")
 
 
-def test_application_signal(mock_hubspot):
+def test_application_signal(mock_hubspot_on_commit):
     """Test that hubspot is synced whenever a BootcampApplication is created/updated"""
 
     application = BootcampApplicationFactory.create()
     application.save()
     application.save()
-    assert mock_hubspot.call_count == 2  # None for creation, twice for updates
-    mock_hubspot.assert_any_call(application)
+    assert (
+        mock_hubspot_on_commit.call_count == 2
+    )  # None for creation, twice for updates
 
 
-def test_submission_signal(mock_hubspot):
+def test_submission_signal(mock_hubspot_on_commit):
     """ Test that hubspot is synced whenever an ApplicationStepSubmission is created"""
 
     submission = ApplicationStepSubmissionFactory.create()
@@ -36,5 +37,4 @@ def test_submission_signal(mock_hubspot):
     )
     submission.save()
     submission.save()
-    assert mock_hubspot.call_count == 1  # Once for submission creation
-    mock_hubspot.assert_any_call(submission.bootcamp_application)
+    assert mock_hubspot_on_commit.call_count == 1  # Once for submission creation

--- a/hubspot/api.py
+++ b/hubspot/api.py
@@ -21,8 +21,7 @@ from hubspot.serializers import (
     HubspotDealSerializer,
     HubspotLineSerializer,
 )
-from klasses.models import Bootcamp
-
+from klasses.models import BootcampRun
 
 HUBSPOT_API_BASE_URL = "https://api.hubapi.com"
 
@@ -249,19 +248,19 @@ def make_contact_sync_message(user_id):
     return [make_sync_message(user.profile.id, properties)]
 
 
-def make_product_sync_message(bootcamp_id):
+def make_product_sync_message(bootcamp_run_id):
     """
     Create the body of a sync message for a product.
 
     Args:
-        bootcamp_id (int): Bootcamp id
+        bootcamp_run_id (int): Bootcamp run id
 
     Returns:
         list: dict containing serializable sync-message data
     """
-    bootcamp = Bootcamp.objects.get(id=bootcamp_id)
-    properties = HubspotProductSerializer(instance=bootcamp).data
-    return [make_sync_message(bootcamp.id, properties)]
+    bootcamp_run = BootcampRun.objects.get(id=bootcamp_run_id)
+    properties = HubspotProductSerializer(instance=bootcamp_run).data
+    return [make_sync_message(bootcamp_run.integration_id, properties)]
 
 
 def make_deal_sync_message(application_id):

--- a/hubspot/management/commands/sync_hubspot.py
+++ b/hubspot/management/commands/sync_hubspot.py
@@ -13,7 +13,7 @@ from hubspot.api import (
     make_line_sync_message,
 )
 from hubspot.tasks import sync_bulk_with_hubspot
-from klasses.models import Bootcamp
+from klasses.models import BootcampRun
 
 
 class Command(BaseCommand):
@@ -62,7 +62,7 @@ class Command(BaseCommand):
         """
         print("  Syncing products with hubspot products...")
         self.bulk_sync_model(
-            Bootcamp.objects.all(), make_product_sync_message, "PRODUCT"
+            BootcampRun.objects.all(), make_product_sync_message, "PRODUCT"
         )
         print("  Finished")
 

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -10,18 +10,18 @@ from applications.api import get_required_submission_type
 from applications.constants import AppStates, SUBMISSION_TYPE_STATE
 from applications.models import BootcampApplication
 from ecommerce.models import Order
-from klasses.models import Bootcamp
+from klasses.models import BootcampRun
 
 log = logging.getLogger(__name__)
 
 
 class HubspotProductSerializer(serializers.ModelSerializer):
     """
-    Serializer for turning a Bootcamp into a hubspot Product
+    Serializer for turning a BootcampRun into a hubspot Product
     """
 
     class Meta:
-        model = Bootcamp
+        model = BootcampRun
         fields = ["title"]
 
 
@@ -54,8 +54,8 @@ class HubspotDealSerializer(serializers.ModelSerializer):
         return "0.00"
 
     def get_bootcamp_name(self, instance):
-        """Get the name of the bootcamp"""
-        return instance.bootcamp_run.bootcamp.title
+        """Get the name of the bootcamp run"""
+        return instance.bootcamp_run.title
 
     def get_application_stage(self, instance):
         """Get the application stage"""
@@ -113,7 +113,7 @@ class HubspotLineSerializer(serializers.ModelSerializer):
         """Get the id of the associated Bootcamp"""
         from hubspot.api import format_hubspot_id
 
-        return format_hubspot_id(instance.bootcamp_run.bootcamp.id)
+        return format_hubspot_id(instance.bootcamp_run.integration_id)
 
     class Meta:
         model = BootcampApplication

--- a/hubspot/serializers.py
+++ b/hubspot/serializers.py
@@ -110,7 +110,7 @@ class HubspotLineSerializer(serializers.ModelSerializer):
         return format_hubspot_id(instance.integration_id)
 
     def get_product(self, instance):
-        """Get the id of the associated Bootcamp"""
+        """Get the id of the associated BootcampRun"""
         from hubspot.api import format_hubspot_id
 
         return format_hubspot_id(instance.bootcamp_run.integration_id)

--- a/hubspot/serializers_test.py
+++ b/hubspot/serializers_test.py
@@ -13,17 +13,20 @@ from hubspot.serializers import (
     HubspotDealSerializer,
     HubspotLineSerializer,
 )
-from klasses.factories import PersonalPriceFactory, InstallmentFactory
-from klasses.models import Bootcamp
+from klasses.factories import (
+    PersonalPriceFactory,
+    InstallmentFactory,
+    BootcampRunFactory,
+)
 
 pytestmark = [pytest.mark.django_db]
 
 
 def test_product_serializer():
     """Test that the HubspotProductSerializer correctly serializes a Bootcamp"""
-    bootcamp = Bootcamp.objects.create(title="test bootcamp 123")
-    serialized_data = {"title": bootcamp.title}
-    data = HubspotProductSerializer(instance=bootcamp).data
+    bootcamp_run = BootcampRunFactory.create(title="test bootcamp 123")
+    serialized_data = {"title": bootcamp_run.title}
+    data = HubspotProductSerializer(instance=bootcamp_run).data
     assert data == serialized_data
 
 
@@ -48,7 +51,7 @@ def test_deal_serializer_with_personal_price(pay_amount, status):
     )
     serialized_data = {
         "application_stage": application.state,
-        "bootcamp_name": application.bootcamp_run.bootcamp.title,
+        "bootcamp_name": application.bootcamp_run.title,
         "price": personal_price.price.to_eng_string(),
         "purchaser": format_hubspot_id(application.user.profile.id),
         "name": f"Bootcamp-application-order-{application.id}",
@@ -77,7 +80,7 @@ def test_deal_serializer_with_installment_price():
 
     serialized_data = {
         "application_stage": application.state,
-        "bootcamp_name": application.bootcamp_run.bootcamp.title,
+        "bootcamp_name": application.bootcamp_run.title,
         "price": installment.amount.to_eng_string(),
         "purchaser": format_hubspot_id(application.user.profile.id),
         "name": f"Bootcamp-application-order-{application.id}",
@@ -95,7 +98,7 @@ def test_deal_serializer_with_no_price():
 
     serialized_data = {
         "application_stage": application.state,
-        "bootcamp_name": application.bootcamp_run.bootcamp.title,
+        "bootcamp_name": application.bootcamp_run.title,
         "price": "0.00",
         "purchaser": format_hubspot_id(application.user.profile.id),
         "name": f"Bootcamp-application-order-{application.id}",
@@ -111,7 +114,7 @@ def test_deal_serializer_awaiting_submissions(awaiting_submission_app):
         "application_stage": SUBMISSION_TYPE_STATE.get(
             awaiting_submission_app.run_steps[1].application_step.submission_type
         ),
-        "bootcamp_name": awaiting_submission_app.application.bootcamp_run.bootcamp.title,
+        "bootcamp_name": awaiting_submission_app.application.bootcamp_run.title,
         "price": awaiting_submission_app.installment.amount.to_eng_string(),
         "purchaser": format_hubspot_id(
             awaiting_submission_app.application.user.profile.id
@@ -128,7 +131,7 @@ def test_line_serializer():
     application = BootcampApplicationFactory.create()
     serialized_data = {
         "order": format_hubspot_id(application.integration_id),
-        "product": format_hubspot_id(application.bootcamp_run.bootcamp_id),
+        "product": format_hubspot_id(application.bootcamp_run.integration_id),
     }
     data = HubspotLineSerializer(instance=application).data
     assert data == serialized_data

--- a/hubspot/task_helpers.py
+++ b/hubspot/task_helpers.py
@@ -44,12 +44,12 @@ def sync_hubspot_application_from_order(order):
         log.error("No matching BootcampApplication found for order %s", order.id)
 
 
-def sync_hubspot_product(bootcamp):
+def sync_hubspot_product(bootcamp_run):
     """
     Trigger celery task to sync a Bootcamp to Hubspot
 
     Args:
-        bootcamp (Bootcamp): The Bootcamp to sync
+        bootcamp_run (BootcampRun): The BootcampRun to sync
     """
     if settings.HUBSPOT_API_KEY:
-        tasks.sync_product_with_hubspot.delay(bootcamp.id)
+        tasks.sync_product_with_hubspot.delay(bootcamp_run.id)

--- a/hubspot/task_helpers_test.py
+++ b/hubspot/task_helpers_test.py
@@ -11,7 +11,7 @@ from hubspot.task_helpers import (
     sync_hubspot_user,
     sync_hubspot_product,
 )
-from klasses.factories import BootcampFactory
+from klasses.factories import BootcampRunFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -77,12 +77,12 @@ def test_sync_hubspot_user(settings, mock_hubspot, hubspot_key, user):
 @pytest.mark.parametrize("hubspot_key", [None, "abc"])
 def test_sync_hubspot_product(settings, mock_hubspot, hubspot_key):
     """ sync_hubspot_product helper should call task if an API key is present """
-    bootcamp = BootcampFactory.create()
+    bootcamp_run = BootcampRunFactory.create()
     settings.HUBSPOT_API_KEY = hubspot_key
-    sync_hubspot_product(bootcamp)
+    sync_hubspot_product(bootcamp_run)
     if hubspot_key is not None:
         mock_hubspot.sync_product_with_hubspot.delay.assert_called_once_with(
-            bootcamp.id
+            bootcamp_run.id
         )
     else:
         mock_hubspot.sync_product_with_hubspot.delay.assert_not_called()

--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -45,9 +45,9 @@ def sync_contact_with_hubspot(user_id):
 
 
 @app.task
-def sync_product_with_hubspot(bootcamp_id):
-    """Send a sync-message to sync a Bootcamp with a hubspot product"""
-    body = make_product_sync_message(bootcamp_id)
+def sync_product_with_hubspot(bootcamp_run_id):
+    """Send a sync-message to sync a BootcampRun with a hubspot product"""
+    body = make_product_sync_message(bootcamp_run_id)
     response = send_hubspot_request("PRODUCT", HUBSPOT_SYNC_URL, "PUT", body=body)
     response.raise_for_status()
 

--- a/hubspot/tasks_test.py
+++ b/hubspot/tasks_test.py
@@ -30,11 +30,7 @@ from hubspot.tasks import (
     sync_application_with_hubspot,
     retry_invalid_line_associations,
 )
-from klasses.factories import (
-    PersonalPriceFactory,
-    InstallmentFactory,
-    BootcampRunFactory,
-)
+from klasses.factories import InstallmentFactory, BootcampRunFactory
 from profiles.factories import ProfileFactory, UserFactory
 
 pytestmark = [pytest.mark.django_db]
@@ -104,10 +100,6 @@ def test_sync_deal_with_hubspot(mock_hubspot_request):
 def test_sync_line_with_hubspot(mock_hubspot_request):
     """Test that send_hubspot_request is called properly for a LINE sync"""
     application = BootcampApplicationFactory.create()
-    PersonalPriceFactory.create(
-        bootcamp_run=application.bootcamp_run, user=application.user
-    )
-
     sync_line_with_hubspot(application.id)
     body = make_line_sync_message(application.id)
     body[0]["changeOccurredTimestamp"] = ANY

--- a/hubspot/tasks_test.py
+++ b/hubspot/tasks_test.py
@@ -30,7 +30,11 @@ from hubspot.tasks import (
     sync_application_with_hubspot,
     retry_invalid_line_associations,
 )
-from klasses.factories import BootcampFactory, PersonalPriceFactory, InstallmentFactory
+from klasses.factories import (
+    PersonalPriceFactory,
+    InstallmentFactory,
+    BootcampRunFactory,
+)
 from profiles.factories import ProfileFactory, UserFactory
 
 pytestmark = [pytest.mark.django_db]
@@ -64,9 +68,9 @@ def test_sync_contact_with_hubspot_missing_email(mock_hubspot_request):
 
 def test_sync_product_with_hubspot(mock_hubspot_request):
     """Test that send_hubspot_request is called properly for a PRODUCT sync"""
-    bootcamp = BootcampFactory.create()
-    sync_product_with_hubspot(bootcamp.id)
-    body = make_product_sync_message(bootcamp.id)
+    bootcamp_run = BootcampRunFactory.create()
+    sync_product_with_hubspot(bootcamp_run.id)
+    body = make_product_sync_message(bootcamp_run.id)
     body[0]["changeOccurredTimestamp"] = ANY
     mock_hubspot_request.assert_called_once_with(
         "PRODUCT", HUBSPOT_SYNC_URL, "PUT", body=body

--- a/klasses/constants.py
+++ b/klasses/constants.py
@@ -8,3 +8,6 @@ class ApplicationSource:
     FLUIDREVIEW = "FluidRev"
 
     SOURCE_CHOICES = [None, SMAPPLY, FLUIDREVIEW]
+
+
+INTEGRATION_PREFIX_PRODUCT = "BootcampProduct-"

--- a/klasses/models.py
+++ b/klasses/models.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 from django.db import models
 
 from main.models import TimestampedModel
-from klasses.constants import ApplicationSource
+from klasses.constants import ApplicationSource, INTEGRATION_PREFIX_PRODUCT
 
 
 class Bootcamp(models.Model):
@@ -138,6 +138,19 @@ class BootcampRun(models.Model):
         return self.installment_set.filter(
             deadline__lte=next_installment.deadline
         ).aggregate(price=models.Sum("amount"))["price"]
+
+    @property
+    def integration_id(self):
+        """
+        Return an integration id to be used by Hubspot as the unique product id.
+        This is necessary because the integration id used to be based on Bootcamp.id,
+        and is now based on BootcampRun (formerly Klass).  This requires that there be no
+        overlap in integration ids between new and old products.
+
+        Returns:
+            str: the integration id
+        """
+        return f"{INTEGRATION_PREFIX_PRODUCT}{self.id}"
 
     def personal_price(self, user):
         """

--- a/klasses/signals.py
+++ b/klasses/signals.py
@@ -12,5 +12,5 @@ def sync_bootcamp_run(
     sender, instance, created, **kwargs
 ):  # pylint:disable=unused-argument
 
-    """Sync bootcamp to hubspot"""
+    """Sync bootcamp run to hubspot"""
     on_commit(lambda: sync_hubspot_product(instance))

--- a/klasses/signals.py
+++ b/klasses/signals.py
@@ -1,4 +1,5 @@
 """Signals for ecommerce models"""
+from django.db.transaction import on_commit
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -12,4 +13,4 @@ def sync_bootcamp_run(
 ):  # pylint:disable=unused-argument
 
     """Sync bootcamp to hubspot"""
-    sync_hubspot_product(instance)
+    on_commit(lambda: sync_hubspot_product(instance))

--- a/klasses/signals.py
+++ b/klasses/signals.py
@@ -3,11 +3,11 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from hubspot.task_helpers import sync_hubspot_product
-from klasses.models import Bootcamp
+from klasses.models import BootcampRun
 
 
-@receiver(post_save, sender=Bootcamp, dispatch_uid="bootcamp_post_save")
-def sync_bootcamp(
+@receiver(post_save, sender=BootcampRun, dispatch_uid="bootcamp__run_post_save")
+def sync_bootcamp_run(
     sender, instance, created, **kwargs
 ):  # pylint:disable=unused-argument
 

--- a/klasses/signals_test.py
+++ b/klasses/signals_test.py
@@ -1,18 +1,18 @@
 """ Tests for applications.signals"""
 import pytest
 
-from klasses.factories import BootcampFactory
+from klasses.factories import BootcampRunFactory
 
 pytestmark = pytest.mark.django_db
 
 # pylint: disable=redefined-outer-name
 
 
-def test_bootcamp_signal(mocker):
+def test_bootcamp_run_signal(mocker):
     """Test that hubspot is synced whenever a Bootcamp is created/updated"""
     mock_hubspot = mocker.patch("klasses.signals.sync_hubspot_product")
-    bootcamp = BootcampFactory.create()
-    bootcamp.save()
-    bootcamp.save()
+    bootcamp_run = BootcampRunFactory.create()
+    bootcamp_run.save()
+    bootcamp_run.save()
     assert mock_hubspot.call_count == 3  # Once for creation, twice for updates
-    mock_hubspot.assert_any_call(bootcamp)
+    mock_hubspot.assert_any_call(bootcamp_run)

--- a/klasses/signals_test.py
+++ b/klasses/signals_test.py
@@ -10,9 +10,8 @@ pytestmark = pytest.mark.django_db
 
 def test_bootcamp_run_signal(mocker):
     """Test that hubspot is synced whenever a Bootcamp is created/updated"""
-    mock_hubspot = mocker.patch("klasses.signals.sync_hubspot_product")
-    bootcamp_run = BootcampRunFactory.create()
-    bootcamp_run.save()
-    bootcamp_run.save()
-    assert mock_hubspot.call_count == 3  # Once for creation, twice for updates
-    mock_hubspot.assert_any_call(bootcamp_run)
+    mock_on_commit = mocker.patch("klasses.signals.on_commit")
+    bootcamp = BootcampRunFactory.create()
+    bootcamp.save()
+    bootcamp.save()
+    assert mock_on_commit.call_count == 3  # Once for creation, twice for updates


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #679

#### What's this PR do?
- Use `BootcampRun` instead of `Bootcamp` as the hubspot "product"
- Use `on_commit` in signals to make sure the object has been saved to the db before running celery tasks.

#### How should this be manually tested?
- Create some bootcamps and runs in django admin
- Apply for the bootcamps
- Your applications should be synced in hubspot and associated with the correct bootcamp runs as the products
