### PR TITLE
fixing variable name exceptions

### DIFF
--- a/cms/templates/partials/homepage-alumni.html
+++ b/cms/templates/partials/homepage-alumni.html
@@ -1,7 +1,7 @@
 {% load image_version_url wagtailcore_tags static %}
 <section class="global-community">
   <div class="banner-img">
-    <img src="{% image_version_url page.banner_image "fill-1920x200" %}" alt="{{ page.name }}" />
+    <img src="{% image_version_url page.banner_image "fill-1920x200" %}" alt="Alumni banner image" />
   </div>
   <div class="container element-content">
       <div class="row">

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -48,10 +48,10 @@
         if (typeof zE !== 'undefined') {
             zE('webWidget', 'prefill', {
                 name: {
-                    value: '{{user.name}}',
+                    value: '{% if user.is_authenticated %}{{ user.profile.name }}{% endif %}',
                 },
                 email: {
-                    value: '{{user.email}}',
+                    value: '{% if user.is_authenticated %}{{ user.email }}{% endif %}',
                 }
             });
             // set page title as a search term


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/bootcamp-ecommerce/issues/837
fixes https://github.com/mitodl/bootcamp-ecommerce/issues/1040

#### What's this PR do?
Removes variables causing exceptions

#### How should this be manually tested?
Go to any HomePage with/without logging in, and check the logs. 
You will observe the following exceptions:
##### Exception 1:
```
web_1     | [2020-10-01 09:00:28] DEBUG 18 [django.template] base.py:872 - [7a391725c1bd] - Exception while resolving variable 'name' in template 'home_page.html'.
web_1     | Traceback (most recent call last):
web_1     |   File "/usr/local/lib/python3.6/site-packages/django/template/base.py", line 829, in _resolve_lookup
web_1     |     current = current[bit]
web_1     |   File "/usr/local/lib/python3.6/site-packages/django/utils/functional.py", line 257, in inner
web_1     |     return func(self._wrapped, *args)
web_1     | TypeError: 'AnonymousUser' object is not subscriptable
web_1     |
web_1     | During handling of the above exception, another exception occurred:
web_1     |
web_1     | Traceback (most recent call last):
web_1     |   File "/usr/local/lib/python3.6/site-packages/django/template/base.py", line 837, in _resolve_lookup
web_1     |     current = getattr(current, bit)
web_1     |   File "/usr/local/lib/python3.6/site-packages/django/utils/functional.py", line 257, in inner
web_1     |     return func(self._wrapped, *args)
web_1     | AttributeError: 'AnonymousUser' object has no attribute 'name'
```

##### Exception 2:
```
web_1     | [2020-10-01 09:00:28] DEBUG 18 [django.template] base.py:872 - [7a391725c1bd] - Exception while resolving variable 'name' in template 'home_page.html'.
web_1     | Traceback (most recent call last):
web_1     |   File "/usr/local/lib/python3.6/site-packages/django/template/base.py", line 829, in _resolve_lookup
web_1     |     current = current[bit]
web_1     | TypeError: 'HomeAlumniSection' object is not subscriptable
web_1     |
web_1     | During handling of the above exception, another exception occurred:
web_1     |
web_1     | Traceback (most recent call last):
web_1     |   File "/usr/local/lib/python3.6/site-packages/django/template/base.py", line 837, in _resolve_lookup
web_1     |     current = getattr(current, bit)
web_1     | AttributeError: 'HomeAlumniSection' object has no attribute 'name'
web_1     |
web_1     | During handling of the above exception, another exception occurred:
web_1     |
web_1     | Traceback (most recent call last):
web_1     |   File "/usr/local/lib/python3.6/site-packages/django/template/base.py", line 843, in _resolve_lookup
web_1     |     current = current[int(bit)]
web_1     | ValueError: invalid literal for int() with base 10: 'name'
web_1     |
web_1     | During handling of the above exception, another exception occurred:
web_1     |
web_1     | Traceback (most recent call last):
web_1     |   File "/usr/local/lib/python3.6/site-packages/django/template/base.py", line 850, in _resolve_lookup
web_1     |     (bit, current))  # missing attribute
web_1     | django.template.base.VariableDoesNotExist: Failed lookup for key [name] in <HomeAlumniSection: Homepage Alumni Section>
```

#### Solutions:
`Exception 1` was raised because `User` model doesn't have any field named `name` and also because of `Anonymous User` in-case user was not logged in.
`Exception 2` was raised because `HomeAlumniSection` doesn't have any field named `name`.

#### Screenshots:
Our change doesn't effect how zendesk looks, it will render the same way, here is an example of `Anonymous User`:
![image](https://user-images.githubusercontent.com/42243411/94793443-e8a51000-03f3-11eb-94ca-29b67222060e.png)

In-case of Logged in User:
![image](https://user-images.githubusercontent.com/42243411/94793623-2f930580-03f4-11eb-8618-abe22c01bd8f.png)

