### PR TITLE
Send IP address to cybersource

### DIFF
--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -180,13 +180,14 @@ def generate_cybersource_sa_signature(payload):
     return b64encode(digest).decode("utf-8")
 
 
-def generate_cybersource_sa_payload(order, redirect_url):
+def generate_cybersource_sa_payload(order, redirect_url, ip_address=None):
     """
     Generates a payload dict to send to CyberSource for Secure Acceptance
 
     Args:
         order (Order): An order
         redirect_url: (str): The URL to redirect to after order completion
+        ip_address (str): The user's IP address
     Returns:
         dict: the payload to send to CyberSource via Secure Acceptance
     """
@@ -223,6 +224,7 @@ def generate_cybersource_sa_payload(order, redirect_url):
         "access_key": settings.CYBERSOURCE_ACCESS_KEY,
         "amount": str(order.total_price_paid),
         "currency": "USD",
+        "customer_ip_address": ip_address,
         "locale": "en-us",
         "item_0_code": "klass",
         "item_0_name": "{}".format(run_title),

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -224,7 +224,6 @@ def generate_cybersource_sa_payload(order, redirect_url, ip_address=None):
         "access_key": settings.CYBERSOURCE_ACCESS_KEY,
         "amount": str(order.total_price_paid),
         "currency": "USD",
-        "customer_ip_address": ip_address,
         "locale": "en-us",
         "item_0_code": "klass",
         "item_0_name": "{}".format(run_title),
@@ -252,6 +251,9 @@ def generate_cybersource_sa_payload(order, redirect_url, ip_address=None):
         "merchant_defined_data7": "{}".format(order.user.profile.name),
         "merchant_defined_data8": "{}".format(order.user.email),
     }
+
+    if ip_address:
+        payload["customer_ip_address"] = ip_address
 
     field_names = sorted(list(payload.keys()) + ["signed_field_names"])
     payload["signed_field_names"] = ",".join(field_names)

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -132,7 +132,10 @@ def test_signed_payload(mocker, application, bootcamp_run):
         autospec=True,
         return_value=mocker.MagicMock(hex=transaction_uuid),
     )
-    payload = generate_cybersource_sa_payload(order, "dashboard_url")
+    mock_ip = "194.100.0.1"
+    payload = generate_cybersource_sa_payload(
+        order, "dashboard_url", ip_address=mock_ip
+    )
     signature = payload.pop("signature")
     assert generate_cybersource_sa_signature(payload) == signature
     signed_field_names = payload["signed_field_names"].split(",")
@@ -142,6 +145,7 @@ def test_signed_payload(mocker, application, bootcamp_run):
         "access_key": CYBERSOURCE_ACCESS_KEY,
         "amount": str(order.total_price_paid),
         "currency": "USD",
+        "customer_ip_address": mock_ip,
         "item_0_code": "klass",
         "item_0_name": "{}".format(bootcamp_run.title),
         "item_0_quantity": 1,

--- a/ecommerce/api_test.py
+++ b/ecommerce/api_test.py
@@ -115,7 +115,8 @@ def test_valid_signature():
     assert b64encode(digest).decode("utf-8") == signature
 
 
-def test_signed_payload(mocker, application, bootcamp_run):
+@pytest.mark.parametrize("user_ip", ["194.100.0.1", "", None])
+def test_signed_payload(mocker, application, bootcamp_run, user_ip):
     """
     A valid payload should be signed appropriately
     """
@@ -132,20 +133,19 @@ def test_signed_payload(mocker, application, bootcamp_run):
         autospec=True,
         return_value=mocker.MagicMock(hex=transaction_uuid),
     )
-    mock_ip = "194.100.0.1"
+
     payload = generate_cybersource_sa_payload(
-        order, "dashboard_url", ip_address=mock_ip
+        order, "dashboard_url", ip_address=user_ip
     )
     signature = payload.pop("signature")
     assert generate_cybersource_sa_signature(payload) == signature
     signed_field_names = payload["signed_field_names"].split(",")
     assert signed_field_names == sorted(payload.keys())
 
