### PR TITLE
Added min space above footer and made it 'sticky'

### DIFF
--- a/cms/templates/letter_template_page.html
+++ b/cms/templates/letter_template_page.html
@@ -4,31 +4,31 @@
 {% block title %}{{ site_name }} | Letter{% endblock %}
 
 {% block headercontent %}
-    <div id="header"></div>
-    {% render_bundle 'header' %}
+  <div id="header"></div>
+  {% render_bundle 'header' %}
 {% endblock %}
 
 {% block content %}
-    <div class="letter-template-page container">
+  <div class="letter-template-page container">
     {% if preview %}
-    <div class="preview">
+      <div class="preview">
         SAMPLE
-    </div>
+      </div>
     {% endif %}
 
     <div class="main-content">
-        <div class="col-12 text-right">
-            <a class="print-button btn-link" onClick="window.print()">
-                <span class="material-icons">printer</span> Print Letter
-            </a>
-        </div>
-        {{ content|richtext }}
+      <div class="col-12 text-right">
+        <a class="print-button btn-link" onClick="window.print()">
+          <span class="material-icons">printer</span> Print Letter
+        </a>
+      </div>
+      {{ content|richtext }}
     </div>
     <p>
-        Sincerely,<br />
-        <img src="{% static "images/signature-mariah-rawding.png" %}" alt="Signature for Mariah Rawding" /><br />
-        Mariah Rawding<br />
-        MIT Bootcamps Admissions
+      Sincerely,<br />
+      <img src="{% static "images/signature-mariah-rawding.png" %}" alt="Signature for Mariah Rawding" /><br />
+      Mariah Rawding<br />
+      MIT Bootcamps Admissions
     </p>
-    </div>
+  </div>
 {% endblock %}

--- a/main/templates/footer.html
+++ b/main/templates/footer.html
@@ -24,7 +24,7 @@
         </script>
       </div>
     </div>
-    <div class=" footer-bottom">
+    <div class="footer-bottom">
       <div class="row">
         <div class="col-sm-8">
           <div class="row">

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -36,7 +36,14 @@
 @import "cms/letter-page";
 @import "submission-facets";
 
+html, body {
+  height: 100%;
+}
+
 body {
+  // Setting flex styles to enable "sticky" footer
+  display: flex;
+  flex-direction: column;
   margin: 0;
   padding: 0;
   background-color: $default-background-color;
@@ -51,8 +58,19 @@ body {
   }
 }
 
+// Top-level content elements (i.e.: direct child elements of <body> that contain non-footer content).
+// Setting this styles to enable "sticky" footer.
+#app-container, .letter-template-page, .cms-page {
+  flex: 1 0 auto;
+}
+
+#footer {
+  flex-shrink: 0;
+}
+
 .body-content {
   padding-top: 30px;
+  min-height: 325px;
 
   &.deprecated-styling {
     padding-top: 0;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #870 

#### What's this PR do?
- Adds a min height to page contents in the react app so there will be a guaranteed space between the content and the footer
- Makes the footer 'sticky' at short window heights

#### How should this be manually tested?
- Check out various pages around the site, remove the inner contents of the top level container element (`<div id="app-container">`, `<div class="cms-page">`, etc.), then vertically resize the browser window and make sure the footer element remains pinned to the bottom of the page
- Check out `/applications/` with no applications in your database for your logged-in user. Even at short window sizes there should be a space beneath the "select bootcamp" button

#### Any background context you want to provide?
Inspiration taken from [css-tricks](https://css-tricks.com/couple-takes-sticky-footer/#there-is-flexbox)

#### Screenshots (if appropriate)
![ss 2020-07-02 at 14 55 13 ](https://user-images.githubusercontent.com/14932219/86398864-48b0dc80-bc74-11ea-8c60-153253ec4ed9.png)
![ss 2020-07-02 at 14 55 28 ](https://user-images.githubusercontent.com/14932219/86398866-49497300-bc74-11ea-8ae6-eb8eef43d726.png)

