### PR TITLE
fix aria-labelledby value for accessiblity issue

### DIFF
--- a/cms/templates/partials/program-description.html
+++ b/cms/templates/partials/program-description.html
@@ -24,7 +24,7 @@
         <ul class="accordion" id="accordionSteps">
           {% for step in page.steps %}
           <li class="panel-title">
-            <a data-toggle="collapse" data-target="#collapse-{{forloop.counter}}" aria-expanded="{% if forloop.counter == 1 %}true{% else %} false {%endif%}" aria-controls="collapse-{{forloop.counter}}" href="#" class="opener"><span> &gt; </span> {{ step.value.title }} </a>
+            <a id="heading-{{forloop.counter}}" data-toggle="collapse" data-target="#collapse-{{forloop.counter}}" aria-expanded="{% if forloop.counter == 1 %}true{% else %}false{%endif%}" aria-controls="collapse-{{forloop.counter}}" href="#" class="opener"><span> &gt; </span> {{ step.value.title }} </a>
             <div id="collapse-{{forloop.counter}}" class="collapse {% if forloop.counter == 1 %} show {%endif%}" aria-labelledby="heading-{{forloop.counter}}" data-parent="#accordionSteps" class="slide">
               <p> {{ step.value.description }} </p>
             </div>

--- a/cms/templates/partials/program-elements.html
+++ b/cms/templates/partials/program-elements.html
@@ -22,8 +22,8 @@
                   <ul class="accordion" id="accordionSteps">
                     {% for step in page.steps %}  
                     <li class="panel-title">
-                        <a data-toggle="collapse" data-target="#collapse-{{forloop.counter}}" aria-expanded="{% if forloop.counter == 1 %}true{% else %} false {%endif%}" aria-controls="collapse-{{forloop.counter}}" href="#" class="opener">{{ step.value.title }} </a>
-                        <div id="collapse-{{forloop.counter}}" class="collapse {% if forloop.counter == 1 %} show {%endif%}"  aria-labelledby="heading-{{forloop.counter}}" data-parent="#accordionSteps" class="slide">
+                        <a id="heading-{{forloop.counter}}" data-toggle="collapse" data-target="#collapse-{{forloop.counter}}" aria-expanded="{% if forloop.counter == 1 %}true{% else %}false{%endif%}" aria-controls="collapse-{{forloop.counter}}" href="#" class="opener">{{ step.value.title }} </a>
+                        <div id="collapse-{{forloop.counter}}" class="collapse {% if forloop.counter == 1 %}show{%endif%}"  aria-labelledby="heading-{{forloop.counter}}" data-parent="#accordionSteps" class="slide">
                            {{ step.value.description }}
                         </div>
                       </li>


### PR DESCRIPTION
#### What are the relevant tickets?
#827

#### What's this PR do?
fixes #827, Wave webaim report points to 7 Broken ARIA references. They are in the collapsible Program Elements section. They use the attribute: aria-labelledby, but the values specified in that attribute (e.g. heading-1) don’t exist. 

#### How should this be manually tested?
Test accessibility
