### PR TITLE
Add admin for WireTransferReceipt

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -171,6 +171,9 @@ class WireTransferReceiptAdmin(TimestampedModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
+    def has_change_permission(self, request, obj=None):
+        return False
+
     def get_queryset(self, request):
         """Overrides base queryset"""
         return super().get_queryset(request).select_related("order__user")

--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -8,7 +8,7 @@ from django.utils.safestring import mark_safe
 
 from main.admin import TimestampedModelAdmin
 from main.utils import get_field_names
-from ecommerce.models import Line, Order, OrderAudit, Receipt
+from ecommerce.models import Line, Order, OrderAudit, Receipt, WireTransferReceipt
 from applications import models as application_models
 
 
@@ -156,7 +156,62 @@ class ReceiptAdmin(TimestampedModelAdmin):
     order_link.short_description = "Order"
 
 
+class WireTransferReceiptAdmin(TimestampedModelAdmin):
+    """Admin for WireTransferReceipt"""
+
+    model = WireTransferReceipt
+    include_created_on_in_list = True
+    readonly_fields = get_field_names(WireTransferReceipt) + ["order_link"]
+    list_display = ("id", "get_user_email", "order_link", "get_order_status")
+    search_fields = ("order__user__email", "order__user__username")
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def get_queryset(self, request):
+        """Overrides base queryset"""
+        return super().get_queryset(request).select_related("order__user")
+
+    def get_user_email(self, obj):
+        """Returns the user email"""
+        if obj.order is None:
+            return None
+        return obj.order.user.email
+
+    get_user_email.short_description = "User"
+    get_user_email.admin_order_field = "order__user__email"
+
+    def get_order_status(self, obj):
+        """Returns the order status"""
+        if obj.order is None:
+            return None
+        return obj.order.status
+
+    get_order_status.short_description = "Status"
+    get_order_status.admin_order_field = "order__status"
+
+    def order_link(self, obj):
+        """Returns a link to the related order"""
+        if obj.order is None:
+            return None
+        return mark_safe(
+            '<a href="{}">Order ({})</a>'.format(
+                reverse(
+                    "admin:ecommerce_{}_change".format(Order._meta.model_name),
+                    args=(obj.order.id,),
+                ),  # pylint: disable=protected-access
+                obj.order.id,
+            )
+        )
+
+    order_link.short_description = "Order"
+
+
 admin.site.register(Line, LineAdmin)
 admin.site.register(Order, OrderAdmin)
 admin.site.register(OrderAudit, OrderAuditAdmin)
 admin.site.register(Receipt, ReceiptAdmin)
+admin.site.register(WireTransferReceipt, WireTransferReceiptAdmin)

--- a/ecommerce/testdata/#example_wire_transfers.csv#
+++ b/ecommerce/testdata/#example_wire_transfers.csv#
@@ -1,0 +1,5 @@
+DRAFT Bootcamp Wire Transfer Log -- BEFORE THIS GOES INTO PRODUCTION REMEMBER TO CHANGE SHARE SETTINGS,,,,,,,,,,,,,,,,,
+Customer Service,,,,,Finance,,,,,,,,Engineering,,,,
+Id,Date transfers requested ,Learner Email,Zendesk Ticket,Bootcamp ID,Payor Name,Learner email,Payment Date,Bootcamp Name,Bootcamp Start Date,Amount,Transfer Type,SAP doc # - Cash Application,Order Updated By,Refund Order ID,Order Completed Date,Errors,Ignore?
+2,11/1/1973,hdoof@odl.mit.edu,,1,Heinz Doofenschmirtz,hdoof@odl.mit.edu,"Oct 20, 2019",Seed Differential Equations,"Sep 19, 2020",100,,,,,,,
+3,11/1/1944,pplatypus@odl.mit.edu,,1,Perry the Platypus,pplatypus@odl.mit.edu,"Oct 20, 2019",Seed Differential Equations,"Sep 19, 2020",50,,,,,,,


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1020 

#### What's this PR do?
Adds an admin for WireTransferReceipt. I largely copied this from the existing admin for Receipt

#### How should this be manually tested?
View the WireTransferReceipt in the django admin. If you don't have one, try creating one manually in the Django shell, or use the `import_wire_transfers` command.
