### PR TITLE
Attempt to fix undefined hbspt

### DIFF
--- a/main/templates/footer.html
+++ b/main/templates/footer.html
@@ -13,16 +13,18 @@
           </div>
         </div>
       </div>
-      <div class="col-sm-4">
+        <div class="col-sm-4 hbspt-form" id="hs_footer_form"></div>
+        <!--[if lte IE 8]>
         <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
+        <![endif]-->
         <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
         <script>
-            hbspt.forms.create({
-              portalId: '{{ hubspot_portal_id }}',
-              formId: '{{ hubspot_footer_form_guid }}'
-            });
+          hbspt.forms.create({
+            portalId: '{{ hubspot_portal_id }}',
+            formId: '{{ hubspot_footer_form_guid }}',
+            target: '#hs_footer_form'
+          });
         </script>
-      </div>
     </div>
     <div class="footer-bottom">
       <div class="row">


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #859 

#### What's this PR do?
Adds a target to `hbspt.form.create()`
Loads legacy hubspot JS only for older IE browsers, based on sample embed code on the hubspot site.


#### How should this be manually tested?
?? - Could never replicate the problem myself, but tests should pass and a hubspot form should appear in the footer if you populate the following .env variables with values from RC:
   ```
   HUBSPOT_FOOTER_FORM_GUID
   HUBSPOT_PORTAL_ID
   ```
