### PR TITLE
Filter out submissions that cannot be reviewed

### DIFF
--- a/applications/constants.py
+++ b/applications/constants.py
@@ -37,7 +37,6 @@ class AppStates(Enum):
 REVIEWABLE_APP_STATES = [
     AppStates.REJECTED.value,
     AppStates.AWAITING_PAYMENT.value,
-    AppStates.AWAITING_USER_SUBMISSIONS.value,
     AppStates.AWAITING_SUBMISSION_REVIEW.value,
 ]
 

--- a/applications/constants.py
+++ b/applications/constants.py
@@ -34,6 +34,13 @@ class AppStates(Enum):
         return self.value
 
 
+REVIEWABLE_APP_STATES = [
+    AppStates.REJECTED.value,
+    AppStates.AWAITING_PAYMENT.value,
+    AppStates.AWAITING_USER_SUBMISSIONS.value,
+    AppStates.AWAITING_SUBMISSION_REVIEW.value,
+]
+
 VALID_APP_STATE_CHOICES = list(
     zip((member.value for member in AppStates), (member.value for member in AppStates))
 )

--- a/applications/factories.py
+++ b/applications/factories.py
@@ -17,6 +17,8 @@ from applications.constants import (
     REVIEW_STATUS_REJECTED,
     REVIEW_STATUS_WAITLISTED,
     ALL_LETTER_TYPES,
+    SUBMISSION_STATUS_SUBMITTED,
+    REVIEWABLE_APP_STATES,
 )
 from jobma.factories import InterviewFactory
 from klasses.factories import BootcampFactory, BootcampRunFactory
@@ -105,6 +107,11 @@ class ApplicationStepSubmissionFactory(DjangoModelFactory):
         is_rejected = Trait(review_status=REVIEW_STATUS_REJECTED)
         is_approved = Trait(review_status=REVIEW_STATUS_APPROVED)
         is_waitlisted = Trait(review_status=REVIEW_STATUS_WAITLISTED)
+
+        is_review_ready = Trait(
+            submission_status=SUBMISSION_STATUS_SUBMITTED,
+            bootcamp_application__state=fuzzy.FuzzyChoice(REVIEWABLE_APP_STATES),
+        )
 
     class Meta:
         model = models.ApplicationStepSubmission

--- a/applications/views.py
+++ b/applications/views.py
@@ -1,7 +1,7 @@
 """Views for bootcamp applications"""
 from collections import OrderedDict
 
-from django.db.models import Count, Subquery, OuterRef, IntegerField, Prefetch
+from django.db.models import Count, Subquery, OuterRef, IntegerField, Prefetch, Q
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView
 from django_filters.rest_framework import DjangoFilterBackend
@@ -15,6 +15,7 @@ from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.response import Response
 from rest_framework_serializer_extensions.views import SerializerExtensionsAPIViewMixin
 
+from applications.constants import SUBMISSION_STATUS_SUBMITTED, REVIEWABLE_APP_STATES
 from applications.serializers import (
     BootcampApplicationDetailSerializer,
     BootcampApplicationSerializer,
@@ -158,7 +159,10 @@ class ReviewSubmissionViewSet(
     serializer_class = SubmissionReviewSerializer
     permission_classes = (IsAdminUser,)
     queryset = (
-        ApplicationStepSubmission.objects.all()
+        ApplicationStepSubmission.objects.filter(
+            Q(submission_status=SUBMISSION_STATUS_SUBMITTED)
+            & Q(bootcamp_application__state__in=REVIEWABLE_APP_STATES)
+        )
         .select_related(
             "bootcamp_application__user__profile",
             "bootcamp_application__user__legal_address",


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #933

#### What's this PR do?
Filters the submissions shown in the review dashboard to only include those with a submission_status of 'submitted' and in a valid application state that allows their review status to be changed.

#### How should this be manually tested?
Create some submissions with various values for `submission_status` and `bootcamp_application.state`.  The only ones that should show up on the `/review` page should have a `submission_status` of `submitted` and an application state of `AWAITING_SUBMISSION_REVIEW`, `AWAITING_PAYMENT`, or `REJECTED`.
