### PR TITLE
add cache-control header to hash.txt and api urls

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -47,6 +47,11 @@ http {
             try_files /static/images/favicon.ico /favicon.ico;
         }
 
+        location ~* /static/hash.txt {
+            expires -1;
+            add_header Cache-Control private;
+        }
+
         location ~* /static/(.*$) {
             expires max;
             add_header Access-Control-Allow-Origin *;

--- a/main/middleware.py
+++ b/main/middleware.py
@@ -1,0 +1,12 @@
+""" Middleware classes for the main app"""
+from django.utils.deprecation import MiddlewareMixin
+
+
+class CachelessAPIMiddleware(MiddlewareMixin):
+    """ Add Cache-Control header to API responses"""
+
+    def process_response(self, request, response):
+        """ Add a Cache-Control header to an API response """
+        if request.path.startswith("/api/"):
+            response["Cache-Control"] = "private, no-store"
+        return response

--- a/main/middleware_test.py
+++ b/main/middleware_test.py
@@ -1,0 +1,19 @@
+""" Tests for main.middleware """
+import pytest
+from django.urls import reverse
+
+from main.middleware import CachelessAPIMiddleware
+
+
+@pytest.mark.parametrize(
+    "view, cache_value",
+    [["applications", None], ["applications_api-list", "private, no-store"]],
+)
+def test_cacheless_api_middleware(rf, view, cache_value):
+    """Tests that the response has a cache-control header for API URLs"""
+    request = rf.get(reverse(view))
+    middleware = CachelessAPIMiddleware()
+    assert (
+        middleware.process_response(request, {}).get("Cache-Control", None)
+        == cache_value
+    )

--- a/main/settings.py
+++ b/main/settings.py
@@ -165,6 +165,7 @@ MIDDLEWARE = (
     "social_django.middleware.SocialAuthExceptionMiddleware",
     "wagtail.core.middleware.SiteMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+    "main.middleware.CachelessAPIMiddleware",
 )
 
 # enable the nplusone profiler only in debug mode


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #952

#### What's this PR do?
Adds cache-control headers to API responses (via new middleware) with a value of `private, no-store` [as recommended by fastly](https://docs.fastly.com/en/guides/configuring-caching#do-not-cache).
Also adds [the same cache-control headers as xpro](https://github.com/mitodl/mitxpro/pull/1658/files) to `/static/hash.txt` (via nginx.conf)

#### How should this be manually tested?
Make some requests to API and non-API URLs.  The API URL responses should have a `Cache-Control: private, no-store` header, other URL responses should not.  The heroku PR instance should also have cache-control headers for `/static/hash.txt`.

