### PR TITLE
fix dropzone accessibility issue

### DIFF
--- a/static/scss/resume.scss
+++ b/static/scss/resume.scss
@@ -21,6 +21,12 @@
     text-align: center;
     color: $black;
 
+    input.dzu-input {
+      position: fixed;
+      opacity: 0;
+      display: initial;
+    }
+
     .file-types {
       font-size: 16px;
     }


### PR DESCRIPTION
#### What are the relevant tickets?

part of #901

#### What's this PR do?

This just makes some CSS tweaks to allow the user to tab into the hidden input which is used for the resume upload in the dropzone.

#### How should this be manually tested?

Go to the application page and navigate to the resume upload drawer. Initially the 'x' should be selected, and then if you hit tab you'll be on the input. you should then be able to press 'enter' to open a file dialog.