### PR TITLE
Conditional hubspot/zendesk JS

### DIFF
--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -42,16 +42,18 @@
     {% endblock %}
     {% if zendesk_config.help_widget_enabled %}
       <script type="text/javascript">
-        zE('webWidget', 'prefill', {
-            name: {
-                value: '{{user.name}}',
-            },
-            email: {
-                value: '{{user.email}}',
-            }
-        });
-        // set page title as a search term
-        zE('webWidget', 'helpCenter:setSuggestions', { search: document.title });
+        if (typeof zE !== 'undefined') {
+            zE('webWidget', 'prefill', {
+                name: {
+                    value: '{{user.name}}',
+                },
+                email: {
+                    value: '{{user.email}}',
+                }
+            });
+            // set page title as a search term
+            zE('webWidget', 'helpCenter:setSuggestions', { search: document.title });
+        }
       </script>
     {% endif %}
     {% render_bundle 'third_party' %}

--- a/main/templates/footer.html
+++ b/main/templates/footer.html
@@ -19,11 +19,13 @@
         <![endif]-->
         <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
         <script>
-          hbspt.forms.create({
-            portalId: '{{ hubspot_portal_id }}',
-            formId: '{{ hubspot_footer_form_guid }}',
-            target: '#hs_footer_form'
-          });
+          if (typeof hbspt !== 'undefined') {
+              hbspt.forms.create({
+                portalId: '{{ hubspot_portal_id }}',
+                formId: '{{ hubspot_footer_form_guid }}',
+                target: '#hs_footer_form'
+              });
+          }
         </script>
     </div>
     <div class="footer-bottom">


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #907 

#### What's this PR do?
Places embedded hubspot/zendesk JS code inside `if` statements to prevent running them if the variables are undefined (most likely due to ad blockers).

#### How should this be manually tested?
- Populate the following using values from CI:
  ```
  HUBSPOT_FOOTER_FORM_GUID
  HUBSPOT_PORTAL_ID
  ZENDESK_HELP_WIDGET_ENABLED=True
  ```
- Load any page, both the zendesk widget and hubspot email form should appear near the bottom right.
- Add the following to your ad blocker plugin blocklist:
  ```
  *hubspot*
  *hsform*
  *.zendesk.*
  ```
- Reload the web page with the JS console in view.  The zendesk widget and hubspot email form should not be visible, and there should not be any console errors about either `hbspt` or `zE` being undefined.

#### Screenshots (if appropriate)
<img width="344" alt="Screen Shot 2020-07-10 at 2 35 23 PM" src="https://user-images.githubusercontent.com/187676/87187650-838dc280-c2bb-11ea-917e-31eb32b9510c.png">
