### PR TITLE
fix mobile margin

### DIFF
--- a/static/js/pages/register/RegisterConfirmSentPage.js
+++ b/static/js/pages/register/RegisterConfirmSentPage.js
@@ -26,44 +26,48 @@ export class RegisterConfirmSentPage extends React.Component<Props> {
           <title>{formatTitle(REGISTER_CONFIRM_PAGE_TITLE)}</title>
         </MetaTags>
         <div className="row auth-header">
-          <h1>Sign Up</h1>
+          <div className="col-12">
+            <h1>Sign Up</h1>
+          </div>
         </div>
         <div className="row auth-card">
-          <h2 className="font-weight-600">Thank You!</h2>
-          <p>
-            We sent an email to <span className="email">{email}</span>
-            ,<br /> please verify your address to continue.
-          </p>
-          <p>
-            If you do NOT receive your verification email, here’s what to do:
-          </p>
-          <ol>
-            <li>
-              <span className="font-weight-600">Wait a few moments.</span> It
-              might take several minutes to receive your verification email.
-            </li>
-            <li>
-              <span className="font-weight-600">Check your spam folder.</span>{" "}
-              It might be there.
-            </li>
-            <li>
-              <span className="font-weight-600">Is your email correct?</span> If
-              you made a typo, no problem, just try{" "}
-              <a href={routes.register.begin}>creating an account</a> again.
-            </li>
-          </ol>
-          <div className="contact-support">
-            <span className="font-weight-600">
-              Still no verification email?
-            </span>{" "}
-            Please contact our
-            <a
-              href={SETTINGS.support_url}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {` MIT Bootcamp Customer Support Center`}.
-            </a>
+          <div className="col-12">
+            <h2 className="font-weight-600">Thank You!</h2>
+            <p>
+              We sent an email to <span className="email">{email}</span>
+              ,<br /> please verify your address to continue.
+            </p>
+            <p>
+              If you do NOT receive your verification email, here’s what to do:
+            </p>
+            <ol>
+              <li>
+                <span className="font-weight-600">Wait a few moments.</span> It
+                might take several minutes to receive your verification email.
+              </li>
+              <li>
+                <span className="font-weight-600">Check your spam folder.</span>{" "}
+                It might be there.
+              </li>
+              <li>
+                <span className="font-weight-600">Is your email correct?</span>{" "}
+                If you made a typo, no problem, just try{" "}
+                <a href={routes.register.begin}>creating an account</a> again.
+              </li>
+            </ol>
+            <div className="contact-support">
+              <span className="font-weight-600">
+                Still no verification email?
+              </span>{" "}
+              Please contact our
+              <a
+                href={SETTINGS.support_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {` MIT Bootcamp Customer Support Center`}.
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/static/js/pages/register/RegisterConfirmSentPage_test.js
+++ b/static/js/pages/register/RegisterConfirmSentPage_test.js
@@ -48,6 +48,9 @@ describe("RegisterConfirmSentPage", () => {
 
   it("displays user's email on the page", async () => {
     const { inner } = await renderPage()
-    assert.equal(inner.find(".auth-card > p > span").text("href"), userEmail)
+    assert.equal(
+      inner.find(".auth-card > .col-12 > p > span").text("href"),
+      userEmail
+    )
   })
 })

--- a/static/scss/auth.scss
+++ b/static/scss/auth.scss
@@ -43,6 +43,14 @@
 }
 
 .auth-header {
+  @include media-breakpoint-down(sm) {
+    padding: 20px;
+  }
+
+  @include media-breakpoint-down(xs) {
+    padding: 15px 0;
+  }
+
   text-align: left;
   padding: 40px 0 0 40px;
 }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #848

#### What's this PR do?
Tweaks html/css so that the signup thank you page has a decent margin in both desktop and mobile layouts.

#### How should this be manually tested?
Register an email and look at the thank you page in both mobile and desktop layout.

#### Screenshots (if appropriate)
<img width="445" alt="Screen Shot 2020-07-15 at 2 19 23 PM" src="https://user-images.githubusercontent.com/187676/87587308-ee6e3d80-c6af-11ea-9f9e-8ff723db9b08.png">

