### PR TITLE
Add application status label for Refunded

### DIFF
--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -104,6 +104,7 @@ export const APP_STATE_IN_PROGRESS = "In Progress"
 export const APP_STATE_IN_REVIEW = "In Review"
 export const APP_STATE_COMPLETE = "Complete"
 export const APP_STATE_REJECTED = "Rejected"
+export const APP_STATE_REFUNDED = "Refunded"
 
 export const APP_STATE_TEXT_MAP = {
   AWAITING_PROFILE_COMPLETION: APP_STATE_IN_PROGRESS,
@@ -112,7 +113,8 @@ export const APP_STATE_TEXT_MAP = {
   AWAITING_SUBMISSION_REVIEW:  APP_STATE_IN_REVIEW,
   AWAITING_PAYMENT:            APP_STATE_IN_PROGRESS,
   COMPLETE:                    APP_STATE_COMPLETE,
-  REJECTED:                    APP_STATE_REJECTED
+  REJECTED:                    APP_STATE_REJECTED,
+  REFUNDED:                    APP_STATE_REFUNDED
 }
 
 export const SUBMISSION_VIDEO = "videointerviewsubmission"


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #592 

#### What's this PR do?
Displays "Application Status: Refunded" for refunded applications.

#### How should this be manually tested?
- Follow the steps in #806 
- Go to the applications page for the refunded user, the application status should display "Refunded" and not be blank.

#### Screenshots (if appropriate)
<img width="714" alt="Screen Shot 2020-07-08 at 1 34 40 PM" src="https://user-images.githubusercontent.com/187676/86952067-696bad00-c120-11ea-9868-3f7bc85ad0fa.png">
