### PR TITLE
Added 'split-on-first' library to loader config

### DIFF
--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -43,10 +43,11 @@ module.exports = {
     test:    /\.jsx?$/,
     include: [
       path.resolve(__dirname, "static/js"),
-      // The query-string is only published in ES6. These two paths are added to transpile these
-      // libraries to ES5.
+      // The query-string is only published in ES6. These paths are added to transpile that library
+      // and some of its dependencies to ES5.
       path.resolve(__dirname, "node_modules/query-string"),
       path.resolve(__dirname, "node_modules/strict-uri-encode"),
+      path.resolve(__dirname, "node_modules/split-on-first")
     ],
     loader:  "babel-loader",
     query:   {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #873 

#### What's this PR do?
Adds 'split-on-first' library to loader config so it gets transpiled to ES5

#### How should this be manually tested?
Create a production bundle (`yarn run webpack:prod`) and check that `=>` does not appear anywhere in the resulting bundle (`/static/bundles/root*.js`)

#### Any background context you want to provide?
`strict-uri-encode` and `split-on-first` are both dependencies of `query-string` and all 3 are made by the same person/org
