### PR TITLE
Handle failure to create jobma interview

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -246,8 +246,8 @@ class VideoInterviewsView(GenericAPIView):
         )
         # Job should be created by admin beforehand
         job = Job.objects.get(run=application.bootcamp_run)
-        interview, created = Interview.objects.get_or_create(applicant=user, job=job)
-        if not created:
+        interview, _ = Interview.objects.get_or_create(applicant=user, job=job)
+        if interview.interview_url:
             interview_link = interview.interview_url
         else:
             interview_link = create_interview_in_jobma(interview)

--- a/static/js/components/Drawer.js
+++ b/static/js/components/Drawer.js
@@ -7,7 +7,7 @@ import { Theme } from "@rmwc/theme"
 import * as R from "ramda"
 
 import { drawerSelector } from "../lib/selectors"
-import { setDrawerOpen } from "../reducers/drawer"
+import { closeDrawer } from "../reducers/drawer"
 import {
   NEW_APPLICATION,
   PAYMENT,
@@ -26,13 +26,13 @@ import ResumeLinkedIn from "./ResumeLinkedIn"
 
 export const DrawerCloseHeader = (): React$Element<*> => {
   const dispatch = useDispatch()
-  const closeDrawer = useCallback(() => {
-    dispatch(setDrawerOpen(false))
+  const onClick = useCallback(() => {
+    dispatch(closeDrawer(false))
   }, [dispatch])
 
   return (
     <div className="drawer-close">
-      <button onClick={closeDrawer} className="btn-plain d-flex">
+      <button onClick={onClick} className="btn-plain d-flex">
         <i className="material-icons">close</i>
       </button>
     </div>
@@ -74,13 +74,13 @@ export default function Drawer() {
   const { drawerOpen, drawerState, drawerMeta } = useSelector(drawerSelector)
 
   const dispatch = useDispatch()
-  const closeDrawer = useCallback(() => {
-    dispatch(setDrawerOpen(false))
+  const onClose = useCallback(() => {
+    dispatch(closeDrawer())
   }, [dispatch])
 
   return (
     <Theme>
-      <RMWCDrawer open={drawerOpen} onClose={closeDrawer} dir="rtl" modal>
+      <RMWCDrawer open={drawerOpen} onClose={onClose} dir="rtl" modal>
         <DrawerContent dir="ltr">
           {renderDrawerContents(drawerState, drawerMeta)}
         </DrawerContent>

--- a/static/js/components/Drawer_test.js
+++ b/static/js/components/Drawer_test.js
@@ -11,7 +11,7 @@ import {
 } from "../constants"
 
 import IntegrationTestHelper from "../util/integration_test_helper"
-import { setDrawerOpen, setDrawerState, openDrawer } from "../reducers/drawer"
+import { closeDrawer, openDrawer } from "../reducers/drawer"
 import { makeApplicationDetail } from "../factories/application"
 
 describe("Drawer", () => {
@@ -39,24 +39,21 @@ describe("Drawer", () => {
     [PROFILE_VIEW, "ViewProfileDisplay"],
     [PAYMENT, "PaymentDisplay"],
     [NEW_APPLICATION, "NewApplication"]
-  ].forEach(([drawerType, expComponent]) => {
+  ].forEach(([type, expComponent]) => {
     it(`should render a drawer component with a ${expComponent} child`, async () => {
-      const { wrapper } = await render({}, [
-        setDrawerState(drawerType),
-        setDrawerOpen(true)
-      ])
+      const { wrapper } = await render({}, [openDrawer({ type })])
       assert.ok(wrapper.find(RMWCDrawer).exists())
       assert.isTrue(wrapper.find(expComponent).exists())
     })
   })
 
   it("should have the drawer open if action is dispatched", async () => {
-    const { wrapper } = await render({}, [setDrawerOpen(true)])
+    const { wrapper } = await render({}, [openDrawer({ type: PAYMENT })])
     assert.isTrue(wrapper.find(RMWCDrawer).prop("open"))
   })
 
   it("should pass down a close function to drawer", async () => {
-    const { wrapper, store } = await render({}, [setDrawerOpen(false)])
+    const { wrapper, store } = await render({}, [closeDrawer()])
     wrapper.find(RMWCDrawer).prop("onClose")()
     assert.isFalse(store.getState().drawer.drawerOpen)
   })

--- a/static/js/components/NewApplication.js
+++ b/static/js/components/NewApplication.js
@@ -14,7 +14,7 @@ import {
 import { partial } from "ramda"
 
 import { DrawerCloseHeader } from "./Drawer"
-import { setDrawerOpen } from "../reducers/drawer"
+import { closeDrawer } from "../reducers/drawer"
 import users, { currentUserSelector } from "../lib/queries/users"
 import bootcamps, { bootcampRunsSelector } from "../lib/queries/bootcamps"
 import applications, { createAppQueryKey } from "../lib/queries/applications"
@@ -32,7 +32,7 @@ type Props = {
   appliedRunIds: Array<number>,
   createAppIsPending: boolean,
   createNewApplication: (bootcampRunId: number) => void,
-  setDrawerOpen: (newState: boolean) => void
+  closeDrawer: () => void
 }
 
 type State = {
@@ -55,7 +55,7 @@ export class NewApplication extends React.Component<Props, State> {
   }
 
   handleSubmit = async () => {
-    const { createNewApplication, setDrawerOpen } = this.props
+    const { createNewApplication, closeDrawer } = this.props
     const { selectedBootcamp } = this.state
 
     if (!selectedBootcamp) {
@@ -63,7 +63,7 @@ export class NewApplication extends React.Component<Props, State> {
     }
     await createNewApplication(selectedBootcamp.id)
     this.setState({ ...INITIAL_STATE })
-    setDrawerOpen(false)
+    closeDrawer()
   }
 
   render() {
@@ -148,7 +148,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(
       mutateAsync(applications.createApplicationMutation(bootcampRunId))
     ),
-  setDrawerOpen: (newState: boolean) => dispatch(setDrawerOpen(newState))
+  closeDrawer: () => dispatch(closeDrawer())
 })
 
 export default compose(

--- a/static/js/components/ResumeLinkedIn.js
+++ b/static/js/components/ResumeLinkedIn.js
@@ -11,7 +11,7 @@ import * as yup from "yup"
 
 import { DrawerCloseHeader } from "./Drawer"
 import FormError from "./forms/elements/FormError"
-import { setDrawerOpen } from "../reducers/drawer"
+import { closeDrawer } from "../reducers/drawer"
 import applications, {
   applicationDetailSelector
 } from "../lib/queries/applications"
@@ -225,7 +225,7 @@ const mapStateToProps = (state, ownProps) => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  closeDrawer:    () => dispatch(setDrawerOpen(false)),
+  closeDrawer:    () => dispatch(closeDrawer()),
   addLinkedInUrl: async (
     applicationId: number,
     linkedInUrl: string

--- a/static/js/components/TakeVideoInterviewDisplay.js
+++ b/static/js/components/TakeVideoInterviewDisplay.js
@@ -1,7 +1,6 @@
 // @flow
-import React from "react"
-import { connect } from "react-redux"
-import { mutateAsync } from "redux-query"
+import React, { useState } from "react"
+import { useMutation } from "redux-query-react"
 
 import { DrawerCloseHeader } from "./Drawer"
 import { JOBMA, JOBMA_SITE } from "../constants"
@@ -15,17 +14,18 @@ import type { HttpAuthResponse } from "../flow/authTypes"
 
 type Props = {
   application: ApplicationDetail,
-  stepId: number,
-  createVideoInterview: (
-    applicationId: number,
-    stepId: number
-  ) => Promise<HttpAuthResponse<VideoInterviewResponse>>
+  stepId: number
 }
-export function TakeVideoInterviewDisplay({
+
+export default function TakeVideoInterviewDisplay({
   application,
-  stepId,
-  createVideoInterview
+  stepId
 }: Props) {
+  const [hasError, setHasError] = useState(false)
+  const [{ isPending }, createVideoInterview] = useMutation(() =>
+    queries.applications.createVideoInterviewMutation(application.id, stepId)
+  )
+
   return (
     <div className="container drawer-wrapper take-video-interview">
       <DrawerCloseHeader />
@@ -40,31 +40,38 @@ export function TakeVideoInterviewDisplay({
         <button
           className="btn-external-link"
           onClick={async () => {
-            const {
-              body: { interview_link: interviewLink }
-            }: HttpAuthResponse<VideoInterviewResponse> = await createVideoInterview(
-              application.id,
-              stepId
-            )
-            if (interviewLink) {
-              window.location = interviewLink
+            setHasError(false)
+
+            const result: HttpAuthResponse<VideoInterviewResponse> = await createVideoInterview()
+
+            if (result.status === 200 && result.body.interview_link) {
+              window.location = result.body.interview_link
+              return
             }
+            setHasError(true)
           }}
+          disabled={isPending}
         >
           Take Interview at {JOBMA_SITE}
         </button>
       </div>
+
+      {hasError ? (
+        <div className="form-error">
+          <p>
+            We're unable to start a video interview for you at this time, please
+            try again later. If you continue to see this message, please{" "}
+            <a
+              href="https://mitbootcamps.zendesk.com/hc/en-us/requests/new"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              contact support
+            </a>
+            .
+          </p>
+        </div>
+      ) : null}
     </div>
   )
 }
-
-const mapDispatchToProps = dispatch => ({
-  createVideoInterview: (applicationId: number, stepId: number) =>
-    dispatch(
-      mutateAsync(
-        queries.applications.createVideoInterviewMutation(applicationId, stepId)
-      )
-    )
-})
-
-export default connect(null, mapDispatchToProps)(TakeVideoInterviewDisplay)

--- a/static/js/components/TakeVideoInterviewDisplay_test.js
+++ b/static/js/components/TakeVideoInterviewDisplay_test.js
@@ -38,6 +38,7 @@ describe("TakeVideoInterviewDisplay", () => {
     await wrapper
       .find(".take-video-interview button.btn-external-link")
       .prop("onClick")()
+    wrapper.update() // needed to assert the error message doesn't render
     sinon.assert.calledWith(
       helper.handleRequestStub,
       videoInterviewsUrl,
@@ -53,5 +54,21 @@ describe("TakeVideoInterviewDisplay", () => {
       }
     )
     assert.equal(window.location.toString(), interviewLink)
+    assert.notOk(wrapper.find(".form-error").exists())
+  })
+
+  it("displays an error message if no link returned", async () => {
+    helper.handleRequestStub.withArgs(videoInterviewsUrl).returns({
+      status: 200,
+      body:   {
+        interview_link: null
+      }
+    })
+    const { wrapper } = await renderPage()
+    await wrapper
+      .find(".take-video-interview button.btn-external-link")
+      .prop("onClick")()
+    wrapper.update()
+    assert.ok(wrapper.find(".form-error").exists())
   })
 })

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -98,7 +98,8 @@ export type LoggedInUser = {
 export type CurrentUser = AnonymousUser | LoggedInUser
 
 export type HttpAuthResponse<T> = {
-  body: T | Object
+  body: T | Object,
+  status: number
 }
 
 export type StateOrTerritory = {

--- a/static/js/reducers/drawer.js
+++ b/static/js/reducers/drawer.js
@@ -2,9 +2,9 @@
 import { createAction, createReducer } from "@reduxjs/toolkit"
 
 export const setDrawerState = createAction("SET_DRAWER_STATE")
-export const setDrawerOpen = createAction("SET_DRAWER_OPEN")
 export const setDrawerMeta = createAction("SET_DRAWER_META")
 export const openDrawer = createAction("OPEN_DRAWER")
+export const closeDrawer = createAction("CLOSE_DRAWER")
 
 type DrawerState = {
   drawerState: ?string,
@@ -23,11 +23,13 @@ export const drawer = createReducer(
     [setDrawerState]: (state: DrawerState, action: { payload: ?string }) => {
       state.drawerState = action.payload
     },
-    [setDrawerOpen]: (state: DrawerState, action: { payload: boolean }) => {
-      state.drawerOpen = action.payload
-    },
     [setDrawerMeta]: (state: DrawerState, action: { payload: Object }) => {
       state.drawerMeta = action.payload
+    },
+    [closeDrawer]: (state: DrawerState) => {
+      state.drawerState = null
+      state.drawerMeta = {}
+      state.drawerOpen = false
     },
     [openDrawer]: (
       state: DrawerState,

--- a/static/scss/application.scss
+++ b/static/scss/application.scss
@@ -137,6 +137,7 @@ $border-style: 1px solid $black;
       .material-icons {
         width: 24px;
         margin-right: 10px;
+
       }
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #753

#### What's this PR do?
- Updates the endpoint to create the interview in Jobma if there is no `interview_url`
- Updates the frontend to display a error message if the request fails
- Updates the frontend to disable the button while the request is processing so the user gets feedback something is happening and so that they can't click it multiple times

I also found and fixed this bug because my changes here exposed it:

- `setDrawerOpen(false)` doesn't clear out the other state, so this causes the component to never unmount, and thus its state sticks until you open a different drawe

#### How should this be manually tested?

- Hardcode `create_interview_in_jobma` to return `None`, you may wish to add a `os.sleep(5)` so you can observe that the function is being called
- Got to your `/applications` and click "Take video" on a bootcamp to open the drawer
- Click on "Take video" button, it should disable, and then display an error message.
- Repeat again, you should see the same behavior
- Remove the hardcoded return, you should be able to create a video interview

- Test other uses of the drawer to verify my fix for that didn't break anything else

#### Screenshots

Showing the progression:

![Screenshot_2020-06-25 MIT Bootcamps Dashboard(2)](https://user-images.githubusercontent.com/28598/85798022-be63f800-b70a-11ea-8b7a-c57c759e0e59.png)
![Screenshot_2020-06-25 MIT Bootcamps Dashboard(1)](https://user-images.githubusercontent.com/28598/85798023-befc8e80-b70a-11ea-90b2-065b592ebf04.png)
![Screenshot_2020-06-25 MIT Bootcamps Dashboard](https://user-images.githubusercontent.com/28598/85798024-befc8e80-b70a-11ea-9724-50b5dbdd1c3b.png)

