### PR TITLE
legal address requirement

### DIFF
--- a/applications/api.py
+++ b/applications/api.py
@@ -62,6 +62,8 @@ def derive_application_state(
     if (
         not hasattr(bootcamp_application.user, "profile")
         or not bootcamp_application.user.profile.is_complete
+        or not hasattr(bootcamp_application.user, "legal_address")
+        or not bootcamp_application.user.legal_address.is_complete
     ):
         return AppStates.AWAITING_PROFILE_COMPLETION.value
     if not bootcamp_application.resume_file:

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -29,7 +29,7 @@ from ecommerce.models import Order
 from klasses.factories import BootcampRunFactory, InstallmentFactory
 from jobma.factories import InterviewFactory, JobFactory
 from jobma.models import Interview
-from profiles.factories import ProfileFactory, UserFactory
+from profiles.factories import ProfileFactory, UserFactory, LegalAddressFactory
 from main.utils import now_in_utc
 
 
@@ -47,11 +47,17 @@ def test_derive_application_state():
     )
 
     app = BootcampApplicationFactory.create(
-        bootcamp_run=bootcamp_run, user__profile=None, resume_file=None
+        bootcamp_run=bootcamp_run,
+        user__profile=None,
+        user__legal_address=None,
+        resume_file=None,
     )
     assert derive_application_state(app) == AppStates.AWAITING_PROFILE_COMPLETION.value
 
     ProfileFactory.create(user=app.user)
+    app.refresh_from_db()
+    assert derive_application_state(app) == AppStates.AWAITING_PROFILE_COMPLETION.value
+    LegalAddressFactory.create(user=app.user)
     app.refresh_from_db()
     assert derive_application_state(app) == AppStates.AWAITING_RESUME.value
 

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -126,7 +126,9 @@ class LegalAddressSerializer(serializers.ModelSerializer):
             "state_or_territory",
             "country",
             "postal_code",
+            "is_complete",
         )
+        read_only_fields = ("is_complete",)
         extra_kwargs = {
             "street_address_1": {"write_only": True},
             "street_address_2": {"write_only": True},

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -3,7 +3,7 @@ import pytest
 
 from rest_framework.exceptions import ValidationError
 
-from profiles.factories import UserFactory
+from profiles.factories import UserFactory, LegalAddressFactory
 from profiles.models import ChangeEmailRequest
 from profiles.serializers import ChangeEmailRequestUpdateSerializer
 from profiles.serializers import LegalAddressSerializer, UserSerializer
@@ -31,6 +31,17 @@ def sample_address():
         "city": "Boulder",
         "postal_code": "80309",
     }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("is_complete", [True, False])
+def test_complete_address(is_complete):
+    """Test that is_complete in serializer has correct value"""
+    address = LegalAddressFactory.create(
+        street_address_1=("Main St" if is_complete else "")
+    )
+    serializer = LegalAddressSerializer(instance=address)
+    assert serializer.data["is_complete"] is is_complete
 
 
 def test_validate_legal_address(sample_address):

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -46,6 +46,7 @@ def test_get_user_by_id(user_client, user):
             "state_or_territory": user.legal_address.state_or_territory,
             "country": user.legal_address.country,
             "postal_code": user.legal_address.postal_code,
+            "is_complete": True,
         },
         "profile": {
             "name": user.profile.name,
@@ -83,6 +84,7 @@ def test_get_user_by_me(user_client, user):
             "state_or_territory": user.legal_address.state_or_territory,
             "country": user.legal_address.country,
             "postal_code": user.legal_address.postal_code,
+            "is_complete": True,
         },
         "profile": {
             "name": user.profile.name,

--- a/static/js/factories/user.js
+++ b/static/js/factories/user.js
@@ -45,7 +45,8 @@ export const makeUser = (username: ?string): LoggedInUser => ({
     city:               casual.city,
     state_or_territory: "US-MA",
     country:            "US",
-    postal_code:        "02090"
+    postal_code:        "02090",
+    is_complete:        true
   }
 })
 
@@ -57,6 +58,8 @@ export const makeCompleteUser = (username: ?string): LoggedInUser => {
   fakeUser.profile.updated_on = moment().format()
   // $FlowFixMe: Profile can't be undefined
   fakeUser.profile.is_complete = true
+  // $FlowFixMe: LegalAddress can't be undefined
+  fakeUser.legal_address.is_complete = true
   return fakeUser
 }
 
