### PR TITLE
Safari CSS issue fix - #771

### DIFF
--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -43,6 +43,11 @@ body {
   text-align: left;
   font-family: Helvetica, Arial, sans-serif;
   overflow-x: hidden;
+
+  .row:before, .row:after {
+    display: unset !important;
+    content: unset !important;
+  }
 }
 
 .body-content {


### PR DESCRIPTION
#### What are the relevant tickets?
#771 

#### What's this PR do?
Unsets the before and after pseudo element CSS rules that were set by legacy SCSS code.

#### How should this be manually tested?
Open any page on the website that uses bootstrap columns (home page or product page). Verify that the layout is correct and identical in both Chrome, Safari (and optionally) Firefox.
