### PR TITLE
change recaptcha script domain

### DIFF
--- a/static/js/components/ScaledRecaptcha.js
+++ b/static/js/components/ScaledRecaptcha.js
@@ -27,6 +27,9 @@ export default class ScaledRecaptcha extends React.Component<Props, State> {
   recaptcha: null
 
   constructor(props: Props) {
+    window.recaptchaOptions = {
+      useRecaptchaNet: true
+    }
     super(props)
     // use old-style ref so we can resize when it mounts
     this.recaptcha = null


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #970

#### What's this PR do?
Changes the origin of the recaptcha script to recaptcha.net

#### How should this be manually tested?
Go to the `/create-account` page and verify that the recaptcha script is being loaded from `recaptcha.net` instead of `google.com`
