### PR TITLE
Fix terms link on payment drawer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-05-11T15:09:09Z",
+  "generated_at": "2020-08-03T14:44:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -72,7 +72,7 @@
       {
         "hashed_secret": "b927bbc88b9ee3ac1e1474f41d70f17478264f3c",
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 23,
         "type": "Secret Keyword"
       }
     ]

--- a/main/context_processors.py
+++ b/main/context_processors.py
@@ -40,6 +40,7 @@ def js_settings(request):
                 },
                 "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
                 "support_url": settings.SUPPORT_URL,
+                "terms_url": get_resource_page_urls(request.site)["terms_of_service"],
             }
         )
     }

--- a/main/context_processors_test.py
+++ b/main/context_processors_test.py
@@ -8,9 +8,21 @@ from main.context_processors import configuration_context, js_settings
 from profiles.factories import UserFactory
 
 
+# pylint: disable=redefined-outer-name
+@pytest.fixture
+def patched_get_resource_page_urls(mocker):
+    """ Return a mock of main.context_processors.get_resource_page_urls """
+    yield mocker.patch(
+        "main.context_processors.get_resource_page_urls",
+        return_value={"terms_of_service": "/terms-of-service"},
+    )
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize("is_authed", [True, False])
-def test_configuration_context(settings, mocker, is_authed):
+def test_configuration_context(
+    settings, mocker, is_authed, patched_get_resource_page_urls
+):
     """Verify the context that is provided to all Django templates"""
     settings.ZENDESK_CONFIG = {
         "HELP_WIDGET_ENABLED": False,
@@ -20,9 +32,6 @@ def test_configuration_context(settings, mocker, is_authed):
         "HUBSPOT_PORTAL_ID": "fake-portal-id",
         "HUBSPOT_FOOTER_FORM_GUID": "fake-form-guid",
     }
-    patched_get_resource_page_urls = mocker.patch(
-        "main.context_processors.get_resource_page_urls"
-    )
     user = UserFactory.create() if is_authed else AnonymousUser()
 
     request = RequestFactory().get("/")
@@ -30,7 +39,7 @@ def test_configuration_context(settings, mocker, is_authed):
     request.site = mocker.Mock()
     context = configuration_context(request)
     assert context == {
-        "resource_page_urls": patched_get_resource_page_urls.return_value,
+        "resource_page_urls": {"terms_of_service": "/terms-of-service"},
         "zendesk_config": {
             "help_widget_enabled": settings.ZENDESK_CONFIG["HELP_WIDGET_ENABLED"],
             "help_widget_key": settings.ZENDESK_CONFIG["HELP_WIDGET_KEY"],
@@ -44,7 +53,7 @@ def test_configuration_context(settings, mocker, is_authed):
     patched_get_resource_page_urls.assert_called_once_with(request.site)
 
 
-def test_get_context_js_settings(settings):
+def test_get_context_js_settings(mocker, settings, patched_get_resource_page_urls):
     """Verify the specific JS settings in the base context dictionary"""
     settings.USE_WEBPACK_DEV_SERVER = False
     settings.ENVIRONMENT = "TEST"
@@ -59,6 +68,7 @@ def test_get_context_js_settings(settings):
 
     request = RequestFactory().get("/")
     request.user = AnonymousUser()
+    request.site = mocker.Mock()
     context = js_settings(request)
     assert json.loads(context["js_settings_json"]) == {
         "environment": settings.ENVIRONMENT,
@@ -71,4 +81,5 @@ def test_get_context_js_settings(settings):
         },
         "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
         "support_url": settings.SUPPORT_URL,
+        "terms_url": patched_get_resource_page_urls.return_value["terms_of_service"],
     }

--- a/static/js/components/Payment.js
+++ b/static/js/components/Payment.js
@@ -175,8 +175,9 @@ export default class Payment extends React.Component<*, void> {
           <p className="tac">
             By making a payment I certify that I agree with the{" "}
             <a
-              href="/terms_and_conditions/"
+              href={SETTINGS.terms_url}
               target="_blank"
+              rel="noopener noreferrer"
               className="tac-link"
             >
               MIT Bootcamps Terms and Conditions

--- a/static/js/components/PaymentDisplay.js
+++ b/static/js/components/PaymentDisplay.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import { sum } from "ramda"
 
@@ -18,7 +19,6 @@ import {
   formatReadableDateFromStr,
   isNilOrBlank
 } from "../util/util"
-import { routes } from "../lib/urls"
 
 import type { PaymentPayload } from "../flow/ecommerceTypes"
 import type { ApplicationDetail } from "../flow/applicationTypes"
@@ -114,7 +114,7 @@ export const PaymentDisplay = (props: Props) => {
       </div>
       <div className="terms-and-conditions">
         By making a payment I certify that I agree with the MIT Bootcamps{" "}
-        <a href={routes.resourcePages.terms}>Terms and Conditions</a>.
+        <a href={SETTINGS.terms_url}>Terms and Conditions</a>.
       </div>
     </div>
   )

--- a/static/js/components/PaymentDisplay_test.js
+++ b/static/js/components/PaymentDisplay_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import { assert } from "chai"
 import sinon from "sinon"
 import { shallow } from "enzyme"
@@ -40,6 +41,18 @@ describe("PaymentDisplay", () => {
     assert.equal(
       inner.find(".bootcamp-title").text(),
       application.bootcamp_run.bootcamp.title
+    )
+  })
+
+  it("renders the terms and conditions link", async () => {
+    SETTINGS.terms_url = "/terms-of-service"
+    const { inner } = await renderPage()
+    assert.equal(
+      inner
+        .find(".terms-and-conditions")
+        .find("a")
+        .prop("href"),
+      SETTINGS.terms_url
     )
   })
 

--- a/static/js/components/Payment_test.js
+++ b/static/js/components/Payment_test.js
@@ -88,6 +88,7 @@ describe("Payment", () => {
   })
 
   it("should show terms and conditions message", () => {
+    SETTINGS.terms_url = "/terms/"
     const fakeRun = generateFakePayableRuns(1, { hasInstallment: true })[0]
     const wrapper = renderPayment({ selectedBootcampRun: fakeRun })
     const termsText = wrapper.find(".tac").text()
@@ -97,7 +98,7 @@ describe("Payment", () => {
       termsText,
       "By making a payment I certify that I agree with the MIT Bootcamps Terms and Conditions"
     )
-    assert.equal(termsLink.prop("href"), "/terms_and_conditions/")
+    assert.equal(termsLink.prop("href"), SETTINGS.terms_url)
   })
 
   describe("bootcamp run dropdown", () => {

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -4,6 +4,7 @@ declare var SETTINGS: {
   reactGaDebug: boolean,
   recaptchaKey: ?string,
   support_url: string,
+  terms_url: string,
   zendesk_config: {
     help_widget_enabled: boolean,
     help_widget_key: ?string

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -54,8 +54,7 @@ export const routes = {
   }),
 
   resourcePages: include("", {
-    howToApply: "apply/",
-    terms:      "terms-and-conditions/"
+    howToApply: "apply/"
   })
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #861

#### What's this PR do?
Fixes a wrong URL on the payment drawer

#### How should this be manually tested?
- Publish a terms page in Wagtail CMS with slug `terms_of_service`
- Open up the payment drawer and click on the "Terms and Conditions" link, it should go to the above CMS page.
