### PR TITLE
Added setting for overriding base SAML URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -67,6 +67,10 @@
       "description": "Email to send ecommerce alerts to",
       "required": false
     },
+    "BOOTCAMP_ECOMMERCE_SAML_BASE_URL": {
+      "description": "(Optional) If provided, this base URL will be used instead of BOOTCAMP_ECOMMERCE_BASE_URL for SAML login/logout URLs",
+      "required": false
+    },
     "BOOTCAMP_EMAIL_BACKEND": {
       "description": "The backend for email sending",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -878,7 +878,17 @@ DJOSER = {
 }
 
 # NovoEd SAML settings (using Bootcamps app as IdP)
-IDP_BASE_URL = urljoin(BOOTCAMP_ECOMMERCE_BASE_URL, "/idp")
+BOOTCAMP_ECOMMERCE_SAML_BASE_URL = get_string(
+    "BOOTCAMP_ECOMMERCE_SAML_BASE_URL",
+    None,
+    description=(
+        "(Optional) If provided, this base URL will be used instead of BOOTCAMP_ECOMMERCE_BASE_URL "
+        "for SAML login/logout URLs"
+    ),
+)
+IDP_BASE_URL = urljoin(
+    BOOTCAMP_ECOMMERCE_SAML_BASE_URL or BOOTCAMP_ECOMMERCE_BASE_URL, "/idp"
+)
 _novoed_saml_key = get_string(
     "NOVOED_SAML_KEY",
     None,


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #1008, #1015 

#### What's this PR do?
Adds a setting that allows use to override the base URL being used for SAML login/logout

#### How should this be manually tested?
In your .env, set `BOOTCAMP_ECOMMERCE_SAML_BASE_URL` to some URL, then run a Django shell and check the `IDP_BASE_URL` setting value (one liner: `docker-compose run --rm web ./manage.py shell -c "from django.conf import settings; print(settings.IDP_BASE_URL)"`)

Then remove that setting from your .env and confirm that settings value has the correct base URL (based on your `BOOTCAMP_ECOMMERCE_BASE_URL` setting)
