### PR TITLE
Fixed thumbnail stretching in application dashboard

### DIFF
--- a/static/scss/application.scss
+++ b/static/scss/application.scss
@@ -13,6 +13,10 @@ $border-style: 1px solid $black;
     content: none;
   }
 
+  img {
+    align-self: start;
+  }
+
   .label {
     color: $med-dark-gray;
   }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #763 

#### What's this PR do?
Fixes bug where bootcamp thumbnails were stretching under certain conditions in the app dashboard

#### How should this be manually tested?
- Go to the application dashboard, and make sure that at least one bootcamp has a CMS page and an image
- Go into dev tools and edit the bootcamp title to span multiple lines

The thumbnail should not stretch

#### Screenshots (if appropriate)
Before
<img width="940" alt="ss 2020-06-29 at 23 21 28 " src="https://user-images.githubusercontent.com/14932219/86079907-999bb780-ba5f-11ea-8328-54045754de22.png">

After
<img width="941" alt="ss 2020-06-29 at 23 21 42 " src="https://user-images.githubusercontent.com/14932219/86079904-97d1f400-ba5f-11ea-90fc-6ac13e86c00e.png">
