### PR TITLE
Fix hubspot retry_invalid_line_associations function

### DIFF
--- a/hubspot/tasks.py
+++ b/hubspot/tasks.py
@@ -23,7 +23,6 @@ from hubspot.api import (
     make_deal_sync_message,
     make_line_sync_message,
     exists_in_hubspot,
-    format_hubspot_id,
 )
 from hubspot.models import HubspotErrorCheck, HubspotLineResync
 
@@ -133,14 +132,13 @@ def retry_invalid_line_associations():
     Check lines that have errored and retry them if their orders have synced
     """
     for hubspot_line_resync in HubspotLineResync.objects.all():
-        integrationId = format_hubspot_id(
-            hubspot_line_resync.application.integration_id
-        )
-        if exists_in_hubspot("LINE_ITEM", integrationId):
+        if exists_in_hubspot(
+            "LINE_ITEM", hubspot_line_resync.application.integration_id
+        ):
             hubspot_line_resync.delete()
             continue
 
-        if exists_in_hubspot("DEAL", integrationId):
+        if exists_in_hubspot("DEAL", hubspot_line_resync.application.integration_id):
             sync_line_with_hubspot(hubspot_line_resync.application.id)
         else:
             sync_application_with_hubspot(hubspot_line_resync.application.id)

--- a/hubspot/tasks_test.py
+++ b/hubspot/tasks_test.py
@@ -159,11 +159,14 @@ def test_retry_invalid_line_associations(mocker, deal_exists, line_exists):
     """
     mock_line_task = mocker.patch("hubspot.tasks.sync_line_with_hubspot")
     mock_application_task = mocker.patch("hubspot.tasks.sync_application_with_hubspot")
-    mocker.patch(
+    mock_exists = mocker.patch(
         "hubspot.tasks.exists_in_hubspot", side_effect=[line_exists, deal_exists]
     )
     resync = HubspotLineResyncFactory.create()
     retry_invalid_line_associations()
+    mock_exists.assert_any_call("LINE_ITEM", resync.application.integration_id)
+    if not line_exists:
+        mock_exists.assert_any_call("DEAL", resync.application.integration_id)
     assert HubspotLineResync.objects.filter(application=resync.application).count() == (
         1 if not line_exists else 0
     )


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #680 

#### What's this PR do?
Fixes the hubspot id sent to tasks in `retry_invalid_line_associations` function

#### How should this be manually tested?
There isn't a very good way to test this manually, but tests should pass
