### PR TITLE
Make take interview link open in a separate tab

### DIFF
--- a/applications/api.py
+++ b/applications/api.py
@@ -1,4 +1,5 @@
 """API for bootcamp applications app"""
+from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
 from applications.constants import (
@@ -6,10 +7,17 @@ from applications.constants import (
     REVIEW_STATUS_REJECTED,
     REVIEW_STATUS_PENDING,
 )
-from applications.models import BootcampApplication
+from applications.models import (
+    ApplicationStepSubmission,
+    BootcampApplication,
+    BootcampRunApplicationStep,
+    VideoInterviewSubmission,
+)
+from applications import tasks
+from jobma.api import create_interview_in_jobma
+from jobma.models import Interview, Job
 
 
-@transaction.atomic
 def get_or_create_bootcamp_application(user, bootcamp_run_id):
     """
     Fetches a bootcamp application for a user if it exists. Otherwise, an application is created with the correct
@@ -23,13 +31,18 @@ def get_or_create_bootcamp_application(user, bootcamp_run_id):
         Tuple[BootcampApplication, bool]: The bootcamp application paired with a boolean indicating whether
             or not a new application was created
     """
-    bootcamp_app, created = BootcampApplication.objects.select_for_update().get_or_create(
-        user=user, bootcamp_run_id=bootcamp_run_id
-    )
+    with transaction.atomic():
+        bootcamp_app, created = BootcampApplication.objects.select_for_update().get_or_create(
+            user=user, bootcamp_run_id=bootcamp_run_id
+        )
+        if created:
+            derived_state = derive_application_state(bootcamp_app)
+            bootcamp_app.state = derived_state
+            bootcamp_app.save()
+
     if created:
-        derived_state = derive_application_state(bootcamp_app)
-        bootcamp_app.state = derived_state
-        bootcamp_app.save()
+        tasks.populate_interviews_in_jobma.delay(bootcamp_app.id)
+
     return bootcamp_app, created
 
 
@@ -89,3 +102,34 @@ def get_required_submission_type(application):
         .values_list("application_step__submission_type", flat=True)
         .first()
     )
+
+
+def populate_interviews_in_jobma(application):
+    """
+    Go over each ApplicationStep for the application and create the interviews in Jobma.
+
+    Args:
+        application (BootcampApplication): A bootcamp application
+    """
+    for run_step in BootcampRunApplicationStep.objects.filter(
+        bootcamp_run=application.bootcamp_run
+    ):
+        # Job should be created by admin beforehand
+        job = Job.objects.get(run=application.bootcamp_run)
+        interview, _ = Interview.objects.get_or_create(
+            applicant=application.user, job=job
+        )
+        if not interview.interview_url:
+            create_interview_in_jobma(interview)
+
+            video_interview_submission, _ = VideoInterviewSubmission.objects.get_or_create(
+                interview=interview
+            )
+            ApplicationStepSubmission.objects.get_or_create(
+                bootcamp_application=application,
+                run_application_step=run_step,
+                object_id=video_interview_submission.id,
+                content_type=ContentType.objects.get_for_model(
+                    video_interview_submission
+                ),
+            )

