### PR TITLE
Implement the customized signatory name and signature image in the application

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -28,6 +28,7 @@ from applications.models import (
     ApplicationStepSubmission,
     BootcampApplication,
 )
+from cms.models import LetterTemplatePage
 from ecommerce.models import Order
 from klasses.models import BootcampRun, Bootcamp
 from main.permissions import UserIsOwnerPermission, UserIsOwnerOrAdminPermission
@@ -229,4 +230,9 @@ class LettersView(TemplateView):
         """
         hash_code = kwargs.get("hash")
         letter = get_object_or_404(ApplicantLetter, hash=hash_code)
-        return {"content": letter.letter_text}
+        letter_template = LetterTemplatePage.objects.get()
+        signatory_details = {
+            "name": letter_template.signatory_name,
+            "image": letter_template.signature_image,
+        }
+        return {"content": letter.letter_text, "signatory": signatory_details}

--- a/cms/models.py
+++ b/cms/models.py
@@ -665,10 +665,11 @@ class LetterTemplatePage(Page):
 <h2>Rejection letter:</h2><br />
 {render_template(text=self.rejection_text, context=SAMPLE_DECISION_TEMPLATE_CONTEXT)}
 """
+        signatory = {"name": self.signatory_name, "image": self.signature_image}
         return render(
             request,
             "letter_template_page.html",
-            context={"preview": True, "content": content},
+            context={"preview": True, "content": content, "signatory": signatory},
         )
 
     def serve(self, request, *args, **kwargs):

--- a/cms/templates/letter_template_page.html
+++ b/cms/templates/letter_template_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static render_bundle wagtailcore_tags wagtailimages_tags wagtailroutablepage_tags %}
+{% load static render_bundle wagtailcore_tags wagtailimages_tags wagtailroutablepage_tags image_version_url %}
 
 {% block title %}{{ site_name }} | Letter{% endblock %}
 
@@ -26,8 +26,8 @@
     </div>
     <p>
       Sincerely,<br />
-      <img src="{% static "images/signature-mariah-rawding.png" %}" alt="Signature for Mariah Rawding" /><br />
-      Mariah Rawding<br />
+      <img src="{% if signatory.image %}{% image_version_url signatory.image "fill-300x300" %}{% else %}{% static "images/signature-mariah-rawding.png" %}{% endif %}" alt="Signature for {% if signatory.name %}{{ signatory.name }}{% else %}Mariah Rawding{% endif %}" /><br />
+      {% if signatory.name %}{{ signatory.name }}{% else %}Mariah Rawding{% endif %}<br />
       MIT Bootcamps Admissions
     </p>
   </div>

--- a/mail/templates/applicant_letter/body.html
+++ b/mail/templates/applicant_letter/body.html
@@ -1,4 +1,5 @@
 {% extends "email_base.html" %}
+{% load static image_version_url %}
 
 {% block content %}
 
@@ -14,8 +15,8 @@
                   <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                       <p style="margin: 0 0 10px;">
                         Sincerely,<br />
-                        <img src="{{ base_url }}/static/images/signature-mariah-rawding.png" alt="Signature for Mariah Rawding" /><br />
-                        Mariah Rawding<br />
+                        <img src="{{ base_url }}{% if signatory.image %}{% image_version_url signatory.image "fill-300x300" %}{% else %}/static/images/signature-mariah-rawding.png{% endif %}" alt="Signature for {% if signatory.name %}{{ signatory.name }}{% else %}Mariah Rawding{% endif %}" /><br />
+                        {% if signatory.name %}{{ signatory.name }}{% else %}Mariah Rawding{% endif %}<br />
                         MIT Bootcamps Admissions
                       </p>
                   </td>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #818 

#### What's this PR do?
Implement the customized signatory name and signature image in the application

#### How should this be manually tested?
Just see cms template page has signatory field and check all the pages should show the customized signatory details for letter template preview, acceptance/rejection letter and application letter

#### Screenshots
<img width="1430" alt="Screenshot 2020-08-13 at 11 56 54" src="https://user-images.githubusercontent.com/4043989/90104042-fe377b00-dd5c-11ea-9314-2a1db2db0c31.png">
<img width="1424" alt="Screenshot 2020-08-13 at 11 57 20" src="https://user-images.githubusercontent.com/4043989/90104058-04c5f280-dd5d-11ea-88cf-ae282ee88a5d.png">
<img width="724" alt="Screenshot 2020-08-13 at 11 57 53" src="https://user-images.githubusercontent.com/4043989/90104060-05f71f80-dd5d-11ea-8f33-40ef9b9c17f5.png">
<img width="715" alt="Screenshot 2020-08-13 at 11 58 09" src="https://user-images.githubusercontent.com/4043989/90104064-07c0e300-dd5d-11ea-8cef-9c5fdaebc977.png">
<img width="1428" alt="Screenshot 2020-08-13 at 12 03 02" src="https://user-images.githubusercontent.com/4043989/90104067-098aa680-dd5d-11ea-8bcd-11abda07514b.png">

