### PR TITLE
add filter for payment type in admin order

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -43,7 +43,7 @@ class OrderAdmin(TimestampedModelAdmin):
         "application_link",
     ]
     list_display = ("id", "get_user_email", "status", "application_id")
-    list_filter = ("status",)
+    list_filter = ("status", "payment_type")
     search_fields = ("user__email", "user__username")
     raw_id_fields = ("user", "application")
 


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/bootcamp-ecommerce/issues/1025

#### What's this PR do?
Adds Payment-Type filter on Order in the admin panel

#### How should this be manually tested?
Using an Admin account, navigate to Orders in the admin panel(/admin/ecommerce/order) you will see Payment-type filters on the right side. Simply click on any payment type to view its effect.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/42243411/94558085-ea969400-0278-11eb-8458-3e176fc2ca06.png)

