### PR TITLE
Show payment error message

### DIFF
--- a/static/js/components/PaymentDisplay.js
+++ b/static/js/components/PaymentDisplay.js
@@ -13,6 +13,7 @@ import FormError from "./forms/elements/FormError"
 import { closeDrawer } from "../reducers/drawer"
 import queries from "../lib/queries"
 import ButtonWithLoader from "./loaders/ButtonWithLoader"
+import SupportLink from "./SupportLink"
 import {
   formatRunDateRange,
   createForm,
@@ -91,12 +92,24 @@ export const PaymentDisplay = (props: Props) => {
           validate={validate}
           onSubmit={async (values, actions) => {
             const amount = values.amount
-            await sendPayment({
-              application_id: application.id,
-              payment_amount: roundToCent(amount)
-            })
-            actions.resetForm()
-            closeDrawer()
+            try {
+              await sendPayment({
+                application_id: application.id,
+                payment_amount: roundToCent(amount)
+              })
+              actions.resetForm()
+              closeDrawer()
+            } catch {
+              actions.setErrors({
+                amount: (
+                  <span>
+                    Something went wrong while submitting your payment. Please
+                    try again, or <SupportLink />
+                  </span>
+                )
+              })
+              actions.setSubmitting(false)
+            }
           }}
           render={({ isSubmitting, isValidating }) => (
             <Form>
@@ -129,6 +142,9 @@ const mapDispatchToProps = dispatch => ({
     const {
       body: { url, payload }
     } = result
+    if (!url || !payload) {
+      throw new Error(result.body)
+    }
     const form = createForm(url, payload)
     const body = document.querySelector("body")
     if (!body) {

--- a/static/js/components/PaymentDisplay_test.js
+++ b/static/js/components/PaymentDisplay_test.js
@@ -183,5 +183,23 @@ describe("PaymentDisplay", () => {
         }
       )
     })
+
+    it("calls setErrors if the payment API fails", async () => {
+      helper.handleRequestStub.withArgs(paymentAPI.toString()).returns({
+        status: 400,
+        body:   ["Invalid application state"]
+      })
+      const setErrorsStub = helper.sandbox.stub()
+      const setSubmittingStub = helper.sandbox.stub()
+      const { formik } = await renderFormik()
+      await formik.prop("onSubmit")(
+        { amount: 1 },
+        { setErrors: setErrorsStub, setSubmitting: setSubmittingStub }
+      )
+      sinon.assert.calledWith(setSubmittingStub, false)
+      sinon.assert.calledWith(setErrorsStub, {
+        amount: sinon.match.any
+      })
+    })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1014 

#### What's this PR do?
Shows a generic error message with a support link if the payment request fails.

#### How should this be manually tested?
- Find or create a valid application with a state of `AWAITING_PAYMENT`
- Change the state to `COMPLETED`
- Try to make a payment.  You should see an error message matching the one show in the screenshot below.


#### Screenshots (if appropriate)
<img width="580" alt="Screen Shot 2020-10-02 at 3 34 54 PM" src="https://user-images.githubusercontent.com/187676/94962734-e8c11080-04c4-11eb-878d-6f7c10394919.png">

