### PR TITLE
Remove "View your video" link on application

### DIFF
--- a/static/js/components/applications/detail_sections.js
+++ b/static/js/components/applications/detail_sections.js
@@ -147,12 +147,6 @@ export const VideoInterviewDetail = (
               Take Video Interview
             </AccessibleAnchor>
           </div>
-        ) : submission && submission.interview_url ? (
-          <div className="col-12 col-sm-5 text-sm-right">
-            <a className="btn-link" href={submission.interview_url}>
-              View Your Interview
-            </a>
-          </div>
         ) : null
       ) : null}
     </ProgressDetailRow>

--- a/static/js/components/applications/detail_sections_test.js
+++ b/static/js/components/applications/detail_sections_test.js
@@ -106,7 +106,6 @@ describe("application detail section component", () => {
     ;[
       [false, false, false, undefined],
       [true, false, false, "Take Video Interview"],
-      [true, true, true, "View Your Interview"],
       [true, true, false, undefined]
     ].forEach(([ready, fulfilled, submitted, expLinkText]) => {
       it(`should show correct link if ready === ${String(
@@ -138,9 +137,6 @@ describe("application detail section component", () => {
             fulfilled ? link.text() : link.prop("children"),
             expLinkText
           )
-        }
-        if (submitted) {
-          assert.equal(link.prop("href"), submission.interview_url)
         }
       })
     })


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #833 

#### What's this PR do?
Removes the "View your video" link on applications

#### How should this be manually tested?
- Go to `/applications`
- Ensure you have a completed video interview
- Verify on master you see the "View your video" link
- You should no longer see the link on this branch