### PR TITLE
Implemented consistent error and success behavior

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -1,7 +1,6 @@
 """Views for bootcamp applications"""
 from collections import OrderedDict
 
-import django_fsm
 from django.db.models import Count, Subquery, OuterRef, IntegerField, Prefetch
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView
@@ -193,17 +192,11 @@ class UploadResumeView(GenericAPIView):
         linkedin_url = request.data.get("linkedin_url")
         resume_file = request.FILES.get("file")
         if linkedin_url is None and resume_file is None and not application.resume_file:
-
             raise ValidationError("At least one form of resume is required.")
 
-        try:
-            application.add_resume(resume_file=resume_file, linkedin_url=linkedin_url)
-            # when state transition happens need to save manually
-            application.save()
-        except django_fsm.TransitionNotAllowed:
-            return Response(
-                {"errors": "Cannot upload a resume in this application state"}
-            )
+        application.add_resume(resume_file=resume_file, linkedin_url=linkedin_url)
+        # when state transition happens need to save manually
+        application.save()
 
         return Response(
             {

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -60,6 +60,14 @@ class ApplicationOrderSerializer(serializers.ModelSerializer):
         ]
 
 
+class OrderSerializer(serializers.ModelSerializer):
+    """Serializer for orders"""
+
+    class Meta:
+        model = Order
+        fields = ["id", "status", "application_id", "created_on", "updated_on"]
+
+
 class LineSerializer(serializers.ModelSerializer):
     """
     Serializer for Line

--- a/ecommerce/serializers_test.py
+++ b/ecommerce/serializers_test.py
@@ -2,7 +2,12 @@
 import pytest
 
 from main.utils import serializer_date_format
-from ecommerce.factories import LineFactory, BootcampApplicationFactory, ReceiptFactory
+from ecommerce.factories import (
+    LineFactory,
+    BootcampApplicationFactory,
+    ReceiptFactory,
+    OrderFactory,
+)
 from ecommerce.models import Order
 from ecommerce.serializers import (
     PaymentSerializer,
@@ -10,6 +15,7 @@ from ecommerce.serializers import (
     LineSerializer,
     ApplicationOrderSerializer,
     CheckoutDataSerializer,
+    OrderSerializer,
 )
 from klasses.factories import InstallmentFactory
 from klasses.serializers import BootcampRunSerializer, InstallmentSerializer
@@ -124,4 +130,16 @@ def test_checkout_data(has_paid):
         "payments": [LineSerializer(line).data] if has_paid else [],
         "total_paid": application.total_paid,
         "total_price": application.price,
+    }
+
+
+def test_order_serializer():
+    """OrderSerializer should return expected data"""
+    order = OrderFactory.create()
+    assert OrderSerializer(instance=order).data == {
+        "id": order.id,
+        "status": order.status,
+        "application_id": order.application.id,
+        "created_on": serializer_date_format(order.created_on),
+        "updated_on": serializer_date_format(order.updated_on),
     }

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -11,6 +11,7 @@ from ecommerce.views import (
     UserBootcampRunDetail,
     UserBootcampRunList,
     UserBootcampRunStatement,
+    OrderView,
 )
 
 
@@ -36,5 +37,6 @@ urlpatterns = [
         UserBootcampRunStatement.as_view(),
         name="bootcamp-run-statement",
     ),
+    url(r"api/orders/(?P<pk>[0-9]+)/$", OrderView.as_view(), name="order-api"),
     path("api/checkout/", CheckoutDataView.as_view(), name="checkout-data-detail"),
 ]

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -32,10 +32,15 @@ from ecommerce.constants import CYBERSOURCE_DECISION_ACCEPT, CYBERSOURCE_DECISIO
 from ecommerce.exceptions import EcommerceException
 from ecommerce.models import Line, Order, Receipt
 from ecommerce.permissions import IsSignedByCyberSource
-from ecommerce.serializers import CheckoutDataSerializer, PaymentSerializer
+from ecommerce.serializers import (
+    CheckoutDataSerializer,
+    PaymentSerializer,
+    OrderSerializer,
+)
 from hubspot.task_helpers import sync_hubspot_application_from_order
 from klasses.models import BootcampRun
 from klasses.permissions import CanReadIfSelf
+from main.permissions import UserIsOwnerOrAdminPermission
 from main.serializers import serialize_maybe_user
 
 
@@ -240,3 +245,12 @@ class CheckoutDataView(RetrieveAPIView):
         """Get the application given the query parameter"""
         application_id = self.request.query_params.get("application")
         return get_object_or_404(self.get_queryset(), id=application_id)
+
+
+class OrderView(RetrieveAPIView):
+    """API view for Orders"""
+
+    permission_classes = (IsAuthenticated, UserIsOwnerOrAdminPermission)
+    serializer_class = OrderSerializer
+    queryset = Order.objects.all()
+    owner_field = "user"

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -14,6 +14,7 @@
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css" rel="stylesheet"/>
     <script type="text/javascript">
     var SETTINGS = {{ js_settings_json|safe }};
+    var CSOURCE_PAYLOAD = {% if CSOURCE_PAYLOAD %}{{ CSOURCE_PAYLOAD|safe }}{% else %}null{% endif %};
     </script>
     {% load render_bundle %}
     {% load wagtailcore_tags latest_notification %}
@@ -56,6 +57,5 @@
         }
       </script>
     {% endif %}
-    {% render_bundle 'third_party' %}
   </body>
 </html>

--- a/main/utils.py
+++ b/main/utils.py
@@ -163,8 +163,8 @@ def has_all_keys(dict_to_scan, keys):
     Returns True if the given dict has all of the given keys
 
     Args:
-        dict_to_scan (dict):
-        keys (iterable of str): Iterable of keys to check for
+        dict_to_scan (Dict[str, Any]):
+        keys (Iterable[str]): Iterable of keys to check for
 
     Returns:
         bool: True if the given dict has all of the given keys

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -30,5 +30,11 @@ export const hideDialog = createAction(HIDE_DIALOG)
 export const ADD_USER_NOTIFICATION = "ADD_USER_NOTIFICATION"
 export const addUserNotification = createAction(ADD_USER_NOTIFICATION)
 
+export const ADD_ERROR_NOTIFICATION = "ADD_ERROR_NOTIFICATION"
+export const addErrorNotification = createAction(ADD_ERROR_NOTIFICATION)
+
+export const ADD_SUCCESS_NOTIFICATION = "ADD_SUCCESS_NOTIFICATION"
+export const addSuccessNotification = createAction(ADD_SUCCESS_NOTIFICATION)
+
 export const REMOVE_USER_NOTIFICATION = "REMOVE_USER_NOTIFICATION"
 export const removeUserNotification = createAction(REMOVE_USER_NOTIFICATION)

--- a/static/js/components/EditProfileDisplay.js
+++ b/static/js/components/EditProfileDisplay.js
@@ -12,14 +12,17 @@ import EditProfileForm from "./forms/EditProfileForm"
 import { PROFILE_VIEW } from "../constants"
 import users, { currentUserSelector } from "../lib/queries/users"
 import queries from "../lib/queries"
+import { getFirstResponseBodyError, isErrorResponse } from "../util/util"
 import { setDrawerState } from "../reducers/drawer"
 
 import type {
   Country,
   CurrentUser,
   User,
-  HttpAuthResponse
+  HttpAuthResponse,
+  EditProfileResponse
 } from "../flow/authTypes"
+import SupportLink from "./SupportLink"
 
 type StateProps = {|
   countries: ?Array<Country>,
@@ -50,14 +53,16 @@ export class EditProfileDisplay extends React.Component<Props> {
         {})
     }
     try {
-      const {
-        body: { errors }
-      }: // $FlowFixMe
-      { body: Object } = await editProfile(payload)
-
-      if (errors && errors.length > 0) {
+      const response: EditProfileResponse = await editProfile(payload)
+      if (isErrorResponse(response)) {
+        const responseBodyError = getFirstResponseBodyError(response)
         setErrors({
-          email: errors[0]
+          general: responseBodyError || (
+            <span>
+              Something went wrong while updating your profile. Please refresh
+              the page and try again, or <SupportLink />
+            </span>
+          )
         })
       } else {
         updateDrawer(PROFILE_VIEW)

--- a/static/js/components/SupportLink.js
+++ b/static/js/components/SupportLink.js
@@ -1,0 +1,23 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+
+type Props = {
+  className?: string
+}
+
+const SupportLink = (props: Props): React$Element<*> => (
+  <React.Fragment>
+    <a
+      href={SETTINGS.support_url}
+      target="_blank"
+      rel="noopener noreferrer"
+      {...(props.className ? { className: props.className } : {})}
+    >
+      contact support
+    </a>{" "}
+    to resolve this issue.
+  </React.Fragment>
+)
+
+export default SupportLink

--- a/static/js/components/forms/EditProfileForm.js
+++ b/static/js/components/forms/EditProfileForm.js
@@ -40,7 +40,13 @@ const EditProfileForm = ({ onSubmit, countries, user }: Props) => (
     onSubmit={onSubmit}
     validationSchema={legalAddressValidation.concat(profileValidation)}
     initialValues={getInitialValues(user)}
-    render={({ isSubmitting, setFieldValue, setFieldTouched, values }) => (
+    render={({
+      isSubmitting,
+      setFieldValue,
+      setFieldTouched,
+      values,
+      errors
+    }) => (
       <Form>
         <div className="row">
           <h2 className="col-6">Profile</h2>
@@ -54,6 +60,11 @@ const EditProfileForm = ({ onSubmit, countries, user }: Props) => (
             </button>
           </div>
         </div>
+        {errors && errors.general ? (
+          <div className="row mt-2 mb-2">
+            <div className="col-12 form-error">{errors.general}</div>
+          </div>
+        ) : null}
         <div className="row">
           {user.is_authenticated ? (
             <div className="col-12 bootcamp-form">

--- a/static/js/components/notifications/NotificationContainer.js
+++ b/static/js/components/notifications/NotificationContainer.js
@@ -5,15 +5,15 @@ import { compose } from "redux"
 import { partial } from "ramda"
 import { Alert } from "reactstrap"
 
-import { removeUserNotification } from "../actions"
-import { newSetWith, newSetWithout, timeoutPromise } from "../util/util"
-import { notificationTypeMap } from "./notifications"
+import { notificationConfigMap } from "."
+import { removeUserNotification } from "../../actions"
+import { newSetWith, newSetWithout, timeoutPromise } from "../../util/util"
 import {
-  CMS_SITE_WIDE_NOTIFICATION,
-  CMS_NOTIFICATION_LCL_STORAGE_ID
-} from "../constants"
+  CMS_NOTIFICATION_LCL_STORAGE_ID,
+  CMS_SITE_WIDE_NOTIFICATION
+} from "../../constants"
 
-import type { UserNotificationMapping } from "../reducers/ui"
+import type { UserNotificationMapping } from "../../flow/uiTypes"
 
 const DEFAULT_REMOVE_DELAY_MS = 1000
 
@@ -74,7 +74,9 @@ export class NotificationContainer extends React.Component<Props, State> {
         {Object.keys(userNotifications || {}).map((notificationKey, i) => {
           const dismiss = partial(this.onDismiss, [notificationKey])
           const notification = userNotifications[notificationKey]
-          const AlertBodyComponent = notificationTypeMap[notification.type]
+          const notificationConfig = notificationConfigMap[notification.type]
+          const AlertBodyComponent = notificationConfig.bodyComponent
+          const alertProps = notificationConfig.alertProps
 
           return (
             <Alert
@@ -84,6 +86,7 @@ export class NotificationContainer extends React.Component<Props, State> {
               isOpen={!hiddenNotifications.has(notificationKey)}
               toggle={dismiss}
               fade={true}
+              {...alertProps}
             >
               <AlertBodyComponent dismiss={dismiss} {...notification.props} />
             </Alert>

--- a/static/js/components/notifications/NotificationContainer_test.js
+++ b/static/js/components/notifications/NotificationContainer_test.js
@@ -4,13 +4,13 @@ import { assert } from "chai"
 import NotificationContainer, {
   NotificationContainer as InnerNotificationContainer
 } from "./NotificationContainer"
-import { TextNotification } from "./notifications"
+import { TextNotification } from "."
 import {
   ALERT_TYPE_TEXT,
   CMS_NOTIFICATION_LCL_STORAGE_ID,
   CMS_SITE_WIDE_NOTIFICATION
-} from "../constants"
-import IntegrationTestHelper from "../util/integration_test_helper"
+} from "../../constants"
+import IntegrationTestHelper from "../../util/integration_test_helper"
 
 describe("NotificationContainer component", () => {
   const messages = {

--- a/static/js/components/notifications/index.js
+++ b/static/js/components/notifications/index.js
@@ -1,18 +1,58 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 
-import { ALERT_TYPE_TEXT } from "../../constants"
+import {
+  ALERT_TYPE_ERROR,
+  ALERT_TYPE_SUCCESS,
+  ALERT_TYPE_TEXT
+} from "../../constants"
 
-import type { TextNotificationProps } from "../../reducers/ui"
-
-type ComponentProps = {
-  dismiss: Function
-}
+import type {
+  NotificationProps,
+  TextNotificationProps,
+  ErrorNotificationProps
+} from "../../flow/uiTypes"
 
 export const TextNotification = (
-  props: TextNotificationProps & ComponentProps
-) => <span>{props.text}</span>
+  props: TextNotificationProps & NotificationProps
+): string | React$Element<*> => props.text
 
-export const notificationTypeMap = {
-  [ALERT_TYPE_TEXT]: TextNotification
+export const ErrorNotification = (
+  props: ErrorNotificationProps & NotificationProps
+): string | React$Element<*> =>
+  props.text || (
+    <span>
+      Something went wrong. Please refresh the page and try again, or{" "}
+      <a href={SETTINGS.support_url} target="_blank" rel="noopener noreferrer">
+        contact support
+      </a>{" "}
+      if the problem persists.
+    </span>
+  )
+
+type NotificationConfig = {
+  [string]: {
+    bodyComponent: (props: any) => string | React$Element<*>,
+    alertProps: Object
+  }
+}
+
+export const notificationConfigMap: NotificationConfig = {
+  [ALERT_TYPE_TEXT]: {
+    bodyComponent: TextNotification,
+    alertProps:    {}
+  },
+  [ALERT_TYPE_ERROR]: {
+    bodyComponent: ErrorNotification,
+    alertProps:    {
+      color: "danger"
+    }
+  },
+  [ALERT_TYPE_SUCCESS]: {
+    bodyComponent: TextNotification,
+    alertProps:    {
+      color: "success"
+    }
+  }
 }

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -99,6 +99,13 @@ export const COUNTRIES_REQUIRING_POSTAL_CODE = [US_ALPHA_2, CA_ALPHA_2]
 export const COUNTRIES_REQUIRING_STATE = [US_ALPHA_2, CA_ALPHA_2]
 
 export const ALERT_TYPE_TEXT = "text"
+export const ALERT_TYPE_ERROR = "error"
+export const ALERT_TYPE_SUCCESS = "success"
+export const ALERT_TYPES = [
+  ALERT_TYPE_TEXT,
+  ALERT_TYPE_ERROR,
+  ALERT_TYPE_SUCCESS
+]
 
 export const APP_STATE_IN_PROGRESS = "In Progress"
 export const APP_STATE_IN_REVIEW = "In Review"
@@ -147,6 +154,12 @@ export const SUBMISSION_STATUS_TEXT_MAP = {
   SUBMISSION_STATUS_SUBMITTED: SUBMISSION_STATUS_SUBMITTED
 }
 
+export const ORDER_STATUS_FULFILLED = "fulfilled"
+export const ORDER_STATUS_FAILED = "failed"
+
+export const CYBERSOURCE_RETURN_QS_STATE = "receipt"
+export const CYBERSOURCE_DECISION_ACCEPT = "ACCEPT"
+
 // HTML title for different pages
 export const LOGIN_EMAIL_PAGE_TITLE = "Sign In"
 export const LOGIN_PASSWORD_PAGE_TITLE = LOGIN_EMAIL_PAGE_TITLE
@@ -177,6 +190,7 @@ export const CMS_SITE_WIDE_NOTIFICATION = "cms-site-wide-notification"
 export const CMS_NOTIFICATION_SELECTOR = ".site-wide"
 export const CMS_NOTIFICATION_ID_ATTR = "data-notification-id"
 export const CMS_NOTIFICATION_LCL_STORAGE_ID = "dismissedNotification"
+export const APP_NOTIFICATION = "app-notification"
 
 // Drawer content types
 export const PROFILE_VIEW = "profileView"

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -11,6 +11,7 @@ import {
 
 import type { BootcampRun } from "./bootcampTypes"
 import type { User } from "./authTypes"
+import type {HttpResponse} from "./httpTypes"
 
 export type Application = {
   id:           number,
@@ -56,13 +57,16 @@ export type ApplicationOrder = {
   payment_method:   string
 } & LegacyOrderPartial
 
-export type ApplicationDetail = {
+export type ResumeLinkedInDetail = {
+  resume_url:         ?string,
+  linkedin_url:       ?string,
+  resume_upload_date: ?string
+}
+
+export type ApplicationDetail = ResumeLinkedInDetail & {
   id:                    number,
   state:                 string,
   bootcamp_run:          BootcampRun,
-  resume_url:            ?string,
-  linkedin_url:          ?string,
-  resume_upload_date:    ?string,
   payment_deadline:      string,
   is_paid_in_full:       boolean,
   run_application_steps: Array<ApplicationRunStep>,
@@ -85,7 +89,7 @@ export type ApplicationDetailState = {
   [string]: ApplicationDetail
 }
 
-export type SubmissionReviewState ={
+export type SubmissionReviewState = {
   [string]: SubmissionReview
 }
 
@@ -111,8 +115,6 @@ export type VideoInterviewResponse = {
   interview_link: string,
 }
 
-export type ResumeLinkedInResponse = {
-  body: {
-    errors?: Array<string>
-  }
-}
+export type NewApplicationResponse = HttpResponse<Application>
+export type ResumeLinkedInResponse = HttpResponse<ResumeLinkedInDetail>
+export type ApplicationDetailResponse = HttpResponse<ApplicationDetail>

--- a/static/js/flow/authTypes.js
+++ b/static/js/flow/authTypes.js
@@ -1,6 +1,8 @@
 // @flow
+import type {HttpResponse} from "./httpTypes"
 
 // API response types
+
 export type AuthStates =
   | "success"
   | "inactive"
@@ -137,3 +139,5 @@ export type updateEmailResponse = {
   confirmed: boolean,
   detail: ?string,
 }
+
+export type EditProfileResponse = HttpResponse<User>

--- a/static/js/flow/ecommerceTypes.js
+++ b/static/js/flow/ecommerceTypes.js
@@ -8,3 +8,17 @@ export type PaymentResponse = {
   url: string,
   payload: Object
 }
+
+export type OrderResponse = {
+  id: number,
+  status: string,
+  application_id: number,
+  created_on: string,
+  updated_on: string
+}
+
+export type CybersourcePayload = {
+  decision: string,
+  bootcamp_run_purchased: string,
+  purchase_date_utc: string
+}

--- a/static/js/flow/httpTypes.js
+++ b/static/js/flow/httpTypes.js
@@ -1,0 +1,6 @@
+export type HttpResponse<T> = {
+  body: T|{
+    errors: string|Array<string>
+  },
+  status: number
+}

--- a/static/js/flow/uiTypes.js
+++ b/static/js/flow/uiTypes.js
@@ -1,0 +1,24 @@
+import {ALERT_TYPE_TEXT} from "../constants"
+
+export type NotificationProps = {
+  dismiss: Function
+}
+
+export type TextNotificationProps = {
+  text: string|React$Element<*>,
+  persistedId?: string
+}
+
+export type ErrorNotificationProps = {
+  text: string|React$Element<*>
+}
+
+export type NotificationPropTypes = TextNotificationProps | ErrorNotificationProps
+
+export type UserNotificationSpec = {
+  type: ALERT_TYPE_TEXT,
+  color?: string,
+  props: NotificationPropTypes
+}
+
+export type UserNotificationMapping = { [string]: UserNotificationSpec }

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -11,6 +11,7 @@ const _createSettings = () => ({})
 
 global.SETTINGS = _createSettings()
 global._testing = true
+global.CSOURCE_PAYLOAD = null
 
 window.scrollTo = () => "scroll!"
 

--- a/static/js/lib/applicationApi.js
+++ b/static/js/lib/applicationApi.js
@@ -1,0 +1,46 @@
+import * as R from "ramda"
+
+import { ORDER_STATUS_FAILED, ORDER_STATUS_FULFILLED } from "../constants"
+import { isErrorResponse } from "../util/util"
+
+import type { Application, ApplicationDetail } from "../flow/applicationTypes"
+import type { HttpResponse } from "../flow/httpTypes"
+import type { OrderResponse } from "../flow/ecommerceTypes"
+
+export const calcOrderBalances = (application: ApplicationDetail) => {
+  const sortedOrders = R.sortBy(order => order.updated_on, application.orders)
+  let balance = application.price
+  const ordersAndBalances = sortedOrders.map(order => {
+    balance -= order.total_price_paid
+    return { order, balance }
+  })
+  const totalPaid = R.sum(sortedOrders.map(order => order.total_price_paid))
+  const totalPrice = application.price
+
+  return {
+    ordersAndBalances,
+    totalPaid,
+    totalPrice,
+    balanceRemaining: balance
+  }
+}
+
+export const isStatusPollingFinished = (
+  response: HttpResponse<OrderResponse>
+): boolean =>
+  isErrorResponse(response) ||
+  !!(
+    response.body &&
+    response.body.status &&
+    [ORDER_STATUS_FULFILLED, ORDER_STATUS_FAILED].includes(response.body.status)
+  )
+
+export const findAppByRunTitle = (
+  applications: Array<Application>,
+  bootcampRunTitle: string
+): ?Application => {
+  return applications.find(
+    (application: Application) =>
+      application.bootcamp_run.title === bootcampRunTitle
+  )
+}

--- a/static/js/lib/applicationApi_test.js
+++ b/static/js/lib/applicationApi_test.js
@@ -1,0 +1,77 @@
+import { assert } from "chai"
+
+import * as api from "./applicationApi"
+import {
+  makeApplication,
+  makeApplicationDetail
+} from "../factories/application"
+import { generateOrder } from "../factories"
+import { ORDER_STATUS_FAILED, ORDER_STATUS_FULFILLED } from "../constants"
+
+describe("applications API", () => {
+  it("calcOrderBalances sorts orders by updated_on and balances from the application", () => {
+    const application = makeApplicationDetail()
+    application.price = 60
+    // $FlowFixMe
+    application.orders = [
+      { ...generateOrder(), total_price_paid: 20, updated_on: "2020-01-01" },
+      { ...generateOrder(), total_price_paid: 30, updated_on: "2020-02-01" }
+    ]
+    const {
+      ordersAndBalances,
+      totalPaid,
+      totalPrice,
+      balanceRemaining
+    } = api.calcOrderBalances(application)
+    assert.deepEqual(ordersAndBalances, [
+      {
+        order:   application.orders[0],
+        balance: 40
+      },
+      {
+        order:   application.orders[1],
+        balance: 10
+      }
+    ])
+    assert.equal(totalPaid, 50)
+    assert.equal(totalPrice, 60)
+    assert.equal(balanceRemaining, 10)
+  })
+
+  //
+  ;[
+    [400, ORDER_STATUS_FULFILLED, "response indicates error", true],
+    [200, null, "response body is empty", false],
+    [200, "pending", "order status indicates that it's still pending", false],
+    [200, ORDER_STATUS_FULFILLED, "order status is fulfilled", true],
+    [200, ORDER_STATUS_FAILED, "order status is failed", true]
+  ].forEach(([statusCode, statusText, desc, expected]) => {
+    it(`isStatusPollingFinished should return ${String(
+      expected
+    )} when ${desc}`, () => {
+      const responseBody = statusText ?
+        {
+          body: {
+            status: statusText
+          }
+        } :
+        {}
+      const response = {
+        status: statusCode,
+        ...responseBody
+      }
+      assert.equal(api.isStatusPollingFinished(response), expected)
+    })
+  })
+
+  it("findAppByRunTitle should return an application matching a given bootcamp run title", () => {
+    const applications = [makeApplication(), makeApplication()]
+    const titleToSearch = `My Title: ${applications[0].bootcamp_run.title}`
+    assert.isNotOk(api.findAppByRunTitle(applications, titleToSearch))
+    applications[0].bootcamp_run.title = titleToSearch
+    assert.deepEqual(
+      api.findAppByRunTitle(applications, titleToSearch),
+      applications[0]
+    )
+  })
+})

--- a/static/js/lib/queries/applications.js
+++ b/static/js/lib/queries/applications.js
@@ -10,6 +10,8 @@ import type {
   ApplicationDetail,
   ApplicationDetailState
 } from "../../flow/applicationTypes"
+// $FlowFixMe: This export exists
+import type { QueryState } from "redux-query"
 
 const applicationsKey = "applications"
 export const applicationDetailKey = "applicationDetail"
@@ -22,6 +24,11 @@ export const applicationsSelector = (state: any): ?Array<Application> =>
 export const allApplicationDetailSelector = (
   state: any
 ): { [string]: ApplicationDetail } => state.entities[applicationDetailKey]
+
+// HACK: This wouldn't work with R.curry for some reason. Settling for a function that returns a function.
+export const appDetailQuerySelector = (state: any) => (
+  applicationId: string
+): ?QueryState => state.queries[`appDetail.${applicationId}`]
 
 export const applicationDetailSelector = (
   applicationId: number,
@@ -58,6 +65,7 @@ export default {
     }
   }),
   applicationDetailQuery: (applicationId: string, force?: boolean) => ({
+    queryKey:  `appDetail.${applicationId}`,
     url:       applicationDetailAPI.param({ applicationId }).toString(),
     transform: (json: ?ApplicationDetail) => {
       return {

--- a/static/js/lib/queries/ecommerce.js
+++ b/static/js/lib/queries/ecommerce.js
@@ -1,21 +1,38 @@
 // @flow
+import { objOf } from "ramda"
+
 import { DEFAULT_NON_GET_OPTIONS } from "../redux_query"
 import { paymentAPI } from "../urls"
+import { nextState } from "./util"
 
 import type { PaymentPayload } from "../../flow/ecommerceTypes"
+
+const orderStatusKey = "orderStatus"
 
 export default {
   paymentMutation: (payload: PaymentPayload) => ({
     queryKey: "payment",
     url:      paymentAPI.toString(),
-    update:   {
-      payment: () => null
+    options:  {
+      ...DEFAULT_NON_GET_OPTIONS
     },
     body: {
       ...payload
     },
-    options: {
-      ...DEFAULT_NON_GET_OPTIONS
+    update: {
+      payment: () => null
     }
+  }),
+  orderQuery: (orderId: string) => ({
+    queryKey: orderStatusKey,
+    url:      `/api/orders/${orderId}/`,
+    options:  {
+      ...DEFAULT_NON_GET_OPTIONS
+    },
+    transform: objOf(orderStatusKey),
+    update:    {
+      [orderStatusKey]: nextState
+    },
+    force: true
   })
 }

--- a/static/js/lib/queries/users.js
+++ b/static/js/lib/queries/users.js
@@ -45,11 +45,11 @@ export default {
   }),
   editProfileMutation: (profileData: UserProfileForm) => ({
     ...DEFAULT_OPTIONS,
-    transform: transformCurrentUser,
-    update:    updateResult,
-    url:       "/api/users/me",
-    body:      {
+    url:  "/api/users/me",
+    body: {
       ...profileData
-    }
+    },
+    transform: transformCurrentUser,
+    update:    updateResult
   })
 }

--- a/static/js/lib/redux_query.js
+++ b/static/js/lib/redux_query.js
@@ -1,5 +1,8 @@
 // @flow
 import { getCookie } from "./api"
+import { isErrorStatusCode } from "../util/util"
+// $FlowFixMe: This export exists
+import type { QueryState } from "redux-query"
 
 export const DEFAULT_NON_GET_OPTIONS = {
   headers: {
@@ -19,3 +22,6 @@ export const constructIdMap = (results: Array<Object>) => {
 
 export const getQueries = (state: Object) => state.queries
 export const getEntities = (state: Object) => state.entities
+
+export const isQueryInErrorState = (queryState?: QueryState) =>
+  !!queryState && isErrorStatusCode(queryState.status)

--- a/static/js/lib/redux_query_test.js
+++ b/static/js/lib/redux_query_test.js
@@ -1,8 +1,8 @@
 import { assert } from "chai"
 
-import { constructIdMap } from "./redux_query"
+import { constructIdMap, isQueryInErrorState } from "./redux_query"
 
-describe("Redux Query helpers", () => {
+describe("Redux Query helper", () => {
   it("constructIdMap should return a map from a list", () => {
     const results = [
       { id: 1, content: "foo" },
@@ -14,6 +14,24 @@ describe("Redux Query helpers", () => {
       1: results[0],
       2: results[1],
       3: results[2]
+    })
+  })
+  ;[
+    [null, false],
+    [200, false],
+    [300, false],
+    [400, true],
+    [500, true]
+  ].forEach(([statusCode, expected]) => {
+    it(`isQueryInErrorState should return ${String(
+      expected
+    )} when query status=${String(statusCode)}`, () => {
+      const queryState = statusCode ?
+        {
+          status: statusCode
+        } :
+        null
+      assert.equal(isQueryInErrorState(queryState), expected)
     })
   })
 })

--- a/static/js/pages/App.js
+++ b/static/js/pages/App.js
@@ -9,7 +9,7 @@ import { createStructuredSelector } from "reselect"
 
 import PrivateRoute from "../components/PrivateRoute"
 import SiteNavbar from "../components/SiteNavbar"
-import NotificationContainer from "../components/NotificationContainer"
+import NotificationContainer from "../components/notifications/NotificationContainer"
 import Drawer from "../components/Drawer"
 import LoginPages from "./login/LoginPages"
 import RegisterPages from "./register/RegisterPages"
@@ -49,7 +49,7 @@ export class App extends Component<Props> {
       const notificationId = cmsNotification.getAttribute(
         CMS_NOTIFICATION_ID_ATTR
       )
-      const notificationMessage = cmsNotification.textContent
+      const notificationHtml = cmsNotification.innerHTML
       if (
         window.localStorage.getItem(CMS_NOTIFICATION_LCL_STORAGE_ID) !==
         notificationId
@@ -58,7 +58,12 @@ export class App extends Component<Props> {
           [CMS_SITE_WIDE_NOTIFICATION]: {
             type:  ALERT_TYPE_TEXT,
             props: {
-              text:        notificationMessage,
+              text: (
+                <div
+                  className="site-wide"
+                  dangerouslySetInnerHTML={{ __html: notificationHtml }}
+                />
+              ),
               persistedId: notificationId
             }
           }

--- a/static/js/pages/HeaderApp.js
+++ b/static/js/pages/HeaderApp.js
@@ -4,7 +4,7 @@ import { compose } from "redux"
 import { connect } from "react-redux"
 
 import SiteNavbar from "../components/SiteNavbar"
-import NotificationContainer from "../components/NotificationContainer"
+import NotificationContainer from "../components/notifications/NotificationContainer"
 import { addUserNotification } from "../actions"
 import {
   ALERT_TYPE_TEXT,
@@ -22,7 +22,7 @@ export class HeaderApp extends React.Component<*, *> {
       const notificationId = cmsNotification.getAttribute(
         CMS_NOTIFICATION_ID_ATTR
       )
-      const notificationMessage = cmsNotification.textContent
+      const notificationHtml = cmsNotification.innerHTML
       if (
         window.localStorage.getItem(CMS_NOTIFICATION_LCL_STORAGE_ID) !==
         notificationId
@@ -31,7 +31,12 @@ export class HeaderApp extends React.Component<*, *> {
           [CMS_SITE_WIDE_NOTIFICATION]: {
             type:  ALERT_TYPE_TEXT,
             props: {
-              text:        notificationMessage,
+              text: (
+                <div
+                  className="site-wide"
+                  dangerouslySetInnerHTML={{ __html: notificationHtml }}
+                />
+              ),
               persistedId: notificationId
             }
           }

--- a/static/js/pages/applications/ApplicationDashboardPage_test.js
+++ b/static/js/pages/applications/ApplicationDashboardPage_test.js
@@ -68,7 +68,11 @@ describe("ApplicationDashboardPage", () => {
 
     renderPage = helper.configureReduxQueryRenderer(
       ApplicationDashboardPage,
-      {},
+      {
+        location: {
+          search: ""
+        }
+      },
       {
         entities: {
           currentUser: fakeUser
@@ -203,7 +207,10 @@ describe("ApplicationDashboardPage", () => {
         allApplicationDetail: { [application.id]: applicationDetail },
         currentUser:          makeCompleteUser(),
         fetchAppDetail:       sinon.stub(),
-        openDrawer:           openDrawerStub
+        openDrawer:           openDrawerStub,
+        location:             {
+          search: ""
+        }
       }
       // This function renders the component then sets the state so the detail section is expanded
       renderExpanded = async props => {

--- a/static/js/pages/applications/PaymentHistoryPage.js
+++ b/static/js/pages/applications/PaymentHistoryPage.js
@@ -6,9 +6,9 @@ import { connectRequest } from "redux-query-react"
 
 import Address from "../../components/Address"
 
+import { calcOrderBalances } from "../../lib/applicationApi"
 import queries from "../../lib/queries"
 import {
-  calcOrderBalances,
   formatPrice,
   formatReadableDateFromStr,
   formatRunDateRange

--- a/static/js/pages/applications/PaymentHistoryPage_test.js
+++ b/static/js/pages/applications/PaymentHistoryPage_test.js
@@ -4,11 +4,11 @@ import sinon from "sinon"
 
 import PaymentHistoryPage from "./PaymentHistoryPage"
 
+import { calcOrderBalances } from "../../lib/applicationApi"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import { makeCountries } from "../../factories/user"
 import { makeApplicationDetail } from "../../factories/application"
 import {
-  calcOrderBalances,
   formatPrice,
   formatReadableDateFromStr,
   formatRunDateRange

--- a/static/js/reducers/ui.js
+++ b/static/js/reducers/ui.js
@@ -1,5 +1,6 @@
 // @flow
 import moment from "moment"
+import { mergeRight, omit } from "ramda"
 
 import {
   CLEAR_UI,
@@ -11,12 +12,18 @@ import {
   SHOW_DIALOG,
   HIDE_DIALOG,
   ADD_USER_NOTIFICATION,
-  REMOVE_USER_NOTIFICATION
+  REMOVE_USER_NOTIFICATION,
+  ADD_ERROR_NOTIFICATION,
+  ADD_SUCCESS_NOTIFICATION
 } from "../actions"
+import {
+  ALERT_TYPE_ERROR,
+  ALERT_TYPE_SUCCESS,
+  APP_NOTIFICATION
+} from "../constants"
 
 import type { Action } from "../flow/reduxTypes"
-import { mergeRight, omit } from "ramda"
-import { ALERT_TYPE_TEXT } from "../constants"
+import type { UserNotificationMapping } from "../flow/uiTypes"
 
 export type ToastMessage = {
   message: string,
@@ -31,9 +38,10 @@ export type UIState = {
   timeoutActive: boolean,
   toastMessage: ?ToastMessage,
   dialogVisibility: Object,
-  userNotifications: Object
+  userNotifications: UserNotificationMapping
 }
-const INITIAL_UI_STATE = {
+
+const INITIAL_UI_STATE: UIState = {
   paymentAmount:     "",
   initialTime:       moment().toISOString(),
   timeoutActive:     false,
@@ -41,19 +49,6 @@ const INITIAL_UI_STATE = {
   dialogVisibility:  {},
   userNotifications: {}
 }
-
-export type TextNotificationProps = {
-  text: string,
-  persistedId?: string
-}
-
-export type UserNotificationSpec = {
-  type: ALERT_TYPE_TEXT,
-  color: string,
-  props: TextNotificationProps
-}
-
-export type UserNotificationMapping = { [string]: UserNotificationSpec }
 
 const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
   switch (action.type) {
@@ -89,6 +84,26 @@ const ui = (state: UIState = INITIAL_UI_STATE, action: Action) => {
     return {
       ...state,
       userNotifications: mergeRight(state.userNotifications, action.payload)
+    }
+  case ADD_ERROR_NOTIFICATION:
+    return {
+      ...state,
+      userNotifications: mergeRight(state.userNotifications, {
+        [APP_NOTIFICATION]: {
+          type: ALERT_TYPE_ERROR,
+          ...action.payload
+        }
+      })
+    }
+  case ADD_SUCCESS_NOTIFICATION:
+    return {
+      ...state,
+      userNotifications: mergeRight(state.userNotifications, {
+        [APP_NOTIFICATION]: {
+          type: ALERT_TYPE_SUCCESS,
+          ...action.payload
+        }
+      })
     }
   case REMOVE_USER_NOTIFICATION:
     return {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -8,7 +8,6 @@ $placeholder-color: #bbb;
 $input-font-size: 16px;
 $input-radius: 5px;
 
-$primary: #a31f34;
 $button-red: #ec654d;
 $button-dk-grey: #4b4b4b;
 $medium-soft-light-gray: #e6e6e6;
@@ -36,7 +35,6 @@ $cornflower-blue: #579cf9;
 $tab-color: #c2c0bf;
 $label-gray: #7c7b7d;
 $outline-red: #db312a;
-$success-green: #28a745;
 
 $artsy-font: PT Serif, "Times New Roman", Helvetica, Arial, sans-serif;
 $sans-serif-font: Lato, sans-serif;
@@ -63,3 +61,7 @@ $twitter: #55acee;
 $youtube: #cd201f;
 $instagram: #a17357;
 $soundcloud: #ff5600;
+
+$primary: #a31f34;
+$success: #28a745;
+$danger: #a31f34;

--- a/static/scss/application.scss
+++ b/static/scss/application.scss
@@ -107,13 +107,13 @@ $border-style: 1px solid $black;
 
     .fulfilled .progress-meter {
       .check, .bottom-line {
-        background-color: $success-green;
+        background-color: $success;
       }
     }
 
     .fulfilled + .detail-section {
       .progress-meter .top-line {
-        background-color: $success-green;
+        background-color: $success;
       }
     }
 

--- a/static/scss/notification.scss
+++ b/static/scss/notification.scss
@@ -5,16 +5,15 @@
   // HACK: Using this rule to get around styling issues with <p> elements in the
   //       notification content (notification content in Wagtail is configured to be HTML,
   //       and Wagtail wraps content in a <p> tag by default when you use the editor).
-  &.site-wide {
-    p {
-      margin: 0;
-    }
+  .site-wide p {
+    margin: 0;
+    padding: 0;
   }
 
   .alert {
     margin-bottom: 0;
 
-    &.alert-info, &.alert-danger {
+    &.alert-info, &.alert-danger, &.alert-success {
       color: white;
 
       a.alert-link, .close {
@@ -24,10 +23,6 @@
       a.alert-link {
         font-weight: inherit;
         text-decoration: underline;
-
-        &:hover {
-          font-weight: 700;
-        }
       }
 
       .close {
@@ -44,27 +39,11 @@
     }
 
     &.alert-danger {
-      background-color: $primary;
+      background-color: $danger;
+    }
+
+    &.alert-success {
+      background-color: $success;
     }
   }
-
-  // Django-rendered implementation
-  .notification {
-    background: $primary;
-    text-align: center;
-    color: white;
-  }
-
-  .close-notification {
-    text-decoration: none;
-    color: white;
-    float: right;
-    margin-right: 10px;
-
-    &:after {
-      content: "\e906";
-      font-family: icomoon;
-      margin-left: 10px;
-   }
- }
 }

--- a/static/scss/slick.scss
+++ b/static/scss/slick.scss
@@ -1,4 +1,6 @@
 // sass-lint:disable mixins-before-declarations
+$slick-red: #a31f34;
+
 /* Slider */
 .slick-slider {
   position: relative;
@@ -142,7 +144,7 @@
   }
 
   &:hover {
-    color: $primary;
+    color: $slick-red;
     background: black;
   }
 
@@ -212,7 +214,7 @@
 
     &.slick-active {
       button {
-        background: $primary;
+        background: $slick-red;
       }
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #658 
Closes #633 
Closes #919 

#### What's this PR do?
- Adds UI artifacts for instances where certain requests succeed and fail
- Re-enables HTML in site-wide notifications

#### How should this be manually tested?

##### Payment success/failure messages
- Create some order for an in-progress application in django admin. Set the status to "created" and note the id
- Apply this patch
    ```
    diff --git a/main/views.py b/main/views.py
    index afbf03f..51cf424 100644
    --- a/main/views.py
    +++ b/main/views.py
    @@ -60,6 +60,13 @@ def react(request, **kwargs):
                     "purchase_date_utc": request.POST["signed_date_time"],
                 }
             )
    +    context["CSOURCE_PAYLOAD"] = json.dumps(
    +        {
    +            "decision": "ACCEPT",
    +            "bootcamp_run_purchased": "<YOUR BOOTCAMP RUN TITLE>",
    +            "purchase_date_utc": "2021-07-08T00:00:00Z",
    +        }
    +    )
         return render(request, "bootcamp/react.html", context)
 
    ```
- Visit your application dashboard with some qs params: `/applications/?status=receipt&order=<your_order_id>`. You should see a notification thanking you for submitting a payment 
- At this point the app should be polling our API until the order status goes to "fulfilled" or "failed", or the request limit is reached.
    - If you set the status to "fulfilled" within the allotted time, the notification should be the same as the bottom screenshot
    - If you set the status to "failed" within the allotted time, the notification should be the same as the second-to-last screenshot
    - If you let the time elapse without changing the status, the notification should be the same as the second-to-last screenshot

NOTE: These notifications should only come up if (a) those querystring params exist and point to an actual order, and (b) the `purchase_date_utc` value in the context is a maximum of 15 min old.

##### Request failures

- Test the new application form
    - Edit `applications.views.BootcampApplicationViewset.create` to immediately raise an exception or return an error response
    - Use the new application form and click "Continue". You should see an error message
- Test the resume/LinkedIn form
    - Edit `UploadResumeView` to immediately raise an exception or return an error response
    - Using an application with no resume, try to add/edit a LinkedIn url and click "submit". You should see an error message

#### Any background context you want to provide?

- There are some notes in the issue about what to do when certain requests are successful. What I found while I was working on this was that we didn't need them so much because there was already some user feedback. When a new application is created, the drawer closes and the user can see that application immediately. When profile info is edited, the form closes and shows the read-only profile info UI. When a resume/LinkedIn URL are added, the drawer closes and the user's application state will be updated right away in the dashboard. Adding a notification on top of those bits of feedback seems unnecessary for now

#### Screenshots (if appropriate)
<img width="939" alt="ss 2020-07-08 at 17 15 33 " src="https://user-images.githubusercontent.com/14932219/86995164-4835ab80-c176-11ea-94e5-1cbb0161616c.png">
<img width="1320" alt="ss 2020-07-08 at 17 16 32 " src="https://user-images.githubusercontent.com/14932219/86995162-479d1500-c176-11ea-9d3c-68a0f402fb5f.png">
<img width="1294" alt="ss 2020-07-08 at 17 17 29 " src="https://user-images.githubusercontent.com/14932219/86995157-44098e00-c176-11ea-83c5-e7e0253fa0bf.png">

