### PR TITLE
Fix personal price calculation

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -155,12 +155,7 @@ class BootcampApplication(TimestampedModel):
     def price(self):
         """Calculate the price for the user, possibly their personal price or else the full price"""
         bootcamp_run = self.bootcamp_run
-        price_obj = bootcamp_run.personal_prices.first()
-        if price_obj is None:
-            price = bootcamp_run.price
-        else:
-            price = price_obj.price
-        return price or Decimal(0)
+        return bootcamp_run.personal_price(self.user) or Decimal(0)
 
     @property
     def is_paid_in_full(self):

--- a/applications/models_test.py
+++ b/applications/models_test.py
@@ -18,7 +18,12 @@ from applications.factories import (
 )
 from applications.constants import AppStates
 from ecommerce.test_utils import create_test_application, create_test_order
-from klasses.factories import BootcampFactory, BootcampRunFactory, InstallmentFactory
+from klasses.factories import (
+    BootcampFactory,
+    BootcampRunFactory,
+    InstallmentFactory,
+    PersonalPriceFactory,
+)
 from klasses.models import Installment, PersonalPrice
 
 
@@ -213,9 +218,14 @@ def test_price(
         InstallmentFactory.create(amount=run_price / 2, bootcamp_run=bootcamp_run)
 
     if personal_price is not None:
+        # this price should be ignored
+        PersonalPriceFactory.create(bootcamp_run=bootcamp_run)
+        # this price should be used
         PersonalPrice.objects.create(
             bootcamp_run=bootcamp_run, user=user, price=personal_price
         )
+        # this price should be ignored
+        PersonalPriceFactory.create(bootcamp_run=bootcamp_run)
 
     assert application.price == expected_price
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fixes the personal price calculation for bootcamp applications

#### How should this be manually tested?
Create a personal price for another user and not for your logged in user. View the price of a bootcamp in `/api/applications/<application primary key>/. It should have the full price, not the personal price.
