### PR TITLE
Better formatting for negative formatPrice

### DIFF
--- a/main/templatetags/dollar_format.py
+++ b/main/templatetags/dollar_format.py
@@ -1,4 +1,6 @@
 """Templatetags for dollar value formatting"""
+from decimal import Decimal
+
 from django.template import Library
 from django.template.defaultfilters import stringfilter
 
@@ -9,11 +11,15 @@ register = Library()
 def dollar_format(dollars):
     """
     Args:
-        dollars: A dollar value (Any value that can be turned into a float can be used - int, Decimal, str, etc.)
+        dollars (any): A dollar value (Any value that can be turned into a float can be used - int, Decimal, str, etc.)
     Returns:
         str: The formatted string
     """
-    return "${:,.2f}".format(float(dollars))
+    decimal_dollars = Decimal(dollars)
+    if decimal_dollars < 0:
+        return "-${:,.2f}".format(-decimal_dollars)
+    else:
+        return "${:,.2f}".format(decimal_dollars)
 
 
 register.filter(dollar_format)

--- a/main/templatetags_test.py
+++ b/main/templatetags_test.py
@@ -111,6 +111,7 @@ def test_dollar_format():
     assert dollar_format("123.5") == "$123.50"
     assert dollar_format(123) == "$123.00"
     assert dollar_format(123.5) == "$123.50"
+    assert dollar_format(-34.56) == "-$34.56"
 
 
 def test_parse_iso_datetime():

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -135,14 +135,20 @@ export const formatPrice = (price: ?string | number | Decimal): string => {
   if (price === null || price === undefined) {
     return ""
   } else {
-    let formattedPrice: Decimal = Decimal(price).toDecimalPlaces(2)
-
-    if (formattedPrice.isInteger()) {
-      formattedPrice = formattedPrice.toFixed(0)
-    } else {
-      formattedPrice = formattedPrice.toFixed(2, Decimal.ROUND_HALF_UP)
+    let decimalPrice: Decimal = Decimal(price).toDecimalPlaces(2)
+    let formattedPrice
+    const isNegative = decimalPrice.isNegative()
+    if (isNegative) {
+      decimalPrice = decimalPrice.times(-1)
     }
-    return `$${formattedPrice}`
+
+    if (decimalPrice.isInteger()) {
+      formattedPrice = decimalPrice.toFixed(0)
+    } else {
+      formattedPrice = decimalPrice.toFixed(2, Decimal.ROUND_HALF_UP)
+    }
+
+    return `${isNegative ? "-" : ""}$${formattedPrice}`
   }
 }
 

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -211,6 +211,7 @@ describe("util", () => {
       assert.equal(formatPrice(20.6959), "$20.70")
       assert.equal(formatPrice(20.1234567), "$20.12")
       assert.equal(formatPrice(-0.0000000001), "$0")
+      assert.equal(formatPrice(-123.467), "-$123.47")
     })
 
     it("returns an empty string if null or undefined", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #845 

#### What's this PR do?
Adjusts formatting for `formatPrice` on the frontend and `dollar_format` for the backend to handle negative numbers.

#### How should this be manually tested?
Change one of your orders to temporarily have a negative `total_price_paid`.  Go to the order history page and verify that it looks fine

#### Screenshot
![Screenshot from 2020-07-01 16-04-50](https://user-images.githubusercontent.com/863262/86286913-52273f80-bbb5-11ea-8a7c-04a6c475b67b.png)

