### PR TITLE
Don't prefetch interview which doesn't exist on QuizSubmission

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -164,7 +164,7 @@ class ReviewSubmissionViewSet(
             "bootcamp_application__user__profile",
             "bootcamp_application__user__legal_address",
         )
-        .prefetch_related("content_object__interview")
+        .prefetch_related("content_object")
     )
     filterset_class = ApplicationStepSubmissionFilterSet
     filter_backends = [DjangoFilterBackend, OrderingFilter]

--- a/applications/views_test.py
+++ b/applications/views_test.py
@@ -17,6 +17,8 @@ from applications.factories import (
     BootcampApplicationFactory,
     ApplicationStepSubmissionFactory,
     ApplicantLetterFactory,
+    QuizSubmissionFactory,
+    VideoInterviewSubmissionFactory,
 )
 from applications.serializers import (
     BootcampApplicationDetailSerializer,
@@ -155,7 +157,10 @@ def test_review_submission_update(admin_drf_client, review_status, application_s
     assert submission.bootcamp_application.state == application_state
 
 
-def test_review_submission_list(admin_drf_client):
+@pytest.mark.parametrize(
+    "submission_factory", [QuizSubmissionFactory, VideoInterviewSubmissionFactory]
+)
+def test_review_submission_list(admin_drf_client, submission_factory):
     """
     The review submission list view should return a list of all submissions
     """
@@ -167,6 +172,7 @@ def test_review_submission_list(admin_drf_client):
                 ApplicationStepSubmissionFactory.create(
                     review_status=review_status,
                     bootcamp_application__bootcamp_run__bootcamp=bootcamp,
+                    content_object=submission_factory.create(),
                 )
             )
     url = reverse("submissions_api-list")


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #889 

#### What's this PR do?
Removes the prefetch on the interview to fix handling of quiz submissions. This brings back an n+1 query issue in the submissions API, but I think we need to do that for now to fix the bug. We can figure out a more creative solution later.

#### How should this be manually tested?
On your local instance set one of your `ApplicationStepSubmission.content_object` to a `QuizSubmission`. On master, go to `/api/submissions/?limit=1000`. You should see an exception. Switch to this branch and you should see a list of submission instances.

