### PR TITLE
Fixed app dashboard regression that prevented cards from expanding

### DIFF
--- a/static/js/lib/queries/applications.js
+++ b/static/js/lib/queries/applications.js
@@ -21,7 +21,6 @@ const applicationsKey = "applications"
 export const applicationDetailKey = "applicationDetail"
 export const createAppQueryKey = "createApplication"
 export const appQueryKey = applicationsKey
-export const appDetailQueryKey = applicationDetailKey
 
 export const applicationsSelector = (state: any): ?Array<Application> =>
   state.entities[applicationsKey]
@@ -65,7 +64,6 @@ export default {
     }
   }),
   applicationDetailQuery: (applicationId: string, force?: boolean) => ({
-    queryKey:  appDetailQueryKey,
     url:       applicationDetailAPI.param({ applicationId }).toString(),
     transform: (json: ?ApplicationDetail) => {
       return {


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
Fixes regression that prevents users from expanding multiple application dashboard cards

#### How should this be manually tested?
Click "Expand" on multiple application dashboard cards

#### Any background context you want to provide?
This code was left over from some debugging I was doing 😬 
