### PR TITLE
Added link to NovoEd from application dashboard

### DIFF
--- a/app.json
+++ b/app.json
@@ -339,6 +339,10 @@
       "description": "Contents of the SAML key for NovoEd ('\n' line separators)",
       "required": false
     },
+    "NOVOED_SAML_LOGIN_URL": {
+      "description": "The SP-initiated SAML login URL for NovoEd",
+      "required": false
+    },
     "PGBOUNCER_DEFAULT_POOL_SIZE": {
       "value": "50"
     },

--- a/klasses/serializers.py
+++ b/klasses/serializers.py
@@ -4,7 +4,7 @@ Serializers for bootcamps
 from rest_framework import serializers
 
 from cms.serializers import BootcampRunPageSerializer
-from klasses.models import Bootcamp, BootcampRun, Installment
+from klasses.models import Bootcamp, BootcampRun, Installment, BootcampRunEnrollment
 
 
 class InstallmentSerializer(serializers.ModelSerializer):
@@ -51,7 +51,16 @@ class BootcampRunSerializer(serializers.ModelSerializer):
             "bootcamp",
             "title",
             "run_key",
+            "novoed_course_stub",
             "start_date",
             "end_date",
             "installments",
         ]
+
+
+class BootcampRunEnrollmentSerializer(serializers.ModelSerializer):
+    """Serializer for BootcampRunEnrollment model"""
+
+    class Meta:
+        model = BootcampRunEnrollment
+        fields = ["id", "user_id", "bootcamp_run_id", "novoed_sync_date"]

--- a/klasses/serializers_test.py
+++ b/klasses/serializers_test.py
@@ -53,6 +53,7 @@ def test_bootcamp_run_serializer():
         "end_date": serializer_date_format(run.end_date),
         "run_key": run.run_key,
         "installments": [InstallmentSerializer(installment).data],
+        "novoed_course_stub": run.novoed_course_stub,
     }
 
 

--- a/main/context_processors.py
+++ b/main/context_processors.py
@@ -42,6 +42,7 @@ def js_settings(request):
                 "upload_max_size": settings.MAX_FILE_UPLOAD_MB * 1_000_000,
                 "support_url": settings.SUPPORT_URL,
                 "terms_url": get_resource_page_urls(request.site)["terms_of_service"],
+                "novoed_login_url": settings.NOVOED_SAML_LOGIN_URL,
             }
         )
     }

--- a/main/context_processors_test.py
+++ b/main/context_processors_test.py
@@ -84,4 +84,5 @@ def test_get_context_js_settings(mocker, settings, patched_get_resource_page_url
         "upload_max_size": 123_000_000,
         "support_url": settings.SUPPORT_URL,
         "terms_url": patched_get_resource_page_urls.return_value["terms_of_service"],
+        "novoed_login_url": settings.NOVOED_SAML_LOGIN_URL,
     }

