### PR TITLE
Updated Heroku nginx config and Django settings for file upload size

### DIFF
--- a/app.json
+++ b/app.json
@@ -284,8 +284,8 @@
       "description": "The API url for mailfun",
       "required": false
     },
-    "MAX_FILE_UPLOAD_SIZE": {
-      "description": "The maximum size in bytes for an uploaded file",
+    "MAX_FILE_UPLOAD_MB": {
+      "description": "The maximum size in megabytes for an uploaded file",
       "required": false
     },
     "MEDIA_ROOT": {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -83,6 +83,7 @@ http {
             uwsgi_pass unix:/tmp/nginx.socket;
             uwsgi_pass_request_headers on;
             uwsgi_pass_request_body on;
+            client_max_body_size <%= ENV["MAX_FILE_UPLOAD_MB"] || 10 %>M;
         }
     }
 }

--- a/main/context_processors.py
+++ b/main/context_processors.py
@@ -39,7 +39,7 @@ def js_settings(request):
                     "help_widget_key": settings.ZENDESK_CONFIG.get("HELP_WIDGET_KEY"),
                 },
                 "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
-                "upload_max_size": settings.MAX_FILE_UPLOAD_SIZE,
+                "upload_max_size": settings.MAX_FILE_UPLOAD_MB * 1_000_000,
                 "support_url": settings.SUPPORT_URL,
                 "terms_url": get_resource_page_urls(request.site)["terms_of_service"],
             }

--- a/main/context_processors_test.py
+++ b/main/context_processors_test.py
@@ -61,7 +61,7 @@ def test_get_context_js_settings(mocker, settings, patched_get_resource_page_url
     settings.RECAPTCHA_SITE_KEY = "SITE_KEY"
     settings.SUPPORT_URL = "http://example.com/support"
     settings.SENTRY_DSN = "http://example.com/sentry"
-    settings.MAX_FILE_UPLOAD_SIZE = 123
+    settings.MAX_FILE_UPLOAD_MB = 123
     settings.ZENDESK_CONFIG = {
         "HELP_WIDGET_ENABLED": False,
         "HELP_WIDGET_KEY": "fake_key",
@@ -81,7 +81,7 @@ def test_get_context_js_settings(mocker, settings, patched_get_resource_page_url
             "help_widget_key": settings.ZENDESK_CONFIG["HELP_WIDGET_KEY"],
         },
         "recaptchaKey": settings.RECAPTCHA_SITE_KEY,
-        "upload_max_size": settings.MAX_FILE_UPLOAD_SIZE,
+        "upload_max_size": 123_000_000,
         "support_url": settings.SUPPORT_URL,
         "terms_url": patched_get_resource_page_urls.return_value["terms_of_service"],
     }

--- a/main/settings.py
+++ b/main/settings.py
@@ -656,10 +656,10 @@ if BOOTCAMP_ECOMMERCE_USE_S3 and (
 if BOOTCAMP_ECOMMERCE_USE_S3:
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 
-MAX_FILE_UPLOAD_SIZE = get_string(
-    "MAX_FILE_UPLOAD_SIZE",
-    10_000_000,  # 10 MB
-    description="The maximum size in bytes for an uploaded file",
+MAX_FILE_UPLOAD_MB = get_int(
+    "MAX_FILE_UPLOAD_MB",
+    10,
+    description="The maximum size in megabytes for an uploaded file",
 )
 
 # Celery


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #996

#### What's this PR do?
Changs up file upload max size setting to make it compatible with nginx definitions, and makes the max upload size nginx setting configurable for heroku deployments

#### How should this be manually tested?
Set `MAX_FILE_UPLOAD_MB` in your `.env` file, then try to upload a resume smaller than and larger than that setting

#### Any background context you want to provide?
See https://github.com/mitodl/salt-ops/pull/1282
