### PR TITLE
Fix Cybersource payment denied issue

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -134,8 +134,6 @@ def generate_cybersource_sa_payload(order, redirect_url):
     payload = {
         "access_key": settings.CYBERSOURCE_ACCESS_KEY,
         "amount": str(order.total_price_paid),
-        "consumer_id": order.user.username,
-        "customer_account_id": order.user.id,
         "currency": "USD",
         "locale": "en-us",
         "item_0_code": "klass",

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -131,8 +131,6 @@ def test_signed_payload(mocker, application, bootcamp_run):
     assert payload == {
         "access_key": CYBERSOURCE_ACCESS_KEY,
         "amount": str(order.total_price_paid),
-        "consumer_id": order.user.username,
-        "customer_account_id": order.user.id,
         "currency": "USD",
         "item_0_code": "klass",
         "item_0_name": "{}".format(bootcamp_run.title),


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What does this PR do?
Removes `consumer_id` field from being sent to Cybersource. This field is not necessary for us and it was causing checkouts to fail if the user's username contained an email address, which is true for most current usernames.

This also removes `customer_account_id` which was added in #775 as a testing measure but is not needed.

#### Manual testing
Will be done on RC