### PR TITLE
New full_name field for hubspot

### DIFF
--- a/hubspot/management/commands/configure_hubspot_bridge.py
+++ b/hubspot/management/commands/configure_hubspot_bridge.py
@@ -53,6 +53,14 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
         "groups": [],
         "properties": [
             {
+                "name": "full_name",
+                "label": "Full Name",
+                "description": "Full name",
+                "groupName": "contactinformation",
+                "type": "string",
+                "fieldType": "text",
+            },
+            {
                 "name": "highest_education",
                 "label": "Highest Education",
                 "description": "Highest education level",
@@ -284,7 +292,7 @@ HUBSPOT_ECOMMERCE_SETTINGS = {
             },
             {
                 "propertyName": "name",
-                "targetHubspotProperty": "name",
+                "targetHubspotProperty": "full_name",
                 "dataType": "STRING",
             },
             {


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #940 

#### What's this PR do?
- Set `HUBSPOT_API_KEY` to the appropriate value
- Run `manage.py configure_hubspot_bridge`, it should complete without errors
- Run `manage.py sync_hubspot --contacts`
- Log into hubspot, check the contacts for the bootcamp test account, your contacts should have the `Full Name` property populated.
