### PR TITLE
fix some accessibility issues on application dashboard page

### DIFF
--- a/static/js/components/AccessibleAnchor.js
+++ b/static/js/components/AccessibleAnchor.js
@@ -1,0 +1,30 @@
+// @flow
+import React from "react"
+
+// this component is inteded to take care of accessibility concerns
+// when using an anchor tag as a click target without an href
+
+type Props = {
+  onClick: Function,
+  className: string,
+  children: React$Node
+}
+
+export default function AccessibleAnchor(props: Props) {
+  const { onClick, className, children } = props
+
+  return (
+    <a
+      className={className}
+      tabIndex="0"
+      onClick={onClick}
+      onKeyPress={e => {
+        if (e.key === "Enter") {
+          onClick()
+        }
+      }}
+    >
+      {children}
+    </a>
+  )
+}

--- a/static/js/components/AccessibleAnchor_test.js
+++ b/static/js/components/AccessibleAnchor_test.js
@@ -1,0 +1,38 @@
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+import sinon from "sinon"
+
+import AccessibleAnchor from "./AccessibleAnchor"
+
+describe("AccessibleAnchor", () => {
+  const render = (props = {}) => shallow(<AccessibleAnchor {...props} />)
+
+  it("should render children", () => {
+    assert.equal("children", render({ children: "children" }).prop("children"))
+  })
+
+  it("should have a tabindex", () => {
+    assert.equal(render().prop("tabIndex"), "0")
+  })
+
+  it("should set a className", () => {
+    assert.ok(
+      render({ className: "my-class-name" })
+        .find(".my-class-name")
+        .exists()
+    )
+  })
+
+  it("should set an onclick handler", () => {
+    const onClick = sinon.stub()
+    render({ onClick }).simulate("click")
+    sinon.assert.called(onClick)
+  })
+
+  it("should allow keyboard triggering of onclick handler", () => {
+    const onClick = sinon.stub()
+    render({ onClick }).simulate("keypress", { key: "Enter" })
+    sinon.assert.called(onClick)
+  })
+})

--- a/static/js/components/applications/detail_sections.js
+++ b/static/js/components/applications/detail_sections.js
@@ -4,6 +4,8 @@ import React from "react"
 import * as R from "ramda"
 
 import ProgressDetailRow from "./ProgressDetailRow"
+import AccessibleAnchor from "../AccessibleAnchor"
+
 import { formatReadableDateFromStr } from "../../util/util"
 import {
   PAYMENT,
@@ -46,12 +48,12 @@ export const ProfileDetail = (props: ProfileDetailProps): React$Element<*> => {
         ) : null}
       </div>
       <div className="col-12 col-sm-5 text-sm-right">
-        <a
+        <AccessibleAnchor
           className="btn-link"
           onClick={R.partial(openDrawer, [{ type: PROFILE_VIEW }])}
         >
           View/Edit Profile
-        </a>
+        </AccessibleAnchor>
       </div>
     </ProgressDetailRow>
   )