--- a/applications/api.py
+++ b/applications/api.py
@@ -6,6 +6,7 @@ from applications.constants import (
     AppStates,
     REVIEW_STATUS_REJECTED,
     REVIEW_STATUS_PENDING,
+    SUBMISSION_VIDEO,
 )
 from applications.models import (
     ApplicationStepSubmission,
@@ -112,7 +113,8 @@ def populate_interviews_in_jobma(application):
         application (BootcampApplication): A bootcamp application
     """
     for run_step in BootcampRunApplicationStep.objects.filter(
-        bootcamp_run=application.bootcamp_run
+        bootcamp_run=application.bootcamp_run,
+        application_step__submission_type=SUBMISSION_VIDEO,
     ):
         # Job should be created by admin beforehand
         job = Job.objects.get(run=application.bootcamp_run)
@@ -128,8 +130,10 @@ def populate_interviews_in_jobma(application):
             ApplicationStepSubmission.objects.get_or_create(
                 bootcamp_application=application,
                 run_application_step=run_step,
-                object_id=video_interview_submission.id,
-                content_type=ContentType.objects.get_for_model(
-                    video_interview_submission
-                ),
+                defaults={
+                    "object_id": video_interview_submission.id,
+                    "content_type": ContentType.objects.get_for_model(
+                        video_interview_submission
+                    ),
+                },
             )

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -15,8 +15,10 @@ from applications.constants import (
     REVIEW_STATUS_APPROVED,
     REVIEW_STATUS_REJECTED,
     SUBMISSION_QUIZ,
+    SUBMISSION_VIDEO,
 )
 from applications.factories import (
+    ApplicationStepFactory,
     BootcampApplicationFactory,
     BootcampRunApplicationStepFactory,
     ApplicationStepSubmissionFactory,
@@ -167,23 +169,27 @@ def job(application):  # pylint: disable=redefined-outer-name
     yield JobFactory.create(run=application.bootcamp_run)
 
 
-@pytest.fixture
-def step(application):  # pylint: disable=redefined-outer-name
-    """Make an ApplicationStepSubmission"""
-    yield BootcampRunApplicationStepFactory.create(
-        bootcamp_run=application.bootcamp_run
-    )
-
-
 @pytest.mark.parametrize("interview_exists", [True, False])
 @pytest.mark.parametrize("has_interview_link", [True, False])
 def test_populate_interviews_in_jobma(
-    interview_exists, has_interview_link, mocker, application, step, job
+    interview_exists, has_interview_link, mocker, application, job
 ):  # pylint: disable=redefined-outer-name,too-many-arguments
     """
     populate_interviews_in_jobma should create interviews on Jobma via REST API
     for each relevant BootcampRunApplicationStep
     """
+    video_app_step = ApplicationStepFactory.create(
+        bootcamp=application.bootcamp_run.bootcamp, submission_type=SUBMISSION_VIDEO
+    )
+    # this step should be ignored since it's not a video
+    quiz_app_step = ApplicationStepFactory.create(
+        bootcamp=application.bootcamp_run.bootcamp, submission_type=SUBMISSION_QUIZ
+    )
+    for step in (video_app_step, quiz_app_step):
+        BootcampRunApplicationStepFactory.create(
+            bootcamp_run=application.bootcamp_run, application_step=step
+        )
+
     new_interview_link = "http://fake.interview.link"
     create_interview = mocker.patch(
         "applications.api.create_interview_in_jobma", return_value=new_interview_link
@@ -196,16 +202,16 @@ def test_populate_interviews_in_jobma(
             interview.save()
 
     populate_interviews_in_jobma(application)
+    # We should be able to run this repeatedly without creating duplicate objects in the database
+    populate_interviews_in_jobma(application)
+
     if not interview_exists or not has_interview_link:
         interview = Interview.objects.get(job=job, applicant=application.user)
-        create_interview.assert_called_once_with(interview)
+        create_interview.assert_any_call(interview)
+        assert create_interview.call_count == 2
 
-        video_submission = VideoInterviewSubmission.objects.filter(
-            interview=interview
-        ).get()
-        submission = ApplicationStepSubmission.objects.filter(
-            bootcamp_application=application, run_application_step=step
-        ).get()
-        assert submission.content_object == video_submission
+        video_submission = VideoInterviewSubmission.objects.get(interview=interview)
+        step_submission = ApplicationStepSubmission.objects.get()
+        assert step_submission.content_object == video_submission
     else:
         create_interview.assert_not_called()

--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -41,13 +41,23 @@ class SubmissionSerializer(serializers.ModelSerializer):
     """ApplicationStepSubmission serializer"""
 
     interview_url = serializers.SerializerMethodField(required=False, allow_null=True)
+    take_interview_url = serializers.SerializerMethodField(
+        required=False, allow_null=True
+    )
 
     def get_interview_url(self, submission):
-        """ Get the interview url for a video submission if of that type"""
+        """Return the results URL for the reviewer or others to view the interview"""
         if submission.content_type == ContentType.objects.get_for_model(
             VideoInterviewSubmission
         ):
             return submission.content_object.interview.results_url
+
+    def get_take_interview_url(self, submission):
+        """Return the interview URL for the applicant to take the interview"""
+        if submission.content_type == ContentType.objects.get_for_model(
+            VideoInterviewSubmission
+        ):
+            return submission.content_object.interview.interview_url
 
     class Meta:
         model = models.ApplicationStepSubmission
@@ -59,6 +69,7 @@ class SubmissionSerializer(serializers.ModelSerializer):
             "review_status",
             "review_status_date",
             "interview_url",
+            "take_interview_url",
         ]
         read_only_fields = [
             "submitted_date",

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -193,6 +193,9 @@ def test_submission_serializer(content_object_factory):
         "interview_url": submission.content_object.interview.results_url
         if content_object_factory is VideoInterviewSubmissionFactory
         else None,
+        "take_interview_url": submission.content_object.interview.interview_url
+        if content_object_factory is VideoInterviewSubmissionFactory
+        else None,
     }
 
 
@@ -225,6 +228,7 @@ def test_submission_review_serializer(has_interview):
         "review_status_date": serializer_date_format(submission.review_status_date),
         "submission_status": submission.submission_status,
         "interview_url": interview.results_url if has_interview else None,
+        "take_interview_url": interview.interview_url if has_interview else None,
         "learner": UserSerializer(instance=user).data,
         "bootcamp_application": BootcampApplicationSerializer(
             instance=submission.bootcamp_application

--- a/applications/tasks.py
+++ b/applications/tasks.py
@@ -1,5 +1,6 @@
 """Tasks for applications"""
 from applications.models import BootcampApplication
+from applications import api
 from main.celery import app
 
 
@@ -10,3 +11,10 @@ def create_and_send_applicant_letter(application_id, *, letter_type):
 
     application = BootcampApplication.objects.get(id=application_id)
     mail_api.create_and_send_applicant_letter(application, letter_type=letter_type)
+
+
+@app.task
+def populate_interviews_in_jobma(application_id):
+    """Create an interview in Jobma and update our models with a link to the Jobma interview"""
+    application = BootcampApplication.objects.get(id=application_id)
+    api.populate_interviews_in_jobma(application)

--- a/applications/urls.py
+++ b/applications/urls.py
@@ -8,7 +8,6 @@ from rest_framework import routers
 from applications.views import (
     BootcampApplicationViewset,
     ReviewSubmissionViewSet,
-    VideoInterviewsView,
     LettersView,
     UploadResumeView,
 )
@@ -25,11 +24,6 @@ urlpatterns = [
         r"^api/applications/(?P<pk>\d+)/resume/$",
         UploadResumeView.as_view(),
         name="upload-resume",
-    ),
-    path(
-        "api/applications/<int:pk>/video-interviews/",
-        VideoInterviewsView.as_view(),
-        name="video-interviews",
     ),
     path("letters/<uuid:hash>/", LettersView.as_view(), name="letters"),
 ]

--- a/static/js/components/TakeVideoInterviewDisplay.js
+++ b/static/js/components/TakeVideoInterviewDisplay.js
@@ -1,15 +1,9 @@
 // @flow
-import React, { useState } from "react"
-import { useMutation } from "redux-query-react"
+import React from "react"
 
 import { JOBMA, JOBMA_SITE } from "../constants"
-import queries from "../lib/queries"
 
-import type {
-  ApplicationDetail,
-  VideoInterviewResponse
-} from "../flow/applicationTypes"
-import type { HttpAuthResponse } from "../flow/authTypes"
+import type { ApplicationDetail } from "../flow/applicationTypes"
 
 type Props = {
   application: ApplicationDetail,
@@ -20,10 +14,10 @@ export default function TakeVideoInterviewDisplay({
   application,
   stepId
 }: Props) {
-  const [hasError, setHasError] = useState(false)
-  const [{ isPending }, createVideoInterview] = useMutation(() =>
-    queries.applications.createVideoInterviewMutation(application.id, stepId)
+  const submission = application.submissions.find(
+    submission => submission.run_application_step_id === stepId
   )
+  const url = submission && submission.take_interview_url
 
   return (
     <div className="container drawer-wrapper take-video-interview">
@@ -35,41 +29,15 @@ export default function TakeVideoInterviewDisplay({
       </p>
 
       <div>
-        <button
-          className="btn-external-link"
-          onClick={async () => {
-            setHasError(false)
-
-            const result: HttpAuthResponse<VideoInterviewResponse> = await createVideoInterview()
-
-            if (result.status === 200 && result.body.interview_link) {
-              window.location = result.body.interview_link
-              return
-            }
-            setHasError(true)
-          }}
-          disabled={isPending}
+        <a
+          className="btn-external-link btn-styled"
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           Take Interview at {JOBMA_SITE}
-        </button>
+        </a>
       </div>
-
-      {hasError ? (
-        <div className="form-error">
-          <p>
-            We're unable to start a video interview for you at this time, please
-            try again later. If you continue to see this message, please{" "}
-            <a
-              href="https://mitbootcamps.zendesk.com/hc/en-us/requests/new"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              contact support
-            </a>
-            .
-          </p>
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -63,7 +63,8 @@ export const makeApplicationSubmission = (): ApplicationSubmission => ({
   submission_status:       casual.random_element(
     Object.keys(SUBMISSION_STATUS_TEXT_MAP)
   ),
-  interview_url: casual.url
+  interview_url:      casual.url,
+  take_interview_url: casual.url
 })
 
 export const makeApplicationFacets = (): SubmissionFacetData => {
@@ -192,5 +193,6 @@ export const makeSubmissionReview = (): SubmissionReview => ({
   ),
   bootcamp_application: makeApplication(),
   learner:              makeUser(),
-  interview_url:        casual.url
+  interview_url:        casual.url,
+  take_interview_url:   casual.url
 })

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -39,7 +39,8 @@ export type ApplicationSubmission = {
   submission_status:       ValidSubmissionStatusType,
   review_status:           ValidReviewStatusType,
   review_status_date:      ?string,
-  interview_url:           ?string
+  interview_url:           ?string,
+  take_interview_url:      ?string,
 }
 
 export type LegacyOrderPartial = {
@@ -79,7 +80,8 @@ export type SubmissionReview = {
   review_status_date: ?string,
   bootcamp_application: Application,
   learner: User,
-  interview_url: ?string
+  interview_url: ?string,
+  take_interview_url: ?string,
 }
 
 export type ApplicationDetailState = {

--- a/static/js/lib/queries/applications.js
+++ b/static/js/lib/queries/applications.js
@@ -3,18 +3,12 @@ import { objOf, mergeDeepRight } from "ramda"
 
 import { nextState } from "./util"
 
-import {
-  applicationsAPI,
-  applicationDetailAPI,
-  appVideoInterviewAPI,
-  appResumeAPI
-} from "../urls"
+import { applicationsAPI, applicationDetailAPI, appResumeAPI } from "../urls"
 import { DEFAULT_NON_GET_OPTIONS } from "../redux_query"
 import type {
   Application,
   ApplicationDetail,
-  ApplicationDetailState,
-  VideoInterviewResponse
+  ApplicationDetailState
 } from "../../flow/applicationTypes"
 
 const applicationsKey = "applications"
@@ -82,23 +76,6 @@ export default {
       })
     },
     force: !!force
-  }),
-  createVideoInterviewMutation: (applicationId: number, stepId: number) => ({
-    url:  appVideoInterviewAPI.param({ applicationId }).toString(),
-    body: {
-      step_id: stepId
-    },
-    options: {
-      ...DEFAULT_NON_GET_OPTIONS,
-      method: "POST"
-    },
-    transform: (json: ?VideoInterviewResponse) => ({
-      bootcampRuns: json
-    }),
-    update: {
-      bootcampRuns: nextState
-    },
-    force: true
   }),
   applicationLinkedInUrlMutation: (
     applicationId: number,

--- a/static/scss/_inputs.scss
+++ b/static/scss/_inputs.scss
@@ -43,6 +43,10 @@ button, .btn-styled {
     font-size: 14px;
     font-weight: 500;
   }
+
+  &:not([href]) {
+    cursor: pointer;
+  }
 }
 
 button.btn-plain {

--- a/static/scss/application.scss
+++ b/static/scss/application.scss
@@ -154,8 +154,7 @@ $border-style: 1px solid $black;
     margin-top: 50px;
   }
 
-  .link {
-    display: flex;
-    margin-top: 50px;
+  a {
+    color: black;
   }
 }

--- a/static/scss/application.scss
+++ b/static/scss/application.scss
@@ -156,5 +156,9 @@ $border-style: 1px solid $black;
 
   a {
     color: black;
+
+    &:hover {
+      color: black;
+    }
   }
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #816 

#### What's this PR do?
Removes the view to create a Jobma interview and the frontend logic which uses it. Instead, the interview will be created via an API call in the backend, with a celery task, when the `BootcampApplication` is first created

#### How should this be manually tested?
First, make sure the relevant models are created:
 - `Job` with the right template id linking to a bootcamp run you want to test with
 -  `ApplicationStep` for the bootcamp with type  "Video Interview"
 -  `BootcampRunApplicationStep` linking to it and a bootcamp run

Create a new `BootcampApplication` for that run (or try deleting and reenrolling via the UI). The application should start a celery task which populates the `Interview` object, and `Interview.interview_url`, for the application.

On the dashboard, click the link to open the video interview tab. You should see a "Take Video Interview" link. Click it and you should have a new tab or window open with a link to the Jobma interview to be started.
