### PR TITLE
Add a try..except block to refresh_pending_interview_links

### DIFF
--- a/applications/tasks.py
+++ b/applications/tasks.py
@@ -64,4 +64,7 @@ def refresh_pending_interview_links():
         submission = application.submissions.first()
         if submission and submission.content_object:
             submission.content_object.interview.delete()
-        api.populate_interviews_in_jobma(application)
+        try:
+            api.populate_interviews_in_jobma(application)
+        except:
+            log.exception("Exception processing application %d", application.id)

--- a/applications/tasks.py
+++ b/applications/tasks.py
@@ -66,5 +66,5 @@ def refresh_pending_interview_links():
             submission.content_object.interview.delete()
         try:
             api.populate_interviews_in_jobma(application)
-        except:
+        except:  # pylint:disable=bare-except
             log.exception("Exception processing application %d", application.id)


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1005 

#### What's this PR do?
Places a try..except block around the `populate_interviews_in_jobma` call inside `refresh_pending_interview_links`.

#### How should this be manually tested?
- Tests should pass
