### PR TITLE
asadiqbal08/gray link in program elements section.

### DIFF
--- a/static/scss/cms/program-description.scss
+++ b/static/scss/cms/program-description.scss
@@ -105,7 +105,7 @@
         a {
           display: inline-block;
           vertical-align: top;
-          color: #505050;
+          color: $matterhorn;
           font-size: 20px;
           line-height: 25px;
           text-decoration: underline;
@@ -220,7 +220,7 @@
 
           &[aria-expanded="true"] {
             font-weight: bold;
-            color: $dodger-blue;
+            color: $trolley-gray;
           }
         }
 


### PR DESCRIPTION
#### What are the relevant tickets?
fixes: #752 

#### What's this PR do?
Program Elements: link selected color should be gray, not blue -- same as product page

#### Screenshots (if appropriate)

<img width="1433" alt="Screen Shot 2020-06-25 at 2 36 27 PM" src="https://user-images.githubusercontent.com/7334669/85695219-42a98180-b6f1-11ea-9339-d982453aba42.png">
