### PR TITLE
Update the link styling for all links to match InVision on both home and product page

### DIFF
--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -9,6 +9,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="cms-page">
   <div class="home-page">
     <div class="header">
         <div class="container">
@@ -31,4 +32,5 @@
   {% if page.three_column_image_text_section %} {% include "partials/three-column-image-text-section.html" with page=page.three_column_image_text_section %} {% endif %}
   {% if page.alumni %} {% include "partials/homepage-alumni.html" with page=page.alumni %} {% endif %}
   {% if page.learning_resources %} {% include "partials/learning-resources.html" with page=page.learning_resources %} {% endif %}
+</div>
 {% endblock %}

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -9,6 +9,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="cms-page">
   <div class="product-page">
     <div class="header">
       {% image page.header_image fill-1920x1080 %}
@@ -39,5 +40,6 @@
   {% if page.instructors %} {% include "partials/instructor.html" with page=page.instructors %} {% endif %}
   {% if page.alumni %} {% include "partials/alumni.html" with page=page.alumni %} {% endif %}
   {% if page.learning_resources %} {% include "partials/learning-resources.html" with page=page.learning_resources %} {% endif %}
-  </div>
+  </>
+</div>
 {% endblock %}

--- a/cms/templates/resource_template.html
+++ b/cms/templates/resource_template.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-<section class="resource-container {% if not page.header_image %} without-banner {% endif %}" >
+<section class="resource-container cms-page {% if not page.header_image %}without-banner{% endif %}" >
   {% if page.header_image %}
   <div class="banner-holder">
     <img class="resource-image" src="{% image_version_url page.header_image 'fill-1920x540' %}" alt="Resource Page" />

--- a/static/scss/_shared.scss
+++ b/static/scss/_shared.scss
@@ -49,7 +49,8 @@ h3.section-header {
   }
 }
 
-p, .std-text {
+p,
+.std-text {
   font-size: 16px;
 }
 
@@ -67,7 +68,9 @@ p, .std-text {
   margin: 0 auto;
   padding: 15px 0;
 
-  h2, p, li {
+  h2,
+  p,
+  li {
     margin-bottom: $text-page-margin;
   }
 
@@ -119,4 +122,34 @@ p, .std-text {
 
 .bottom-holder {
   margin-bottom: 50px;
+}
+
+.cms-page {
+  .rich-text p {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5 {
+      margin-bottom: 25px;
+
+      a {
+        text-decoration: underline;
+        color: $standard-link-color;
+
+        &:hover {
+          text-decoration: none;
+        }
+      }
+    }
+
+    a {
+      text-decoration: underline;
+      color: $standard-link-color;
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
 }

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -54,6 +54,7 @@ $trolley-gray: #808080;
 $dodger-blue: #0084ff;
 $night-rider: #303030;
 $dim-gray: #696969;
+$standard-link-color: $dodger-blue;
 
 // Social Icons Colours.
 $facebook: #42599e;

--- a/static/scss/cms/admissions-section.scss
+++ b/static/scss/cms/admissions-section.scss
@@ -24,7 +24,7 @@
   }
 
   .admissions-heading > a {
-    color: $crusta-orange;
+    color: $standard-link-color;
     font-weight: 300;
   }
 

--- a/static/scss/cms/alumni.scss
+++ b/static/scss/cms/alumni.scss
@@ -54,17 +54,6 @@
         font-weight: 800;
         font-size: 36px;
       }
-
-      .rich-text {
-        h3 {
-          margin-bottom: 25px;
-
-          a {
-            text-decoration: underline;
-            color: $wewak;
-          }
-        }
-      }
     }
 
     .alumnus {

--- a/static/scss/cms/catalog-section.scss
+++ b/static/scss/cms/catalog-section.scss
@@ -4,7 +4,6 @@
     padding: 0px 0.5px;
     margin-bottom: 90px;
 
-
     .image-holder {
       margin: 0 0 28px;
 

--- a/static/scss/cms/home-page.scss
+++ b/static/scss/cms/home-page.scss
@@ -7,7 +7,6 @@
       min-height: 50vh;
 
       .title-column {
-
         @include media-breakpoint-up(md) {
           padding-left: 20px;
         }
@@ -15,7 +14,6 @@
         @include media-breakpoint-up(lg) {
           padding-left: 50px;
         }
-
 
         .title-block {
           color: $tundora;

--- a/static/scss/cms/homepage-alumni.scss
+++ b/static/scss/cms/homepage-alumni.scss
@@ -1,6 +1,5 @@
 // sass-lint:disable mixins-before-declarations
 .global-community {
-
   .banner-img {
     min-height: 270px;
     position: relative;

--- a/static/scss/cms/instructor.scss
+++ b/static/scss/cms/instructor.scss
@@ -153,21 +153,6 @@
       font-size: 36px;
     }
 
-    .rich-text {
-      margin-bottom: 25px;
-
-      h1,
-      h2,
-      h3,
-      h4,
-      h5 {
-        a {
-          text-decoration: underline;
-          color: $wewak;
-        }
-      }
-    }
-
     .section-headings {
       @include media-breakpoint-down(sm) {
         border: 0px;

--- a/static/scss/cms/product.scss
+++ b/static/scss/cms/product.scss
@@ -60,17 +60,5 @@
       top: 0;
       right: 100%;
     }
-
-    .rich-text p {
-
-      a {
-        color: black;
-        text-decoration: underline;
-
-        &:hover {
-          text-decoration: none;
-        }
-      }
-    }
   }
 }

--- a/static/scss/cms/program-description.scss
+++ b/static/scss/cms/program-description.scss
@@ -112,6 +112,7 @@
 
           &[aria-expanded="true"] {
             font-weight: bold;
+            color: $standard-link-color;
           }
         }
 
@@ -220,7 +221,7 @@
 
           &[aria-expanded="true"] {
             font-weight: bold;
-            color: $trolley-gray;
+            color: $standard-link-color;
           }
         }
 


### PR DESCRIPTION
#### What are the relevant tickets?
#786 

#### What's this PR do?
fixes #786, Update the link styling for all links to match InVision on both home and product page

#### How should this be manually tested?
Just see the links in dodger-blue color as given in the Invision for both Product and Home Page

#### Screenshots (if appropriate)

**Home Page**

![screencapture-bc-odl-local-8099-2020-06-26-14_54_00](https://user-images.githubusercontent.com/4043989/85845135-3be84080-b7bd-11ea-898e-1aca3eefcc89.png)

**Product Page**

![screencapture-bc-odl-local-8099-enterpreneur-bootcamp-bootcamp-13-2020-06-26-15_02_33](https://user-images.githubusercontent.com/4043989/85845729-23c4f100-b7be-11ea-9dd5-9df026027da4.jpg)
