### PR TITLE
return 1000 applications instead of 10 on review dashboard

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -102,7 +102,7 @@ class ReviewSubmissionPagination(LimitOffsetPagination):
     """Pagination class for ReviewSubmissionViewSet"""
 
     default_limit = 10
-    max_limit = 100
+    max_limit = 1000
     facets = {}
 
     def paginate_queryset(self, queryset, request, view=None):

--- a/static/js/lib/queries/submissions.js
+++ b/static/js/lib/queries/submissions.js
@@ -72,10 +72,12 @@ type FacetState = {
 }
 
 export const submissionsQuery = (params: string) => {
-  const url =
-    params === "" ?
-      submissionsAPI.toString() :
-      submissionsAPI.query(qs.parse(params)).toString()
+  const url = submissionsAPI
+    .query({
+      limit: 1000,
+      ...qs.parse(params)
+    })
+    .toString()
 
   return {
     queryKey:  params ? `submissions__${params}` : "submissions",

--- a/static/js/pages/applications/ReviewDashboardPage_test.js
+++ b/static/js/pages/applications/ReviewDashboardPage_test.js
@@ -21,16 +21,18 @@ describe("ReviewDashboardPage", () => {
     helper = new IntegrationTestHelper()
     facets = makeApplicationFacets()
     submissions = times(makeSubmissionReview, 4)
-    helper.handleRequestStub.withArgs(submissionsAPI.toString()).returns({
-      status: 200,
-      body:   {
-        count:    submissions.length,
-        next:     "next",
-        previous: "previous",
-        facets,
-        results:  submissions
-      }
-    })
+    helper.handleRequestStub
+      .withArgs(submissionsAPI.query({ limit: 1000 }).toString())
+      .returns({
+        status: 200,
+        body:   {
+          count:    submissions.length,
+          next:     "next",
+          previous: "previous",
+          facets,
+          results:  submissions
+        }
+      })
     render = helper.configureReduxQueryRenderer(ReviewDashboardPage)
   })
 


### PR DESCRIPTION
#### What are the relevant tickets?
none


#### What's this PR do?

basically just pass an arbitrarily large (1000) `limit` param to the submission review API as a hotfix while we work out paging

#### How should this be manually tested?

if you have more than 10 things locally you should see them all!

also the URL that requests are made to on the review dashboard page should always have a `limit=1000` query param.
