### PR TITLE
Allow any page for bootcamp programs page

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -693,11 +693,11 @@ class ResourcePagesSettings(BaseSetting):
     )
 
     panels = [
-        PageChooserPanel("apply_page", "cms.ResourcePage"),
-        PageChooserPanel("about_us_page", "cms.ResourcePage"),
-        PageChooserPanel("bootcamps_programs_page", "cms.ResourcePage"),
-        PageChooserPanel("terms_of_service_page", "cms.ResourcePage"),
-        PageChooserPanel("privacy_policy_page", "cms.ResourcePage"),
+        PageChooserPanel("apply_page"),
+        PageChooserPanel("about_us_page"),
+        PageChooserPanel("bootcamps_programs_page"),
+        PageChooserPanel("terms_of_service_page"),
+        PageChooserPanel("privacy_policy_page"),
     ]
 
     def save(self, *args, **kwargs):  # pylint: disable=arguments-differ


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Allow any of the Resource pages to be any page type, namely we need "Bootcamp Programs" to link to the home page.

#### How should this be manually tested?
Got to CMS -> Settings -> Resource Pages and verify you can select the home page (`/`) and save and that the footer links update accordingly.