### PR TITLE
Removed ES6 template literal in Django template

### DIFF
--- a/cms/templates/partials/instructor.html
+++ b/cms/templates/partials/instructor.html
@@ -44,9 +44,8 @@
   </div>
   <script>
     var totalSections = {{ page.sections|length }};
-
-    for(i=1 ; i <= totalSections; i++){
-      $(`.slider-${i}`).slick({
+    for(var i=1; i <= totalSections; i++){
+      $(".slider-" + i).slick({
         rows:           0,
         slidesToShow:   4,
         slidesToScroll: 1,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #868 

#### What's this PR do?
See title

#### How should this be manually tested?
Make sure the instructor slider still works (child section of a bootcamp page)

#### Any background context you want to provide?
This was causing IE11 errors as template literals are ES6-only
