### PR TITLE
Fix caching for resource page links

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -1,0 +1,2 @@
+"""Initialize cms app"""
+default_app_config = "cms.apps.CMSConfig"

--- a/cms/apps.py
+++ b/cms/apps.py
@@ -1,0 +1,12 @@
+"""Apps for cms"""
+from django.apps import AppConfig
+
+
+class CMSConfig(AppConfig):
+    """AppConfig for cms"""
+
+    name = "cms"
+
+    def ready(self):
+        """Application is ready"""
+        import cms.signals  # pylint:disable=unused-import, unused-variable

--- a/cms/factories.py
+++ b/cms/factories.py
@@ -53,6 +53,15 @@ class BootcampRunPageFactory(wagtail_factories.PageFactory):
         return obj
 
 
+class BootcampIndexPageFactory(wagtail_factories.PageFactory):
+    """Factory for BootcampIndexPage"""
+
+    title = factory.Faker("text", max_nb_chars=15)
+
+    class Meta:
+        model = models.BootcampIndexPage
+
+
 class ResourcePageFactory(wagtail_factories.PageFactory):
     """ResourcePage factory"""
 

--- a/cms/models.py
+++ b/cms/models.py
@@ -4,7 +4,7 @@ Page models for the CMS
 import logging
 
 from django.conf import settings
-from django.db import models, transaction
+from django.db import models
 from django.http.response import Http404
 from django.urls import reverse
 from django.utils.text import slugify
@@ -485,13 +485,6 @@ class ResourcePage(Page):
             "site_name": settings.SITE_NAME,
         }
 
-    def save(self, *args, **kwargs):
-        """Save the model instance"""
-        from cms.utils import invalidate_get_resource_page_urls
-
-        super().save(*args, **kwargs)
-        transaction.on_commit(invalidate_get_resource_page_urls)
-
 
 @register_snippet
 class SiteNotification(models.Model):
@@ -699,13 +692,6 @@ class ResourcePagesSettings(BaseSetting):
         PageChooserPanel("terms_of_service_page"),
         PageChooserPanel("privacy_policy_page"),
     ]
-
-    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
-        """Save the model instance"""
-        from cms.utils import invalidate_get_resource_page_urls
-
-        super().save(*args, **kwargs)
-        transaction.on_commit(invalidate_get_resource_page_urls)
 
     class Meta:
         verbose_name = "Resource Pages"

--- a/cms/signals.py
+++ b/cms/signals.py
@@ -1,0 +1,19 @@
+"""CMS signals"""
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from wagtail.core.signals import page_published
+
+from cms.models import ResourcePagesSettings
+from cms.utils import invalidate_resource_page_urls
+
+
+@receiver(page_published)
+def resource_page_published(sender, **kwargs):  # pylint: disable=unused-argument
+    """Invalidate the cached values whenever a page is published"""
+    invalidate_resource_page_urls()
+
+
+@receiver(post_save, sender=ResourcePagesSettings)
+def resource_page_settings_change(sender, **kwargs):  # pylint: disable=unused-argument
+    """Invalidate the cached values whenver the settings are saved"""
+    invalidate_resource_page_urls()

--- a/cms/signals_test.py
+++ b/cms/signals_test.py
@@ -1,0 +1,45 @@
+"""CMS signals tests"""
+import pytest
+
+from cms.factories import (
+    ResourcePageFactory,
+    HomePageFactory,
+    BootcampIndexPageFactory,
+    BootcampRunPageFactory,
+    ResourcePagesSettingsFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    "page_factory",
+    [
+        HomePageFactory,
+        BootcampIndexPageFactory,
+        BootcampRunPageFactory,
+        ResourcePageFactory,
+    ],
+)
+def test_resource_page_published(mocker, page_factory):
+    """Test that resource_page_published fires and calls invalidate_resource_page_urls"""
+    mock_invalidate_resource_page_urls = mocker.patch(
+        "cms.signals.invalidate_resource_page_urls"
+    )
+
+    page = page_factory.create()
+    revision = page.save_revision()
+    revision.publish()
+    assert mock_invalidate_resource_page_urls.call_count == 1
+
+
+def test_resource_page_settings_change(mocker):
+    """Verify that resource_page_settings_change fires and calls invalidate_resource_page_urls"""
+    mock_invalidate_resource_page_urls = mocker.patch(
+        "cms.signals.invalidate_resource_page_urls"
+    )
+
+    page_settings = ResourcePagesSettingsFactory.create()
+    page_settings.save()
+    # one for create, one for update
+    assert mock_invalidate_resource_page_urls.call_count == 2

--- a/cms/utils.py
+++ b/cms/utils.py
@@ -28,7 +28,7 @@ def get_resource_page_urls(site):
     return {key: value.url if value else "" for key, value in pages.items()}
 
 
-def invalidate_get_resource_page_urls():
+def invalidate_resource_page_urls():
     """
     Invalidate the cached values of get_resource_page_urls
     """

--- a/cms/utils_test.py
+++ b/cms/utils_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from cms.factories import ResourcePagesSettingsFactory, ResourcePageFactory
-from cms.utils import get_resource_page_urls, invalidate_get_resource_page_urls
+from cms.utils import get_resource_page_urls, invalidate_resource_page_urls
 
 pytestmark = pytest.mark.django_db
 
@@ -20,8 +20,8 @@ def test_get_resource_page_urls():
     }
 
 
-def test_invalidate_get_resource_page_urls():
-    """Test that invalidate_get_resource_page_urls() invalidates the cache for get_resource_page_urls"""
+def test_invalidate_resource_page_urls():
+    """Test that invalidate_resource_page_urls() invalidates the cache for get_resource_page_urls"""
     site_page_settings = ResourcePagesSettingsFactory.create()
     initial = get_resource_page_urls(site_page_settings.site)
 
@@ -33,7 +33,7 @@ def test_invalidate_get_resource_page_urls():
     # verify the calue is cached
     assert get_resource_page_urls(site_page_settings.site) == initial
 
-    invalidate_get_resource_page_urls()
+    invalidate_resource_page_urls()
 
     # updated value should be seen
     assert get_resource_page_urls(site_page_settings.site) == expected

--- a/main/settings.py
+++ b/main/settings.py
@@ -689,14 +689,10 @@ USE_CELERY = True
 # django cache back-ends
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "local-in-memory-cache",
-    },
-    "redis": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": CELERY_BROKER_URL,
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
-    },
+    }
 }
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #853 

#### What's this PR do?
- Switches the default cache to redis
- Cleans up cache invalidation around page publishes by switching to `page_published` signal

#### How should this be manually tested?
- If you haven't already, configure Resource Pages in the CMS (details are in README.md)
- Start the app, poke around a bit and verify the footer links have expected values
- Verify you see a cache key in redis:
```python
from django.core.cache import caches
r = caches["default"]
c = r.client.get_client()
c.get(":1:bb336c8a8b73c52a4cd3a846be084dbd")
```
- Verify that modifying the resource page settings busts the cache
- Verify that modifying a page itself busts the cache too