### PR TITLE
Display interview token in take video interview drawer

### DIFF
--- a/applications/serializers.py
+++ b/applications/serializers.py
@@ -44,6 +44,7 @@ class SubmissionSerializer(serializers.ModelSerializer):
     take_interview_url = serializers.SerializerMethodField(
         required=False, allow_null=True
     )
+    interview_token = serializers.SerializerMethodField(required=False, allow_null=True)
 
     def get_interview_url(self, submission):
         """Return the results URL for the reviewer or others to view the interview"""
@@ -59,6 +60,13 @@ class SubmissionSerializer(serializers.ModelSerializer):
         ):
             return submission.content_object.interview.interview_url
 
+    def get_interview_token(self, submission):
+        """Return the interview token for the applicant"""
+        if submission.content_type == ContentType.objects.get_for_model(
+            VideoInterviewSubmission
+        ):
+            return submission.content_object.interview.interview_token
+
     class Meta:
         model = models.ApplicationStepSubmission
         fields = [
@@ -70,6 +78,7 @@ class SubmissionSerializer(serializers.ModelSerializer):
             "review_status_date",
             "interview_url",
             "take_interview_url",
+            "interview_token",
         ]
         read_only_fields = [
             "submitted_date",
@@ -77,6 +86,8 @@ class SubmissionSerializer(serializers.ModelSerializer):
             "review_status",
             "review_status_date",
             "interview_url",
+            "take_interview_url",
+            "interview_token",
         ]
 
 

--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -196,6 +196,9 @@ def test_submission_serializer(content_object_factory):
         "take_interview_url": submission.content_object.interview.interview_url
         if content_object_factory is VideoInterviewSubmissionFactory
         else None,
+        "interview_token": submission.content_object.interview.interview_token
+        if content_object_factory is VideoInterviewSubmissionFactory
+        else None,
     }
 
 
@@ -229,6 +232,7 @@ def test_submission_review_serializer(has_interview):
         "submission_status": submission.submission_status,
         "interview_url": interview.results_url if has_interview else None,
         "take_interview_url": interview.interview_url if has_interview else None,
+        "interview_token": interview.interview_token if has_interview else None,
         "learner": UserSerializer(instance=user).data,
         "bootcamp_application": BootcampApplicationSerializer(
             instance=submission.bootcamp_application

--- a/static/js/components/TakeVideoInterviewDisplay.js
+++ b/static/js/components/TakeVideoInterviewDisplay.js
@@ -18,6 +18,7 @@ export default function TakeVideoInterviewDisplay({
     submission => submission.run_application_step_id === stepId
   )
   const url = submission && submission.take_interview_url
+  const token = submission && submission.interview_token
 
   return (
     <div className="container drawer-wrapper take-video-interview">
@@ -27,6 +28,8 @@ export default function TakeVideoInterviewDisplay({
         we are collaborating with {JOBMA} and you will be taking this interview
         on their platform at {JOBMA_SITE}.
       </p>
+
+      {token ? <p className="mb-5">Your interview token is: {token}</p> : null}
 
       <div>
         <a

--- a/static/js/components/TakeVideoInterviewDisplay.js
+++ b/static/js/components/TakeVideoInterviewDisplay.js
@@ -29,7 +29,11 @@ export default function TakeVideoInterviewDisplay({
         on their platform at {JOBMA_SITE}.
       </p>
 
-      {token ? <p className="mb-5">If you are on mobile, please enter this token when asked: {token}</p> : null}
+      {token ? (
+        <p className="mb-5">
+          If you are on mobile, please enter this token when asked: {token}
+        </p>
+      ) : null}
 
       <div>
         <a

--- a/static/js/components/TakeVideoInterviewDisplay.js
+++ b/static/js/components/TakeVideoInterviewDisplay.js
@@ -29,7 +29,7 @@ export default function TakeVideoInterviewDisplay({
         on their platform at {JOBMA_SITE}.
       </p>
 
-      {token ? <p className="mb-5">Your interview token is: {token}</p> : null}
+      {token ? <p className="mb-5">If you are on mobile, please enter this token when asked: {token}</p> : null}
 
       <div>
         <a

--- a/static/js/components/TakeVideoInterviewDisplay_test.js
+++ b/static/js/components/TakeVideoInterviewDisplay_test.js
@@ -48,7 +48,7 @@ describe("TakeVideoInterviewDisplay", () => {
     const { wrapper } = await renderPage()
     assert.include(
       wrapper.find(".take-video-interview").text(),
-      `Your interview token is: ${String(submission.interview_token)}`
+      String(submission.interview_token)
     )
   })
 })

--- a/static/js/components/TakeVideoInterviewDisplay_test.js
+++ b/static/js/components/TakeVideoInterviewDisplay_test.js
@@ -43,4 +43,12 @@ describe("TakeVideoInterviewDisplay", () => {
       submission.take_interview_url
     )
   })
+
+  it("shows the interview token", async () => {
+    const { wrapper } = await renderPage()
+    assert.include(
+      wrapper.find(".take-video-interview").text(),
+      `Your interview token is: ${String(submission.interview_token)}`
+    )
+  })
 })

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -64,7 +64,8 @@ export const makeApplicationSubmission = (): ApplicationSubmission => ({
     Object.keys(SUBMISSION_STATUS_TEXT_MAP)
   ),
   interview_url:      casual.url,
-  take_interview_url: casual.url
+  take_interview_url: casual.url,
+  interview_token:    casual.uuid
 })
 
 export const makeApplicationFacets = (): SubmissionFacetData => {
@@ -194,5 +195,6 @@ export const makeSubmissionReview = (): SubmissionReview => ({
   bootcamp_application: makeApplication(),
   learner:              makeUser(),
   interview_url:        casual.url,
-  take_interview_url:   casual.url
+  take_interview_url:   casual.url,
+  interview_token:      casual.uuid
 })

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -41,6 +41,7 @@ export type ApplicationSubmission = {
   review_status_date:      ?string,
   interview_url:           ?string,
   take_interview_url:      ?string,
+  interview_token:         ?string,
 }
 
 export type LegacyOrderPartial = {
@@ -82,6 +83,7 @@ export type SubmissionReview = {
   learner: User,
   interview_url: ?string,
   take_interview_url: ?string,
+  interview_token: ?string,
 }
 
 export type ApplicationDetailState = {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #831 

#### What's this PR do?
Displays the interview token in the take interview drawer

#### How should this be manually tested?
 - First set `interview_url` to `None` for all `Interview` to ensure that the code will recreate the interview on Jobma.
 - Then, run `populate_interviews_in_jobma(application)` in your Django shell (or delete and recreate your `BootcampApplication` via your UI).
 - Go to the take video drawer. You should see the token displayed.

#### Screenshots (if appropriate)
![Screenshot from 2020-06-30 12-20-02](https://user-images.githubusercontent.com/863262/86151260-81ae4d00-bacc-11ea-8209-c1c9f8f9bce4.png)
