### PR TITLE
Fixed text overflow issue with custom select component

### DIFF
--- a/static/scss/_inputs.scss
+++ b/static/scss/_inputs.scss
@@ -173,6 +173,16 @@ input[type=number] {
     background-color: $white;
     color: $default-text-color;
     border: 1px solid $black;
+    text-overflow: ellipsis;
+    overflow-x: hidden;
+  }
+
+  .dropdown-item {
+    white-space: normal;
+
+    &:hover, &:focus {
+      background-color: $soft-light-gray;
+    }
   }
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #766 

#### What's this PR do?
- Fixes text overflow issues w/ custom select options at narrow widths
- Fixes hover/focus styling for custom select options to make the highlighted choice clearer

#### How should this be manually tested?
If you don't have a bootcamp with a long enough title, just lengthen the title in developer tools 

- Click the "Select Bootcamp" button on the application dashboard to open the drawer
- Open the menu. Options with long text should break to new lines, and hovering over options should change the background color noticeably
- Select an option with a long title. The title of the selected bootcamp should be ellips-ified and overflow should be hidden

#### Any background context you want to provide?
I thought I solved this on the first implementation. I must have done all the work in dev tools and forgot to change the actual code 🤷‍♂️ 

#### Screenshots (if appropriate)

**BEFORE**
<img width="409" alt="ss 2020-06-26 at 12 17 26 " src="https://user-images.githubusercontent.com/14932219/85878989-9676a200-b7a7-11ea-988a-15cdcb65476b.png">
<img width="395" alt="ss 2020-06-26 at 12 17 21 " src="https://user-images.githubusercontent.com/14932219/85878993-97a7cf00-b7a7-11ea-9cd4-27d471a6ef91.png">

**AFTER**
<img width="411" alt="ss 2020-06-26 at 12 14 23 " src="https://user-images.githubusercontent.com/14932219/85879011-9ecedd00-b7a7-11ea-9bb2-df1db11f20f9.png">
<img width="407" alt="ss 2020-06-26 at 12 05 32 " src="https://user-images.githubusercontent.com/14932219/85879016-a0000a00-b7a7-11ea-993e-f3956d3c84b4.png">
<img width="396" alt="ss 2020-06-26 at 12 05 14 " src="https://user-images.githubusercontent.com/14932219/85879018-a1313700-b7a7-11ea-921b-bc0561c0846e.png">