-    assert payload == {
+    expected_payload = {
         "access_key": CYBERSOURCE_ACCESS_KEY,
         "amount": str(order.total_price_paid),
         "currency": "USD",
-        "customer_ip_address": mock_ip,
         "item_0_code": "klass",
         "item_0_name": "{}".format(bootcamp_run.title),
         "item_0_quantity": 1,
@@ -174,6 +174,9 @@ def test_signed_payload(mocker, application, bootcamp_run):
         "merchant_defined_data7": "{}".format(order.user.profile.name),
         "merchant_defined_data8": "{}".format(order.user.email),
     }
+    if user_ip:
+        expected_payload["customer_ip_address"] = user_ip
+    assert payload == expected_payload
     now_mock.assert_called_with(tz=pytz.UTC)
 
 

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.http.response import Http404
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from ipware import get_client_ip
 from rest_framework import status as statuses
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import CreateAPIView, GenericAPIView, RetrieveAPIView
@@ -85,10 +86,13 @@ class PaymentView(CreateAPIView):
         sync_hubspot_application_from_order(order)
 
         redirect_url = self.request.build_absolute_uri(reverse("applications"))
+        user_ip, _ = get_client_ip(request)
 
         return Response(
             {
-                "payload": generate_cybersource_sa_payload(order, redirect_url),
+                "payload": generate_cybersource_sa_payload(
+                    order, redirect_url, ip_address=user_ip
+                ),
                 "url": settings.CYBERSOURCE_SECURE_ACCEPTANCE_URL,
             }
         )

--- a/ecommerce/views_test.py
+++ b/ecommerce/views_test.py
@@ -98,6 +98,12 @@ def test_payment(mocker, client, user, bootcamp_run, application):
             bootcamp_run=bootcamp_run, user=user
         )
     )
+    fake_ip = "195.0.0.1"
+
+    mock_ip_call = mocker.patch(
+        "ecommerce.views.get_client_ip", return_value=(fake_ip, True)
+    )
+
     generate_cybersource_sa_payload_mock = mocker.patch(
         "ecommerce.views.generate_cybersource_sa_payload",
         autospec=True,
@@ -117,9 +123,10 @@ def test_payment(mocker, client, user, bootcamp_run, application):
         "payload": fake_payload,
         "url": CYBERSOURCE_SECURE_ACCEPTANCE_URL,
     }
+    assert mock_ip_call.call_count == 1
     assert generate_cybersource_sa_payload_mock.call_count == 1
     generate_cybersource_sa_payload_mock.assert_any_call(
-        fake_order, "http://testserver/applications/"
+        fake_order, "http://testserver/applications/", fake_ip
     )
     assert create_unfulfilled_order_mock.call_count == 1
     create_unfulfilled_order_mock.assert_any_call(

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ django-hijack==2.1.10
 django-hijack-admin==2.1.7
 django-filter==2.2.0
 django-fsm==2.6.1
+django-ipware==3.0.0
 django-mathfilters==1.0.0
 django-redis==4.7.0
 django-server-status==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ django-filter==2.2.0      # via -r requirements.in
 django-fsm==2.6.1         # via -r requirements.in
 django-hijack-admin==2.1.7  # via -r requirements.in
 django-hijack==2.1.10     # via -r requirements.in, django-hijack-admin
+django-ipware==3.0.0      # via -r requirements.in
 django-mathfilters==1.0.0  # via -r requirements.in
 django-modelcluster==5.0.1  # via wagtail
 django-redis==4.7.0       # via -r requirements.in


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #954 

#### What's this PR do?
Sends user IP to cybersource for orders

#### How should this be manually tested?
- Set up your dev instance to connect to cybersource using .env variables
- With the network console open, make a payment for a bootcamp.  Check the request sent to cybersource and make sure it includes the new IP field.
