### PR TITLE
Paging for submission reviews

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-hot-loader": "^4.12.20",
     "react-meta-tags": "^0.4.1",
     "react-page-click": "^4.0.4",
+    "react-paginate": "^6.3.2",
     "react-redux": "7.2.0",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",

--- a/static/js/components/SubmissionFacets.js
+++ b/static/js/components/SubmissionFacets.js
@@ -52,13 +52,13 @@ export function Option({ option, facetKey }: OptionProps) {
     e => {
       e.preventDefault()
 
-      const updatedParams = facetIsActive ?
+      let updatedParams = facetIsActive ?
         omit([qsKey], qs.parse(location.search)) :
         {
           ...qs.parse(location.search),
           [qsKey]: getQSValue(option)
         }
-
+      updatedParams = omit(["limit", "offset"], updatedParams)
       const url = urljoin(location.pathname, `/?${qs.stringify(updatedParams)}`)
       history.push(url)
     },

--- a/static/js/lib/queries/submissions.js
+++ b/static/js/lib/queries/submissions.js
@@ -72,9 +72,7 @@ type FacetState = {
 }
 
 export const submissionsQuery = (params: string) => {
-  const url = submissionsAPI
-    .query(qs.parse(params))
-    .toString()
+  const url = submissionsAPI.query(qs.parse(params)).toString()
 
   return {
     queryKey:  params ? `submissions__${params}` : "submissions",

--- a/static/js/lib/queries/submissions.js
+++ b/static/js/lib/queries/submissions.js
@@ -73,10 +73,7 @@ type FacetState = {
 
 export const submissionsQuery = (params: string) => {
   const url = submissionsAPI
-    .query({
-      limit: 1000,
-      ...qs.parse(params)
-    })
+    .query(qs.parse(params))
     .toString()
 
   return {

--- a/static/js/pages/applications/ReviewDashboardPage.js
+++ b/static/js/pages/applications/ReviewDashboardPage.js
@@ -2,9 +2,9 @@
 import React from "react"
 import { useSelector } from "react-redux"
 import { useRequest } from "redux-query-react"
-import { useLocation } from "react-router"
+import { useHistory, useLocation } from "react-router"
 import { Link } from "react-router-dom"
-import { Pagination, PaginationItem, PaginationLink } from 'reactstrap'
+import ReactPaginate from "react-paginate"
 import { reverse } from "named-urls"
 
 import SubmissionFacets from "../../components/SubmissionFacets"
@@ -17,6 +17,7 @@ import { REVIEW_STATUS_DISPLAY_MAP } from "../../constants"
 import { routes } from "../../lib/urls"
 import type { SubmissionReview } from "../../flow/applicationTypes"
 import qs from "query-string"
+import urljoin from "url-join"
 
 /* eslint-disable camelcase */
 type RowProps = {
@@ -47,17 +48,74 @@ export function SubmissionRow({ submission }: RowProps) {
     </div>
   )
 }
+
+type PaginateProps = {
+  limit: number,
+  count: number,
+  offset: number
+}
+
+export function SubmissionPagination(props: PaginateProps) {
+  const { limit, count, offset } = props
+
+  const initialPage = offset ? offset / limit : 0
+  const pageCount = count <= limit ? 1 : Math.ceil(count / limit)
+  const history = useHistory()
+
+  const handlePageClick = data => {
+    const selected = data.selected
+    const newOffset = Math.ceil(selected * limit)
+    if (newOffset !== offset) {
+      const updatedParams = {
+        ...qs.parse(location.search),
+        offset: newOffset,
+        limit:  limit
+      }
+      const url = urljoin(location.pathname, `/?${qs.stringify(updatedParams)}`)
+      history.push(url)
+    }
+  }
+
+  return pageCount > 1 ? (
+    <div className="row justify-content-center">
+      <ReactPaginate
+        previousLabel={"previous"}
+        nextLabel={"next"}
+        pageCount={pageCount}
+        marginPagesDisplayed={2}
+        initialPage={initialPage}
+        pageRangeDisplayed={5}
+        onPageChange={handlePageClick}
+        containerClassName={"pagination"}
+        subContainerClassName={"pages pagination"}
+        activeClassName={"active"}
+        breakClassName="page-item"
+        breakLabel={<div className="page-link">...</div>}
+        pageClassName="page-item"
+        previousClassName="page-item"
+        nextClassName="page-item"
+        pageLinkClassName="page-link"
+        previousLinkClassName="page-link"
+        nextLinkClassName="page-link"
+      />
+    </div>
+  ) : null
+}
 /* eslint-enable camelcase */
 
 export default function ReviewDashboardPage() {
-  const limit = 10
   const location = useLocation()
   const [{ isFinished }] = useRequest(submissionsQuery(location.search))
-  const { count, results, facets } = useSelector(submissionFacetsSelector)
-  const pages = 5 count <= limit ? 1 : Math.ceil(count / limit)
-  const offset = qs.parse(location.search).offset || 0
-  const currentPage = offset ? (offset / limit + 1) : 1
+  const { next, previous, count, results, facets } = useSelector(
+    submissionFacetsSelector
+  )
 
+  const offset = qs.parse(location.search).offset || 0
+  const limit = next ?
+    qs.parse(new URL(next).search).limit :
+    previous ?
+      qs.parse(new URL(previous).search).limit :
+      10
 
   return (
     <div className="review-dashboard-page container-lg">
@@ -83,33 +141,7 @@ export default function ReviewDashboardPage() {
             {results.map((submission, i) => (
               <SubmissionRow key={i} submission={submission} />
             ))}
-              { pages > 1 ? (
-               <div className="row justify-content-center">
-                 <Pagination>
-                <PaginationItem>
-                    <PaginationLink first href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                    <PaginationLink previous href="#" />
-                </PaginationItem>
-                  {
-                    [...Array(pages)].map((page, idx) => (
-                        <PaginationItem key={idx} active={offset === (limit*idx)}>
-                          <PaginationLink href="#">{idx+1}</PaginationLink>
-                        </PaginationItem>
-                      )
-                    )
-                  }
-                <PaginationItem>
-                    <PaginationLink next href="#" />
-                </PaginationItem>
-                <PaginationItem>
-                    <PaginationLink last href="#" />
-                </PaginationItem>
-               </Pagination>
-               </div>
-                ) : null
-              }
+            <SubmissionPagination limit={limit} count={count} offset={offset} />
           </div>
         </div>
       ) : null}

--- a/static/js/pages/applications/ReviewDashboardPage.js
+++ b/static/js/pages/applications/ReviewDashboardPage.js
@@ -77,7 +77,7 @@ export function SubmissionPagination(props: PaginateProps) {
   }
 
   return pageCount > 1 ? (
-    <div className="pagination-div row justify-content-center">
+    <div className="submission-paging row justify-content-center">
       <ReactPaginate
         previousLabel={"previous"}
         nextLabel={"next"}

--- a/static/js/pages/applications/ReviewDashboardPage.js
+++ b/static/js/pages/applications/ReviewDashboardPage.js
@@ -15,6 +15,7 @@ import {
 import { REVIEW_STATUS_DISPLAY_MAP } from "../../constants"
 import { routes } from "../../lib/urls"
 import type { SubmissionReview } from "../../flow/applicationTypes"
+import qs from "query-string"
 
 /* eslint-disable camelcase */
 type RowProps = {
@@ -48,9 +49,12 @@ export function SubmissionRow({ submission }: RowProps) {
 /* eslint-enable camelcase */
 
 export default function ReviewDashboardPage() {
+  const limit = 10
   const location = useLocation()
   const [{ isFinished }] = useRequest(submissionsQuery(location.search))
-  const { results, facets } = useSelector(submissionFacetsSelector)
+  const { count, results, facets } = useSelector(submissionFacetsSelector)
+  const pages = count <= limit ? 1 : Math.ceil(count / limit)
+  const {offset} = qs.parse(location.search) || 0
 
   return (
     <div className="review-dashboard-page container-lg">
@@ -76,6 +80,20 @@ export default function ReviewDashboardPage() {
             {results.map((submission, i) => (
               <SubmissionRow key={i} submission={submission} />
             ))}
+            <div className="row">
+              { pages > 1 ? (
+                <ul className="pagination">
+                  {
+                    [...Array(pages)].map((page, idx) => (
+                        <li className={`page-item ${ offset === (limit*idx) ? "active" : ""}`}>
+  
+                        </li>
+                      )
+                    )
+                  }
+                </ul>
+                ) : null
+              }
           </div>
         </div>
       ) : null}

--- a/static/js/pages/applications/ReviewDashboardPage.js
+++ b/static/js/pages/applications/ReviewDashboardPage.js
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux"
 import { useRequest } from "redux-query-react"
 import { useLocation } from "react-router"
 import { Link } from "react-router-dom"
+import { Pagination, PaginationItem, PaginationLink } from 'reactstrap'
 import { reverse } from "named-urls"
 
 import SubmissionFacets from "../../components/SubmissionFacets"
@@ -53,8 +54,10 @@ export default function ReviewDashboardPage() {
   const location = useLocation()
   const [{ isFinished }] = useRequest(submissionsQuery(location.search))
   const { count, results, facets } = useSelector(submissionFacetsSelector)
-  const pages = count <= limit ? 1 : Math.ceil(count / limit)
-  const {offset} = qs.parse(location.search) || 0
+  const pages = 5 count <= limit ? 1 : Math.ceil(count / limit)
+  const offset = qs.parse(location.search).offset || 0
+  const currentPage = offset ? (offset / limit + 1) : 1
+
 
   return (
     <div className="review-dashboard-page container-lg">
@@ -80,18 +83,31 @@ export default function ReviewDashboardPage() {
             {results.map((submission, i) => (
               <SubmissionRow key={i} submission={submission} />
             ))}
-            <div className="row">
               { pages > 1 ? (
-                <ul className="pagination">
+               <div className="row justify-content-center">
+                 <Pagination>
+                <PaginationItem>
+                    <PaginationLink first href="#" />
+                </PaginationItem>
+                <PaginationItem>
+                    <PaginationLink previous href="#" />
+                </PaginationItem>
                   {
                     [...Array(pages)].map((page, idx) => (
-                        <li className={`page-item ${ offset === (limit*idx) ? "active" : ""}`}>
-  
-                        </li>
+                        <PaginationItem key={idx} active={offset === (limit*idx)}>
+                          <PaginationLink href="#">{idx+1}</PaginationLink>
+                        </PaginationItem>
                       )
                     )
                   }
-                </ul>
+                <PaginationItem>
+                    <PaginationLink next href="#" />
+                </PaginationItem>
+                <PaginationItem>
+                    <PaginationLink last href="#" />
+                </PaginationItem>
+               </Pagination>
+               </div>
                 ) : null
               }
           </div>

--- a/static/js/pages/applications/ReviewDashboardPage.js
+++ b/static/js/pages/applications/ReviewDashboardPage.js
@@ -77,7 +77,7 @@ export function SubmissionPagination(props: PaginateProps) {
   }
 
   return pageCount > 1 ? (
-    <div className="row justify-content-center">
+    <div className="pagination-div row justify-content-center">
       <ReactPaginate
         previousLabel={"previous"}
         nextLabel={"next"}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -34,7 +34,7 @@
 @import "cms/homepage-alumni";
 @import "cms/catalog-section";
 @import "cms/letter-page";
-@import "submission-facets";
+@import "submission";
 
 html, body {
   height: 100%;

--- a/static/scss/review.scss
+++ b/static/scss/review.scss
@@ -39,13 +39,3 @@
     }
   }
 }
-
-#react-paginate ul {
-    display: inline-block;
-    padding-left: 15px;
-    padding-right: 15px;
-}
-
-#react-paginate li {
-    display: inline-block;
-}

--- a/static/scss/review.scss
+++ b/static/scss/review.scss
@@ -39,3 +39,13 @@
     }
   }
 }
+
+#react-paginate ul {
+    display: inline-block;
+    padding-left: 15px;
+    padding-right: 15px;
+}
+
+#react-paginate li {
+    display: inline-block;
+}

--- a/static/scss/submission.scss
+++ b/static/scss/submission.scss
@@ -8,4 +8,8 @@
 
 .submission-paging {
   padding-top: 15px;
+
+  a {
+    cursor: pointer;
+  }
 }

--- a/static/scss/submission.scss
+++ b/static/scss/submission.scss
@@ -5,3 +5,7 @@
     }
   }
 }
+
+.submission-paging {
+  padding-top: 15px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9051,6 +9051,13 @@ react-page-click@^4.0.4:
   dependencies:
     prop-types "^15.6.0"
 
+react-paginate@^6.3.2:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/react-paginate/-/react-paginate-6.3.2.tgz#4e18cbdb2654d308566775fa14df11e820188391"
+  integrity sha512-Ch++Njfv8UHpLtIMiQouAPeJQA5Ki86kIYfCer6c1B96Rvn3UF27se+goCilCP8oHNXNsA2R2kxvzanY1YIkyg==
+  dependencies:
+    prop-types "^15.6.1"
+
 react-popper@^1.3.6:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.7.tgz#f6a3471362ef1f0d10a4963673789de1baca2324"


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #802 

#### What's this PR do?
Adds paging controls and URL parameters to the submission reviews page.

#### How should this be manually tested?
- Go to the `/review` page and try out the paging controls.  If you have <=10 submissions, the paging controls shouldn't appear.  Otherwise, they should work, the url should be updated on each page change, and a change in selected facets should clear out the URL paging parameters.
- Create lots of fake submissions:
```python
ApplicationStepSubmissionFactory.create_batch(105)
```
- Go to the `/review` page and try out the paging controls again.  They should work, the url should be updated on each page change, and a change in selected facets should clear out the URL paging parameters.

#### Any background context you want to provide?
I didn't implement the usual endless scrolling so that reviewers can easily navigate back to where they were after finishing an individual review.

#### Screenshots (if appropriate)
<img width="973" alt="Screen Shot 2020-07-08 at 4 15 57 PM" src="https://user-images.githubusercontent.com/187676/87044857-1ef03c00-c1c5-11ea-8010-60b3c9c11d48.png">


#### What GIF best describes this PR or how it makes you feel?
(Optional)
