### PR TITLE
Simplify review submission serializer

### DIFF
--- a/applications/serializers_test.py
+++ b/applications/serializers_test.py
@@ -225,18 +225,10 @@ def test_submission_review_serializer(has_interview):
     data = SubmissionReviewSerializer(instance=submission).data
     assert data == {
         "id": submission.id,
-        "run_application_step_id": run_step.id,
-        "submitted_date": serializer_date_format(submission.submitted_date),
         "review_status": submission.review_status,
-        "review_status_date": serializer_date_format(submission.review_status_date),
-        "submission_status": submission.submission_status,
         "interview_url": interview.results_url if has_interview else None,
-        "take_interview_url": interview.interview_url if has_interview else None,
-        "interview_token": interview.interview_token if has_interview else None,
         "learner": UserSerializer(instance=user).data,
-        "bootcamp_application": BootcampApplicationSerializer(
-            instance=submission.bootcamp_application
-        ).data,
+        "application_id": submission.bootcamp_application_id,
     }
 
 

--- a/applications/views.py
+++ b/applications/views.py
@@ -158,7 +158,14 @@ class ReviewSubmissionViewSet(
     authentication_classes = (SessionAuthentication,)
     serializer_class = SubmissionReviewSerializer
     permission_classes = (IsAdminUser,)
-    queryset = ApplicationStepSubmission.objects.all()
+    queryset = (
+        ApplicationStepSubmission.objects.all()
+        .select_related(
+            "bootcamp_application__user__profile",
+            "bootcamp_application__user__legal_address",
+        )
+        .prefetch_related("content_object__interview")
+    )
     filterset_class = ApplicationStepSubmissionFilterSet
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     pagination_class = ReviewSubmissionPagination

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -182,19 +182,13 @@ export const setToPaid = (appDetail: ApplicationDetail): ApplicationDetail => {
   return appDetail
 }
 
-export const makeSubmissionReview = (): SubmissionReview => ({
+export const makeSubmissionReview = (
+  applicationId: number
+): SubmissionReview => ({
   // $FlowFixMe: Flow thinks incr.next().value may be undefined, but it won't ever be
-  id:                      incr.next().value,
-  run_application_step_id: casual.integer,
-  submitted_date:          moment().format(),
-  review_status:           casual.random_element(Object.keys(REVIEW_STATUS_TEXT_MAP)),
-  review_status_date:      moment().format(),
-  submission_status:       casual.random_element(
-    Object.keys(SUBMISSION_STATUS_TEXT_MAP)
-  ),
-  bootcamp_application: makeApplication(),
-  learner:              makeUser(),
-  interview_url:        casual.url,
-  take_interview_url:   casual.url,
-  interview_token:      casual.uuid
+  id:             incr.next().value,
+  review_status:  casual.random_element(Object.keys(REVIEW_STATUS_TEXT_MAP)),
+  learner:        makeUser(),
+  interview_url:  casual.url,
+  application_id: applicationId
 })

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -75,15 +75,10 @@ export type ApplicationDetail = {
 
 export type SubmissionReview = {
   id: number,
-  run_application_step_id: number,
-  submitted_date: ?string,
-  review_status: ?string,
-  review_status_date: ?string,
-  bootcamp_application: Application,
   learner: User,
+  review_status: ?string,
   interview_url: ?string,
-  take_interview_url: ?string,
-  interview_token: ?string,
+  application_id: number,
 }
 
 export type ApplicationDetailState = {

--- a/static/js/pages/applications/ReviewDashboardPage_test.js
+++ b/static/js/pages/applications/ReviewDashboardPage_test.js
@@ -2,6 +2,7 @@
 import { assert } from "chai"
 import { times } from "ramda"
 import { reverse } from "named-urls"
+import casual from "casual-browserify"
 
 import ReviewDashboardPage from "./ReviewDashboardPage"
 
@@ -15,12 +16,13 @@ import { REVIEW_STATUS_DISPLAY_MAP } from "../../constants"
 import { routes } from "../../lib/urls"
 
 describe("ReviewDashboardPage", () => {
-  let helper, render, facets, submissions
+  let helper, render, facets, submissions, applicationId
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
     facets = makeApplicationFacets()
-    submissions = times(makeSubmissionReview, 4)
+    applicationId = casual.integer(2, 30)
+    submissions = times(() => makeSubmissionReview(applicationId), 4)
     helper.handleRequestStub
       .withArgs(submissionsAPI.query({ limit: 1000 }).toString())
       .returns({

--- a/static/js/pages/applications/ReviewDetailPage.js
+++ b/static/js/pages/applications/ReviewDetailPage.js
@@ -264,16 +264,14 @@ export default function ReviewDetailPage(props: PageProps) {
 
   useRequest(
     submission ?
-      queries.applications.applicationDetailQuery(
-        submission.bootcamp_application.id
-      ) :
+      queries.applications.applicationDetailQuery(submission.application_id) :
       null
   )
 
   const applicationDetails = useSelector(allApplicationDetailSelector)
   const application =
     applicationDetails && submission ?
-      applicationDetails[submission.bootcamp_application.id] :
+      applicationDetails[submission.application_id] :
       null
   const user = submission ? submission.learner : null
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #822 

#### What's this PR do?
 - Separates the review serializer from the application detail serializer
 - Cuts out unused parts of it
 - Add select_related and prefetch_related as appropriate for the review viewset
 - 

#### How should this be manually tested?
Nothing should break. You should be able to view `/review` and update the status of a submission without any problem.

Also, populate 100 submissions on your local instance (I did this with the `ApplicationStepSubmissionFactory`). Go to `/api/submissions/?limit=1000`. It takes about 2 seconds to load for me on master. Switch to this PR and try again, and it should be much faster (about 400 milliseconds for me).