@@ -77,7 +79,7 @@ export const ResumeDetail = (props: ResumeDetailProps): React$Element<*> => {
       </div>
       {ready && (
         <div className="col-12 col-sm-5 text-sm-right">
-          <a
+          <AccessibleAnchor
             className="btn-link"
             onClick={R.partial(openDrawer, [
               {
@@ -89,7 +91,7 @@ export const ResumeDetail = (props: ResumeDetailProps): React$Element<*> => {
             {fulfilled ?
               "View/Edit Resume or LinkedIn Profile" :
               "Add Resume or LinkedIn Profile"}
-          </a>
+          </AccessibleAnchor>
         </div>
       )}
     </ProgressDetailRow>
@@ -133,7 +135,7 @@ export const VideoInterviewDetail = (
       {ready ? (
         !fulfilled ? (
           <div className="col-12 col-sm-5 text-sm-right">
-            <a
+            <AccessibleAnchor
               className="btn-link"
               onClick={R.partial(openDrawer, [
                 {
@@ -143,7 +145,7 @@ export const VideoInterviewDetail = (
               ])}
             >
               Take Video Interview
-            </a>
+            </AccessibleAnchor>
           </div>
         ) : submission && submission.interview_url ? (
           <div className="col-12 col-sm-5 text-sm-right">
@@ -228,7 +230,7 @@ export const PaymentDetail = (props: PaymentDetailProps): React$Element<*> => {
       </div>
       {ready && !fulfilled ? (
         <div className="col-12 col-sm-5 text-sm-right">
-          <a
+          <AccessibleAnchor
             className="btn-link"
             onClick={R.partial(openDrawer, [
               {
@@ -238,7 +240,7 @@ export const PaymentDetail = (props: PaymentDetailProps): React$Element<*> => {
             ])}
           >
             Make a Payment
-          </a>
+          </AccessibleAnchor>
         </div>
       ) : null}
     </ProgressDetailRow>

--- a/static/js/components/applications/detail_sections_test.js
+++ b/static/js/components/applications/detail_sections_test.js
@@ -57,7 +57,7 @@ describe("application detail section component", () => {
       const wrapper = shallow(
         <ProfileDetail {...defaultProps} user={makeIncompleteUser()} />
       )
-      wrapper.find("ProgressDetailRow a.btn-link").simulate("click")
+      wrapper.find("ProgressDetailRow AccessibleAnchor").simulate("click")
       sinon.assert.calledWith(openDrawerStub, { type: PROFILE_VIEW })
     })
   })
@@ -85,10 +85,10 @@ describe("application detail section component", () => {
             applicationDetail={applicationDetail}
           />
         )
-        const link = wrapper.find("ProgressDetailRow a.btn-link")
+        const link = wrapper.find("ProgressDetailRow AccessibleAnchor")
         assert.equal(link.exists(), expLinkText !== undefined)
         if (expLinkText !== undefined) {
-          assert.equal(link.text(), expLinkText)
+          assert.equal(link.prop("children"), expLinkText)
         }
       })
     })
@@ -127,10 +127,17 @@ describe("application detail section component", () => {
             applicationDetail={application}
           />
         )
-        const link = wrapper.find("ProgressDetailRow a.btn-link")
+        const link = wrapper.find(
+          fulfilled ?
+            "ProgressDetailRow a.btn-link" :
+            "ProgressDetailRow AccessibleAnchor"
+        )
         assert.equal(link.exists(), expLinkText !== undefined)
         if (expLinkText !== undefined) {
-          assert.equal(link.text(), expLinkText)
+          assert.equal(
+            fulfilled ? link.text() : link.prop("children"),
+            expLinkText
+          )
         }
         if (submitted) {
           assert.equal(link.prop("href"), submission.interview_url)
@@ -210,10 +217,10 @@ describe("application detail section component", () => {
             applicationDetail={applicationDetail}
           />
         )
-        const link = wrapper.find("ProgressDetailRow a.btn-link")
+        const link = wrapper.find("ProgressDetailRow AccessibleAnchor")
         assert.equal(link.exists(), expLinkText !== undefined)
         if (expLinkText !== undefined) {
-          assert.equal(link.text(), expLinkText)
+          assert.equal(link.prop("children"), expLinkText)
         }
       })
     })
@@ -228,7 +235,7 @@ describe("application detail section component", () => {
         />
       )
 
-      wrapper.find("ProgressDetailRow a.btn-link").simulate("click")
+      wrapper.find("ProgressDetailRow AccessibleAnchor").simulate("click")
       sinon.assert.calledWith(openDrawerStub, {
         type: PAYMENT,
         meta: { application: applicationDetail }

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -19,6 +19,8 @@ import {
   ReviewDetail,
   VideoInterviewDetail
 } from "../../components/applications/detail_sections"
+import AccessibleAnchor from "../../components/AccessibleAnchor"
+
 import { openDrawer } from "../../reducers/drawer"
 import queries from "../../lib/queries"
 import {
@@ -274,14 +276,14 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
                 )}
               </div>
               <div className="col-5 text-right collapse-link">
-                <a
+                <AccessibleAnchor
                   className="btn-text expand-collapse"
                   onClick={R.partial(this.loadAndRevealAppDetail, [
                     application.id
                   ])}
                 >
                   {isOpen ? "Collapse −" : "Expand ＋"}
-                </a>
+                </AccessibleAnchor>
               </div>
             </div>
           </div>

--- a/static/js/pages/applications/ApplicationDashboardPage_test.js
+++ b/static/js/pages/applications/ApplicationDashboardPage_test.js
@@ -154,7 +154,7 @@ describe("ApplicationDashboardPage", () => {
       .find(".application-card")
       .at(applicationIndex)
     assert.isFalse(firstApplicationCard.find("Collapse").prop("isOpen"))
-    const expandLink = firstApplicationCard.find(".expand-collapse")
+    const expandLink = firstApplicationCard.find(".expand-collapse").at(0)
     assert.include(expandLink.text(), "Expand")
     assert.isFalse(firstApplicationCard.find(".application-detail").exists())
 


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

this adds keyboard accessibility to a few elements on the application dashboard page. In particular, you can now expand and collapse the sections via the keyboard and tab to the application step 'action' buttons (like 'upload resume' and so on).

#### How should this be manually tested?

I think just try navigating through that page using the keyboard and try to see if there's things you get caught up on.

One thing I noticed is that our dropzone / upload component is not accessible. There is an issue here: https://github.com/fortana-co/react-dropzone-uploader/issues/10 it seems unresolved. So we may want to see about switching to a different component.

#### Screenshots (if appropriate)

![Screenshot from 2020-06-29 11-54-14](https://user-images.githubusercontent.com/6207644/86027960-498d0880-b9ff-11ea-937f-a6291e4b009e.png)
![Screenshot from 2020-06-29 11-54-09](https://user-images.githubusercontent.com/6207644/86027961-4a259f00-b9ff-11ea-9197-597d1483f810.png)

