### PR TITLE
Added rule to transpile query-string library + dependency

### DIFF
--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -41,7 +41,13 @@ module.exports = {
   },
   babelSharedLoader: {
     test:    /\.jsx?$/,
-    exclude: /node_modules/,
+    include: [
+      path.resolve(__dirname, "static/js"),
+      // The query-string is only published in ES6. These two paths are added to transpile these
+      // libraries to ES5.
+      path.resolve(__dirname, "node_modules/query-string"),
+      path.resolve(__dirname, "node_modules/strict-uri-encode"),
+    ],
     loader:  "babel-loader",
     query:   {
       presets: [
@@ -49,7 +55,6 @@ module.exports = {
         "@babel/preset-react",
         "@babel/preset-flow"
       ],
-      ignore:  ["node_modules/**"],
       plugins: [
         "react-hot-loader/babel",
         "@babel/plugin-proposal-object-rest-spread",


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #854 

#### What's this PR do?
See title

#### How should this be manually tested?
One page that we know uses querystring variables is the review list page. Visit `/review/`, click on the filters, make sure it works as expected
