### PR TITLE
Fixed sticky footer

### DIFF
--- a/cms/templates/home_page.html
+++ b/cms/templates/home_page.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="cms-page">
+<div class="top-level-page-body cms-page">
   <div class="home-page">
     <div class="header">
         <div class="container">

--- a/cms/templates/letter_template_page.html
+++ b/cms/templates/letter_template_page.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-  <div class="letter-template-page container">
+  <div class="top-level-page-body letter-template-page container">
     {% if preview %}
       <div class="preview">
         SAMPLE

--- a/cms/templates/product_page.html
+++ b/cms/templates/product_page.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="cms-page">
+<div class="top-level-page-body cms-page">
   <div class="product-page">
     <div class="header">
       {% image page.header_image fill-1920x1080 %}

--- a/cms/templates/resource_template.html
+++ b/cms/templates/resource_template.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-<section class="resource-container cms-page {% if not page.header_image %}without-banner{% endif %}" >
+<section class="top-level-page-body cms-page resource-container {% if not page.header_image %}without-banner{% endif %}" >
   {% if page.header_image %}
   <div class="banner-holder">
     <img class="resource-image" src="{% image_version_url page.header_image 'fill-1920x540' %}" alt="Resource Page" />

--- a/main/templates/404.html
+++ b/main/templates/404.html
@@ -10,7 +10,7 @@
 
 
 {% block content %}
-<div class="body-content">
+<div class="top-level-page-body body-content">
   <div class="container text-center">
     <h1 class="text-capitalize">Oops!</h1>
       <h3 class="text-uppercase">

--- a/main/templates/500.html
+++ b/main/templates/500.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="body-content">
+<div class="top-level-page-body body-content">
   <div class="container text-center">
     <h1 class="text-capitalize">Oops!</h1>
     <h3 class="text-uppercase">Internal Server Error</h3>

--- a/main/templates/bootcamp/react.html
+++ b/main/templates/bootcamp/react.html
@@ -4,7 +4,7 @@
 {% block title %}MIT Bootcamps{% endblock %}
 
 {% block content %}
-<div id="app-container">
+<div id="app-container" class="top-level-page-body">
 </div>
 {% load render_bundle %}
 {% render_bundle "root" %}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -58,9 +58,9 @@ body {
   }
 }
 
-// Top-level content elements (i.e.: direct child elements of <body> that contain non-footer content).
-// Setting this styles to enable "sticky" footer.
-#app-container, .letter-template-page, .cms-page {
+// Top-level content element (i.e.: direct child element of <body> that contains non-footer content).
+// Setting this style to enable "sticky" footer.
+.top-level-page-body {
   flex: 1 0 auto;
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket - fixes issue with #872 

#### What's this PR do?
Adds a class to top-level elements in all of our templates and uses that to set styling that makes the footer "sticky"

#### How should this be manually tested?
Use the same steps listed in the PR above. Make sure you try it for CMS pages, react pages, and 404/500 pages

#### Any background context you want to provide?
I discovered that this styling wasn't being applied to 404 pages on RC. This is because we didn't have a consistent CSS class for the top-level element that contained the main content of each page (i.e.: not the footer or navbar). This PR adds that class