--- a/main/settings.py
+++ b/main/settings.py
@@ -872,6 +872,11 @@ NOVOED_API_SECRET = get_string(
 NOVOED_API_BASE_URL = get_string(
     "NOVOED_API_BASE_URL", None, description="The base URL of the NovoEd API"
 )
+NOVOED_SAML_LOGIN_URL = get_string(
+    "NOVOED_SAML_LOGIN_URL",
+    None,
+    description="The SP-initiated SAML login URL for NovoEd",
+)
 
 # Relative URL to be used by Djoser for the link in the password reset email
 # (see: http://djoser.readthedocs.io/en/stable/settings.html#password-reset-confirm-url)

--- a/static/js/components/applications/detail_sections.js
+++ b/static/js/components/applications/detail_sections.js
@@ -220,10 +220,7 @@ export const PaymentDetail = (props: PaymentDetailProps): React$Element<*> => {
   const { ready, fulfilled, openDrawer, applicationDetail } = props
 
   return (
-    <ProgressDetailRow
-      className="payment"
-      fulfilled={applicationDetail.is_paid_in_full}
-    >
+    <ProgressDetailRow className="payment" fulfilled={fulfilled}>
       <h3>Payment</h3>
       <div className="col-12 col-sm-6 status-text">
         <span className="label">Deadline: </span>
@@ -242,6 +239,41 @@ export const PaymentDetail = (props: PaymentDetailProps): React$Element<*> => {
           >
             Make a Payment
           </button>
+        </div>
+      ) : null}
+    </ProgressDetailRow>
+  )
+}
+
+type BootcampStartProps = {
+  ready: boolean,
+  fulfilled: boolean,
+  applicationDetail: ApplicationDetail
+}
+
+export const BootcampStartDetail = (
+  props: BootcampStartProps
+): React$Element<*> => {
+  const { ready, fulfilled, applicationDetail } = props
+
+  return (
+    <ProgressDetailRow className="bootcampStart" fulfilled={fulfilled}>
+      <h3>Bootcamp Starts</h3>
+      {applicationDetail.bootcamp_run.start_date && (
+        <div className="col-12 col-sm-6 status-text">
+          <span className="label">Start Date: </span>
+          {formatReadableDateFromStr(applicationDetail.bootcamp_run.start_date)}
+        </div>
+      )}
+      {ready && fulfilled ? (
+        <div className="col-12 col-sm-5 text-sm-right">
+          <a
+            href={SETTINGS.novoed_login_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Start Bootcamp
+          </a>
         </div>
       ) : null}
     </ProgressDetailRow>

--- a/static/js/components/applications/detail_sections_test.js
+++ b/static/js/components/applications/detail_sections_test.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import { shallow } from "enzyme"
 import sinon from "sinon"
@@ -10,7 +11,8 @@ import {
   ResumeDetail,
   VideoInterviewDetail,
   ReviewDetail,
-  PaymentDetail
+  PaymentDetail,
+  BootcampStartDetail
 } from "./detail_sections"
 import {
   AWAITING_RESUME,
@@ -265,6 +267,39 @@ describe("application detail section component", () => {
       sinon.assert.calledWith(openDrawerStub, {
         type: PAYMENT,
         meta: { application: applicationDetail }
+      })
+    })
+  })
+
+  describe("BootcampStartDetail", () => {
+    let applicationDetail
+    beforeEach(() => {
+      applicationDetail = makeApplicationDetail()
+    })
+    //
+    ;[
+      [false, false, undefined],
+      [true, false, undefined],
+      [true, true, "Start Bootcamp"]
+    ].forEach(([ready, fulfilled, expLinkText]) => {
+      it(`should show correct link if ready === ${String(
+        ready
+      )}, fulfilled === ${String(fulfilled)}`, () => {
+        SETTINGS.novoed_login_url = "https://novoed.com"
+        const wrapper = shallow(
+          <BootcampStartDetail
+            {...defaultProps}
+            ready={ready}
+            fulfilled={fulfilled}
+            applicationDetail={applicationDetail}
+          />
+        )
+        const link = wrapper.find("ProgressDetailRow a")
+        assert.equal(link.exists(), expLinkText !== undefined)
+        if (expLinkText !== undefined) {
+          assert.equal(link.prop("children"), expLinkText)
+          assert.equal(link.prop("href"), SETTINGS.novoed_login_url)
+        }
       })
     })
   })

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -127,7 +127,8 @@ export const makeApplicationDetail = (): ApplicationDetail => {
     orders:                [generateOrder()],
     created_on:            moment().format(),
     price:                 price,
-    user:                  makeUser()
+    user:                  makeUser(),
+    enrollment:            null
   }
 }
 

--- a/static/js/factories/index.js
+++ b/static/js/factories/index.js
@@ -35,8 +35,9 @@ export const generateFakeRun = (): BootcampRun => ({
   end_date:      moment()
     .add(1, "days")
     .format(),
-  page:     generateFakeRunPage(),
-  bootcamp: {
+  novoed_course_stub: casual.word,
+  page:               generateFakeRunPage(),
+  bootcamp:           {
     // $FlowFixMe: this should always be a number, but flow doesn't know that
     id:    incr.next().value,
     title: casual.title

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -9,9 +9,9 @@ import {
   REVIEW_STATUS_PENDING
 } from "../constants"
 
-import type { BootcampRun } from "./bootcampTypes"
+import type { BootcampRun, BootcampRunEnrollment } from "./bootcampTypes"
 import type { User } from "./authTypes"
-import type {HttpResponse} from "./httpTypes"
+import type { HttpResponse } from "./httpTypes"
 
 export type Application = {
   id:           number,
@@ -74,7 +74,8 @@ export type ApplicationDetail = ResumeLinkedInDetail & {
   orders:                Array<ApplicationOrder>,
   created_on:            string,
   price:                 number,
-  user:                  User
+  user:                  User,
+  enrollment:            ?BootcampRunEnrollment,
 }
 
 export type SubmissionReview = {

--- a/static/js/flow/bootcampTypes.js
+++ b/static/js/flow/bootcampTypes.js
@@ -34,9 +34,17 @@ export type BootcampRun = {
   run_key: string,
   start_date: ?string,
   end_date: ?string,
+  novoed_course_stub: ?string,
   bootcamp: Bootcamp,
   page?: ?BootcampRunPage,
   installments: Array<Installment>,
+}
+
+export type BootcampRunEnrollment = {
+  id: number,
+  user_id: number,
+  bootcamp_run_id: number,
+  novoed_sync_date: ?string,
 }
 
 export type PayableBootcampRun = {

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -1,11 +1,12 @@
 // @flow
 declare var SETTINGS: {
-  gaTrackingID:    string,
-  reactGaDebug:    boolean,
-  recaptchaKey:    ?string,
-  upload_max_size: number,
-  support_url:     string,
-  terms_url:       string,
+  gaTrackingID:     string,
+  reactGaDebug:     boolean,
+  recaptchaKey:     ?string,
+  upload_max_size:  number,
+  support_url:      string,
+  terms_url:        string,
+  novoed_login_url: ?string,
   zendesk_config:  {
     help_widget_enabled: boolean,
     help_widget_key: ?string

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -15,6 +15,7 @@ import qs from "query-string"
 import { reverse } from "named-urls"
 
 import {
+  BootcampStartDetail,
   PaymentDetail,
   ProfileDetail,
   QuizDetail,
@@ -426,12 +427,27 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
       />
     )
 
+    const isNovoEdCourse = !!applicationDetail.bootcamp_run.novoed_course_stub
+    const novoEdEnrolled =
+      isNovoEdCourse &&
+      !!SETTINGS.novoed_login_url &&
+      !!applicationDetail.enrollment &&
+      !!applicationDetail.enrollment.novoed_sync_date
+    const bootcampStartRow = isNovoEdCourse ? (
+      <BootcampStartDetail
+        ready={novoEdEnrolled}
+        fulfilled={novoEdEnrolled}
+        applicationDetail={applicationDetail}
+      />
+    ) : null
+
     return (
       <div className="p-3 mt-3 application-detail">
         {profileRow}
         {resumeRow}
         {submissionStepRows}
         {paymentRow}
+        {bootcampStartRow}
       </div>
     )
   }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1031 

#### What's this PR do?
Adds a link from Bootcamps to NovoEd if a course is served through NovoEd and they are enrolled

#### How should this be manually tested?
- Add `NOVOED_SAML_LOGIN_URL=https://app.novoed.com/saml/sso?provider=mitbootcamps` to your `.env`
- Make sure you have an application started for some bootcamp run
- Add a `BootcampRunEnrollment` record for some user, then expand the detail section of that run in your app dashboard. You should see a "Start Bootcamp" link at the bottom going to that SAML URL above

#### Any background context you want to provide?
- **These "start bootcamp" links won't work locally.** That app.novoed link is the login link on production, which is already known to work.
- It's OK if there are unchecked bubbles above the "Bootcamp Starts" section. We have some scenarios where users have an enrollment despite not having completed all of the standard application steps. We will correct this UI wonkiness in a separate issue.
- This link will bring users to their NovoEd dashboard, which has a link to the enrolled bootcamp. Ideally we would link our users directly to the bootcamp in NovoEd, but I need to hear back from NovoEd about how we can do that. This dashboard link is sufficient in the meantime.

![ss 2020-10-06 at 09 01 07 ](https://user-images.githubusercontent.com/14932219/95226493-02b36980-07cb-11eb-8afb-e31e4d64494b.png)
