### PR TITLE
Fixed payment input validation

### DIFF
--- a/static/js/components/PaymentDisplay.js
+++ b/static/js/components/PaymentDisplay.js
@@ -8,51 +8,58 @@ import { mutateAsync } from "redux-query"
 import { ErrorMessage, Field, Form, Formik } from "formik"
 import Decimal from "decimal.js-light"
 
+import FormError from "./forms/elements/FormError"
+import { closeDrawer } from "../reducers/drawer"
 import queries from "../lib/queries"
 import {
   formatRunDateRange,
   createForm,
   formatPrice,
-  formatReadableDateFromStr
+  formatReadableDateFromStr,
+  isNilOrBlank
 } from "../util/util"
+import { routes } from "../lib/urls"
 
 import type { PaymentPayload } from "../flow/ecommerceTypes"
 import type { ApplicationDetail } from "../flow/applicationTypes"
 
 type Props = {
   application: ?ApplicationDetail,
-  sendPayment: (payload: PaymentPayload) => Promise<void>
+  sendPayment: (payload: PaymentPayload) => Promise<void>,
+  closeDrawer: () => void
 }
 
 const roundToCent = amount => new Decimal(amount).toDecimalPlaces(2).toNumber()
 
 const validate = ({ amount, balance }) => {
-  if (roundToCent(amount) > balance) {
+  let adjustedAmount
+  if (isNilOrBlank(amount)) {
     return {
-      amount: "Enter a number less than the remaining balance"
+      amount: "Payment amount is required"
+    }
+  }
+  try {
+    adjustedAmount = roundToCent(amount)
+  } catch (e) {
+    return {
+      amount: "Payment amount must be a valid number"
+    }
+  }
+  if (adjustedAmount > balance) {
+    return {
+      amount: "Payment amount must be less than the remaining balance"
+    }
+  } else if (adjustedAmount <= 0) {
+    return {
+      amount: "Payment amount must be greater than zero"
     }
   }
 
   return {}
 }
 
-const validateAmount = value => {
-  let price
-  try {
-    price = roundToCent(value)
-  } catch (e) {
-    return "Price must be a valid number"
-  }
-
-  if (price <= 0) {
-    return "Price must be greater than zero"
-  }
-
-  return null
-}
-
 export const PaymentDisplay = (props: Props) => {
-  const { application, sendPayment } = props
+  const { application, sendPayment, closeDrawer } = props
   if (!application) {
     return null
   }
@@ -81,39 +88,33 @@ export const PaymentDisplay = (props: Props) => {
         <Formik
           initialValues={{ amount: "", balance: cost }}
           validate={validate}
-          onSubmit={async ({ amount }, actions) => {
+          onSubmit={async (values, actions) => {
+            const amount = values.amount
             await sendPayment({
               application_id: application.id,
               payment_amount: roundToCent(amount)
             })
-            actions.setSubmitting(false)
+            actions.resetForm()
+            closeDrawer()
           }}
-          render={({ isSubmitting }) => (
+          render={({ isSubmitting, isValidating }) => (
             <Form>
-              <ErrorMessage name="amount" />
-              <Field
-                name="amount"
-                type="text"
-                placeholder="Enter Amount"
-                validate={validateAmount}
-              />
+              <Field type="number" name="amount" placeholder="Enter Amount" />
               <button
                 className="btn-danger"
                 type="submit"
-                disabled={isSubmitting}
+                disabled={isValidating || isSubmitting}
               >
                 Pay Now
               </button>
+              <ErrorMessage name="amount" component={FormError} />
             </Form>
           )}
         />
       </div>
       <div className="terms-and-conditions">
         By making a payment I certify that I agree with the MIT Bootcamps{" "}
-        <a href="/terms_and_conditions/" target="_blank">
-          Terms and Conditions
-        </a>
-        .
+        <a href={routes.resourcePages.terms}>Terms and Conditions</a>.
       </div>
     </div>
   )
@@ -135,7 +136,8 @@ const mapDispatchToProps = dispatch => ({
     }
     body.appendChild(form)
     form.submit()
-  }
+  },
+  closeDrawer: () => dispatch(closeDrawer())
 })
 
 export default compose(connect(null, mapDispatchToProps))(PaymentDisplay)

--- a/static/js/components/PaymentDisplay_test.js
+++ b/static/js/components/PaymentDisplay_test.js
@@ -1,12 +1,12 @@
 // @flow
 import { assert } from "chai"
 import sinon from "sinon"
-import { Field } from "formik"
 import { shallow } from "enzyme"
 
 import PaymentDisplay, {
   PaymentDisplay as InnerPaymentDisplay
 } from "./PaymentDisplay"
+import { paymentAPI } from "../lib/urls"
 
 import { makeApplicationDetail } from "../factories/application"
 import IntegrationTestHelper from "../util/integration_test_helper"
@@ -81,36 +81,48 @@ describe("PaymentDisplay", () => {
       return { formik, inner: rendered }
     }
 
-    it("does nothing if the payment textbox is empty", async () => {
-      const { inner } = await renderFormik()
+    it("returns a validation error if the payment textbox is empty", async () => {
+      const { formik } = await renderFormik()
       assert.deepEqual(
-        inner
-          .find(Field)
-          .filter("[name='amount']")
-          .prop("validate")(""),
-        "Price must be a valid number"
+        formik.prop("validate")({
+          amount:  "",
+          balance: 100
+        }),
+        { amount: "Payment amount is required" }
       )
     })
 
-    it("does nothing if the payment textbox is not parseable as a float", async () => {
-      const { inner } = await renderFormik()
+    it("returns a validation error if the payment textbox is not parseable as a float", async () => {
+      const { formik } = await renderFormik()
       assert.deepEqual(
-        inner
-          .find(Field)
-          .filter("[name='amount']")
-          .prop("validate")("abc"),
-        "Price must be a valid number"
+        formik.prop("validate")({
+          amount:  "abc",
+          balance: 100
+        }),
+        { amount: "Payment amount must be a valid number" }
       )
     })
+    ;["0", "-5"].forEach(amount => {
+      it(`returns a validation error if the amount is ${amount}`, async () => {
+        const { formik } = await renderFormik()
+        assert.deepEqual(
+          formik.prop("validate")({
+            amount:  String(amount),
+            balance: 100
+          }),
+          { amount: "Payment amount must be greater than zero" }
+        )
+      })
+    })
 
-    it("does nothing if the amount is 0", async () => {
-      const { inner } = await renderFormik()
+    it("returns a validation error if the amount is greater than the balance", async () => {
+      const { formik } = await renderFormik()
       assert.deepEqual(
-        inner
-          .find(Field)
-          .filter("[name='amount']")
-          .prop("validate")("0.000001"),
-        "Price must be greater than zero"
+        formik.prop("validate")({
+          amount:  "105",
+          balance: 100
+        }),
+        { amount: "Payment amount must be less than the remaining balance" }
       )
     })
 
@@ -127,7 +139,7 @@ describe("PaymentDisplay", () => {
       const { formik } = await renderFormik()
       const url = "url"
       const payload = { pay: "load" }
-      helper.handleRequestStub.withArgs("/api/v0/payment/").returns({
+      helper.handleRequestStub.withArgs(paymentAPI.toString()).returns({
         status: 200,
         body:   {
           url,
@@ -135,19 +147,18 @@ describe("PaymentDisplay", () => {
         }
       })
       const payment = "123.456" // will get rounded to 123.46
-      const setSubmittingStub = helper.sandbox.stub()
+      const resetFormStub = helper.sandbox.stub()
       await formik.prop("onSubmit")(
         { amount: payment },
-        { setSubmitting: setSubmittingStub }
+        { resetForm: resetFormStub }
       )
 
-      assert.equal(createFormStub.callCount, 1)
-      assert.deepEqual(createFormStub.args[0], [url, payload])
-      assert.equal(submitStub.callCount, 1)
-      assert.deepEqual(submitStub.args[0], [])
+      sinon.assert.calledOnce(createFormStub)
+      sinon.assert.calledOnce(submitStub)
+      sinon.assert.calledOnce(resetFormStub)
       sinon.assert.calledWith(
-        helper.handleRequestStub.withArgs("/api/v0/payment/"),
-        "/api/v0/payment/",
+        helper.handleRequestStub.withArgs(paymentAPI.toString()),
+        paymentAPI.toString(),
         "POST",
         {
           body: {

--- a/static/js/lib/queries/ecommerce.js
+++ b/static/js/lib/queries/ecommerce.js
@@ -1,12 +1,13 @@
 // @flow
 import { DEFAULT_NON_GET_OPTIONS } from "../redux_query"
+import { paymentAPI } from "../urls"
 
 import type { PaymentPayload } from "../../flow/ecommerceTypes"
 
 export default {
   paymentMutation: (payload: PaymentPayload) => ({
     queryKey: "payment",
-    url:      "/api/v0/payment/",
+    url:      paymentAPI.toString(),
     update:   {
       payment: () => null
     },

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -70,3 +70,5 @@ export const appResumeAPI = applicationDetailAPI.segment("resume/")
 export const appVideoInterviewAPI = applicationDetailAPI.segment(
   "video-interviews/"
 )
+
+export const paymentAPI = api.segment("v0/payment/")


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #760 

#### What's this PR do?
Fixes payment input validation so blank/bad values cannot be submitted

#### How should this be manually tested?
Try to submit the payment form with blank/less-than-zero/letter input. You should see a validation message

#### Screenshots (if appropriate)
<img width="532" alt="ss 2020-07-01 at 09 08 58 " src="https://user-images.githubusercontent.com/14932219/86247911-26876380-bb7b-11ea-8651-695765268a0a.png">

