### PR TITLE
Check for and fix missing submissions & null interview urls

### DIFF
--- a/applications/api.py
+++ b/applications/api.py
@@ -126,16 +126,17 @@ def populate_interviews_in_jobma(application):
         if not interview.interview_url:
             create_interview_in_jobma(interview)
 
-            video_interview_submission, _ = VideoInterviewSubmission.objects.get_or_create(
-                interview=interview
-            )
-            ApplicationStepSubmission.objects.get_or_create(
-                bootcamp_application=application,
-                run_application_step=run_step,
-                defaults={
-                    "object_id": video_interview_submission.id,
-                    "content_type": ContentType.objects.get_for_model(
-                        video_interview_submission
-                    ),
-                },
-            )
+        # Make sure a VideoInterviewSubmission & ApplicationStepSubmission exist
+        video_interview_submission, _ = VideoInterviewSubmission.objects.get_or_create(
+            interview=interview
+        )
+        ApplicationStepSubmission.objects.get_or_create(
+            bootcamp_application=application,
+            run_application_step=run_step,
+            defaults={
+                "object_id": video_interview_submission.id,
+                "content_type": ContentType.objects.get_for_model(
+                    video_interview_submission
+                ),
+            },
+        )

--- a/applications/tasks.py
+++ b/applications/tasks.py
@@ -3,13 +3,11 @@ import logging
 from datetime import timedelta
 
 from django.conf import settings
-from django.db import transaction
 from django.db.models import Q
 
 from applications.constants import SUBMISSION_STATUS_PENDING, REVIEW_COMPLETED_STATES
 from applications.models import BootcampApplication, ApplicationStepSubmission
 from applications import api
-from jobma.models import Interview
 from main.celery import app
 from main.utils import now_in_utc
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #998 

#### What's this PR do?
Modifies the `refresh_pending_interview_links` task so that it will check for applications with missing submissions or blank interview urls and run the `populate_interviews_in_jobma` function on each of them.

#### How should this be manually tested?
- Tests should pass
- Create some applications.  Manually remove the submission for one of them, and set `interview_url=None` for the other.  
- Temporarily change `jobma.api.create_interview_in_jobma` because dev.jobma.com doesn't seem to be working at the moment: 
    ```
    #response.raise_for_status()
    result = {"interview_link": "http://jobma.com/fake_url", "interview_token": "fake"}
   ```
- Run `refresh_pending_interview_links`.  After it is completed, both applications should have a submission and a populated interview url.
