### PR TITLE
admin section, make details top aligned

### DIFF
--- a/cms/templates/partials/admissions-section.html
+++ b/cms/templates/partials/admissions-section.html
@@ -39,19 +39,16 @@
                 <div class="col-md-4 col-sm-12 mt-5 border-left border-dark d-flex flex-column">
                     <h3 class="block-title">Format</h3>
                     <h2 class="pb-2">{{ page.bootcamp_format }}</h2>
-                    <div class="flex-grow-1"></div>
                     {{ page.bootcamp_format_details|richtext }}
                 </div>
                 <div class="col-md-4 col-sm-12 mt-5 border-left border-dark d-flex flex-column">
                     <h3 class="block-title">Bootcamp Dates</h3>
                     <h2 class="pb-2">{{ page.dates }}</h2>
-                    <div class="flex-grow-1"></div>
                     {{ page.dates_details|richtext }}
                 </div>
                 <div class="col-md-4 col-sm-12 mt-5 border-left border-dark d-flex flex-column">
                     <h3 class="block-title">Tuition</h3>
                     <h2 class="pb-2">${{ page.price|intcomma }} USD</h2>
-                    <div class="flex-grow-1"></div>
                     <div>{{ page.price_details|richtext }}</div>
                 </div>
             </div>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #896 

#### What's this PR do?
Product Page: in Admissions section, detail text should be top aligned

#### How should this be manually tested?
Just visit the product page

#### Screenshots (if appropriate)
**Before**
<img width="1440" alt="Screenshot 2020-07-30 at 18 13 40" src="https://user-images.githubusercontent.com/4043989/88927153-7186ba80-d290-11ea-8f23-7aa94d5b2269.png">
**Now**
<img width="1440" alt="Screenshot 2020-07-30 at 18 13 22" src="https://user-images.githubusercontent.com/4043989/88927160-7481ab00-d290-11ea-83ee-3e4dfba7a7f2.png">