@@ -66,6 +69,19 @@ export const makeIncompleteUser = (username: ?string): LoggedInUser => {
   fakeUser.profile.name = undefined
   // $FlowFixMe: Profile can't be undefined
   fakeUser.profile.is_complete = false
+  // $FlowFixMe: LegalAddress can't be undefined
+  fakeUser.legal_address.is_complete = true
+  return fakeUser
+}
+
+export const makeUserIncompleteAddress = (username: ?string): LoggedInUser => {
+  const fakeUser = makeUser(username)
+  // $FlowFixMe: LegalAddress can't be undefined
+  fakeUser.legal_address.city = undefined
+  // $FlowFixMe: LegalAddress can't be undefined
+  fakeUser.legal_address.is_complete = false
+  // $FlowFixMe: Profile can't be undefined
+  fakeUser.profile.is_complete = true
   return fakeUser
 }
 

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -51,7 +51,8 @@ export type LegalAddress = {
   street_address: Array<string>,
   country: string,
   state_or_territory?: string,
-  postal_code?: string
+  postal_code?: string,
+  is_complete: boolean
 }
 
 export type ExtendedLegalAddress = LegalAddress & {

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -135,12 +135,16 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
       applicationDetail.submissions
     )
 
-    const profileFulfilled =
-      !!currentUser.profile && currentUser.profile.is_complete
+    const profileAndAddressFulfilled =
+      !!currentUser.profile &&
+      currentUser.profile.is_complete &&
+      !!currentUser.legal_address &&
+      currentUser.legal_address.is_complete
+
     const profileRow = (
       <ProfileDetail
         ready={true}
-        fulfilled={profileFulfilled}
+        fulfilled={profileAndAddressFulfilled}
         openDrawer={openDrawer}
         user={currentUser}
       />
@@ -149,7 +153,7 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
     const resumeFulfilled = !!applicationDetail.resume_upload_date
     const resumeRow = (
       <ResumeDetail
-        ready={profileFulfilled}
+        ready={profileAndAddressFulfilled}
         fulfilled={resumeFulfilled}
         openDrawer={openDrawer}
         applicationDetail={applicationDetail}

--- a/static/js/pages/applications/ApplicationDashboardPage_test.js
+++ b/static/js/pages/applications/ApplicationDashboardPage_test.js
@@ -30,7 +30,8 @@ import {
 import {
   makeCompleteUser,
   makeIncompleteUser,
-  makeUser
+  makeUser,
+  makeUserIncompleteAddress
 } from "../../factories/user"
 import { shouldIf } from "../../lib/test_utils"
 
@@ -240,10 +241,11 @@ describe("ApplicationDashboardPage", () => {
 
     //
     ;[
-      [false, false, "incomplete profile"],
-      [true, false, "complete profile"],
-      [true, true, "submitted resume"]
-    ].forEach(([hasProfile, hasResume, desc]) => {
+      [true, false, false, "incomplete profile"],
+      [false, true, false, "incomplete address"],
+      [true, true, false, "complete profile and address"],
+      [true, true, true, "submitted resume"]
+    ].forEach(([hasAddress, hasProfile, hasResume, desc]) => {
       it(`shows resume details with ${desc}`, async () => {
         let newApplicationDetail = Object.assign({}, applicationDetail)
         newApplicationDetail =
@@ -255,14 +257,18 @@ describe("ApplicationDashboardPage", () => {
           allApplicationDetail: {
             [application.id]: newApplicationDetail
           },
-          currentUser: hasProfile ? makeCompleteUser() : makeIncompleteUser()
+          currentUser: hasAddress ?
+            hasProfile ?
+              makeCompleteUser() :
+              makeIncompleteUser() :
+            makeUserIncompleteAddress()
         }
         const wrapper = await renderExpanded(props)
 
         const resumeDetail = wrapper.find("ResumeDetail")
         assert.isTrue(resumeDetail.exists())
         assert.deepEqual(resumeDetail.props(), {
-          ready:             hasProfile,
+          ready:             hasProfile && hasAddress,
           fulfilled:         hasResume,
           openDrawer:        openDrawerStub,
           applicationDetail: newApplicationDetail


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #878 

#### What's this PR do?
Adds legal address check to the `applications.api.derive_application_state` function

#### How should this be manually tested?
Using django admin, save a blank city or street address to a user's `LegalAddress`.  Then start a new application as that user.  You shouldn't be able to advance beyond "View/Edit Profile" until you enter a complete address.

#### Screenshot
<img width="710" alt="Screen Shot 2020-07-08 at 8 37 39 AM" src="https://user-images.githubusercontent.com/187676/86919560-6e1b6b80-c0f6-11ea-9264-fafe8f666b1f.png">
