### PR TITLE
make the review dashboard refresh more

### DIFF
--- a/static/js/lib/queries/submissions.js
+++ b/static/js/lib/queries/submissions.js
@@ -81,6 +81,7 @@ export const submissionsQuery = (params: string) => {
     queryKey:  params ? `submissions__${params}` : "submissions",
     url,
     transform: facetTransform,
+    force:     true,
     update:    {
       [submissionsFacetsKey]: (
         prevState: { [string]: FacetState },
@@ -92,14 +93,11 @@ export const submissionsQuery = (params: string) => {
         // in order to deal with the situation where the user selects and then
         // unselects a given facet
         return {
-          ...prevState,
-          [params === "" ? "defaultSearch" : params]: {
-            count,
-            next,
-            previous,
-            facets,
-            results
-          }
+          count,
+          next,
+          previous,
+          facets,
+          results
         }
       }
     }
@@ -108,10 +106,5 @@ export const submissionsQuery = (params: string) => {
 
 export const submissionFacetsSelector = createSelector(
   state => state.entities,
-  entities => {
-    if (!entities[submissionsFacetsKey]) {
-      return {}
-    }
-    return entities[submissionsFacetsKey]
-  }
+  entities => entities[submissionsFacetsKey] ?? {}
 )

--- a/static/js/pages/applications/ReviewDashboardPage.js
+++ b/static/js/pages/applications/ReviewDashboardPage.js
@@ -4,7 +4,6 @@ import { useSelector } from "react-redux"
 import { useRequest } from "redux-query-react"
 import { useLocation } from "react-router"
 import { Link } from "react-router-dom"
-import { path } from "ramda"
 import { reverse } from "named-urls"
 
 import SubmissionFacets from "../../components/SubmissionFacets"
@@ -51,17 +50,7 @@ export function SubmissionRow({ submission }: RowProps) {
 export default function ReviewDashboardPage() {
   const location = useLocation()
   const [{ isFinished }] = useRequest(submissionsQuery(location.search))
-
-  const submissions = useSelector(submissionFacetsSelector)
-
-  const results = path(
-    [location.search || "defaultSearch", "results"],
-    submissions
-  )
-  const facets = path(
-    [location.search || "defaultSearch", "facets"],
-    submissions
-  )
+  const { results, facets } = useSelector(submissionFacetsSelector)
 
   return (
     <div className="review-dashboard-page container-lg">


### PR DESCRIPTION
#### What are the relevant tickets?

closes #779 

#### What's this PR do?

This basically adds the `force` key to our query config for grabbing the list of submissions. This means that redux-query will override it's default behavior, which is to not re-run queries if they have already been run. Redux-query de-dupes queries based on the `queryKey` field, and for the review dashboard I'm using the url param string as part of the key to ensure that changing the facets results in a different query. The problem with this is if you navigate to a review detail page, make a change, and then go back - since this is a SPA the data from when you were on the review dashboard page the first time is still around, so the data will be stale.

Adding the `force` key just makes it so that queries are always re-run, even if there was a previous one. This fixes the issue, and also eliminates the need for a little workaround I had in place.

#### How should this be manually tested?

Basically, go to the review dashboard and click on a bunch of facets, turn them on and off and so on, and note that a new request is made each time you change an option.

then confirm that the use-case of navigating to a detail page, changing something, and navigating back shows non-stale data.