### PR TITLE
Added NovoEd link to title in collapsed dashboard card

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -30,7 +30,7 @@ from applications.models import (
 )
 from cms.models import LetterTemplatePage
 from ecommerce.models import Order
-from klasses.models import BootcampRun, Bootcamp, BootcampRunEnrollment
+from klasses.models import BootcampRun, Bootcamp
 from main.permissions import UserIsOwnerPermission, UserIsOwnerOrAdminPermission
 from main.utils import serializer_date_format
 
@@ -51,15 +51,7 @@ class BootcampApplicationViewset(
 
     def get_queryset(self):
         if self.action == "retrieve":
-            return BootcampApplication.objects.prefetch_state_data().prefetch_related(
-                Prefetch(
-                    "bootcamp_run__enrollments",
-                    queryset=BootcampRunEnrollment.objects.filter(
-                        user=self.request.user, active=True
-                    ),
-                    to_attr="application_enrollments",
-                )
-            )
+            return BootcampApplication.objects.prefetch_state_data()
         else:
             return (
                 BootcampApplication.objects.prefetch_related(
@@ -68,15 +60,14 @@ class BootcampApplicationViewset(
                     )
                 )
                 .filter(user=self.request.user)
-                .select_related("bootcamp_run__bootcamprunpage")
+                .select_related("bootcamp_run__bootcamprunpage", "user")
+                .prefetch_related("user__enrollments")
                 .order_by("-created_on")
             )
 
     def get_serializer_context(self):
         added_context = {}
-        if self.action == "retrieve":
-            added_context = {"include_enrollment": True}
-        elif self.action == "list":
+        if self.action == "list":
             added_context = {"include_page": True, "filtered_orders": True}
         return {**super().get_serializer_context(), **added_context}
 

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -3,7 +3,7 @@ import casual from "casual-browserify"
 import moment from "moment"
 import { sum } from "ramda"
 
-import { generateFakeRun, generateOrder } from "./index"
+import { generateFakeRun, generateOrder, generateFakeEnrollment } from "./index"
 import { incrementer } from "../util/util"
 import {
   APP_STATE_TEXT_MAP,
@@ -37,6 +37,7 @@ export const makeApplication = (): Application => ({
   state:        casual.random_element(Object.keys(APP_STATE_TEXT_MAP)),
   created_on:   moment().format(),
   bootcamp_run: generateFakeRun(),
+  enrollment:   generateFakeEnrollment(),
   has_payments: casual.boolean
 })
 

--- a/static/js/factories/index.js
+++ b/static/js/factories/index.js
@@ -6,6 +6,7 @@ import casual from "casual-browserify"
 import type {
   BootcampRun,
   BootcampRunPage,
+  BootcampRunEnrollment,
   Installment,
   PayableBootcampRun,
   Payment
@@ -65,6 +66,14 @@ export const generateFakePayableRuns = (
     payments:     hasPayment ? [generateFakePayment({ runKey: i + 1 })] : [],
     installments: hasInstallment ? [generateFakeInstallment()] : []
   }))
+
+export const generateFakeEnrollment = (): BootcampRunEnrollment => ({
+  // $FlowFixMe: flow thinks that this may be undefined, but it won't ever be
+  id:               incr.next().value,
+  user_id:          casual.integer,
+  bootcamp_run_id:  casual.integer,
+  novoed_sync_date: moment().format()
+})
 
 export const generateLegacyOrderPartial = (): LegacyOrderPartial => ({
   // $FlowFixMe: flow thinks that this may be undefined, but it won't ever be

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -18,6 +18,7 @@ export type Application = {
   state:        string,
   created_on:   any,
   bootcamp_run: BootcampRun,
+  enrollment:   ?BootcampRunEnrollment,
   has_payments: boolean,
 }
 

--- a/static/js/lib/applicationApi.js
+++ b/static/js/lib/applicationApi.js
@@ -1,3 +1,4 @@
+/* global SETTINGS: false */
 import * as R from "ramda"
 
 import { ORDER_STATUS_FAILED, ORDER_STATUS_FULFILLED } from "../constants"
@@ -44,3 +45,9 @@ export const findAppByRunTitle = (
       application.bootcamp_run.title === bootcampRunTitle
   )
 }
+
+export const isNovoEdEnrolled = (application: Application): boolean =>
+  !!application.bootcamp_run.novoed_course_stub &&
+  !!SETTINGS.novoed_login_url &&
+  !!application.enrollment &&
+  !!application.enrollment.novoed_sync_date

--- a/static/js/lib/applicationApi_test.js
+++ b/static/js/lib/applicationApi_test.js
@@ -1,3 +1,4 @@
+/* global SETTINGS: false */
 import { assert } from "chai"
 
 import * as api from "./applicationApi"
@@ -5,7 +6,7 @@ import {
   makeApplication,
   makeApplicationDetail
 } from "../factories/application"
-import { generateOrder } from "../factories"
+import { generateFakeEnrollment, generateOrder } from "../factories"
 import { ORDER_STATUS_FAILED, ORDER_STATUS_FULFILLED } from "../constants"
 
 describe("applications API", () => {
@@ -73,5 +74,20 @@ describe("applications API", () => {
       api.findAppByRunTitle(applications, titleToSearch),
       applications[0]
     )
+  })
+
+  it("isNovoEdEnrolled should return true if certain settings are present and an enrollment has been synced", () => {
+    SETTINGS.novoed_login_url = null
+    const application = makeApplication()
+    application.bootcamp_run.novoed_course_stub = null
+    application.enrollment = null
+    assert.isFalse(api.isNovoEdEnrolled(application))
+    SETTINGS.novoed_login_url = "http://novoed.com"
+    application.bootcamp_run.novoed_course_stub = "some-bootcamp"
+    application.enrollment = generateFakeEnrollment()
+    application.enrollment.novoed_sync_date = null
+    assert.isFalse(api.isNovoEdEnrolled(application))
+    application.enrollment.novoed_sync_date = "2020-01-01T00:00:00.000000Z"
+    assert.isTrue(api.isNovoEdEnrolled(application))
   })
 })

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -31,6 +31,7 @@ import { addErrorNotification, addSuccessNotification } from "../../actions"
 import { openDrawer } from "../../reducers/drawer"
 import {
   findAppByRunTitle,
+  isNovoEdEnrolled,
   isStatusPollingFinished
 } from "../../lib/applicationApi"
 import queries from "../../lib/queries"
@@ -427,12 +428,8 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
       />
     )
 
-    const isNovoEdCourse = !!applicationDetail.bootcamp_run.novoed_course_stub
-    const novoEdEnrolled =
-      isNovoEdCourse &&
-      !!SETTINGS.novoed_login_url &&
-      !!applicationDetail.enrollment &&
-      !!applicationDetail.enrollment.novoed_sync_date
+    const isNovoEdCourse = !!application.bootcamp_run.novoed_course_stub
+    const novoEdEnrolled = isNovoEdEnrolled(application)
     const bootcampStartRow = isNovoEdCourse ? (
       <BootcampStartDetail
         ready={novoEdEnrolled}
@@ -460,6 +457,7 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
     const thumbnailSrc = application.bootcamp_run.page ?
       application.bootcamp_run.page.thumbnail_image_src :
       null
+    const titleText = application.bootcamp_run.bootcamp.title
 
     return (
       <div className="application-card" key={application.id}>
@@ -469,7 +467,20 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
           <div className="container p-0 pt-3 pt-sm-0 pl-sm-3 application-card-top">
             <div className="row">
               <div className={`col-12 col-md-6 mr-auto no-padding`}>
-                <h2>{application.bootcamp_run.bootcamp.title}</h2>
+                <h2>
+                  {isNovoEdEnrolled(application) ? (
+                    <a
+                      href={SETTINGS.novoed_login_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {titleText}
+                      <i className="material-icons">open_in_new</i>
+                    </a>
+                  ) : (
+                    titleText
+                  )}
+                </h2>
                 <div className="run-details">
                   <div>
                     <span className="label">Location:</span>{" "}

--- a/static/scss/application.scss
+++ b/static/scss/application.scss
@@ -21,6 +21,23 @@ $border-style: 1px solid $black;
     color: $med-dark-gray;
   }
 
+  h2 a {
+    display: inline-flex;
+    align-items: center;
+
+    i {
+      padding-left: 3px;
+    }
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    &:visited {
+      color: $link-blue;
+    }
+  }
+
   .run-details {
     .w-100 {
       margin-bottom: 8px;


### PR DESCRIPTION
#### What are the relevant tickets?
Improves upon #1031 

#### What's this PR do?
Adds a NovoEd link to the bootcamp title in the collapsed view if a user is successfully enrolled in the application bootcamp run, and that run is configured for NovoEd

#### How should this be manually tested?
- Set the following env var in your `.env`: `NOVOED_SAML_LOGIN_URL=http://example.com`
- For some bootcamp run that your user has an application for, set the `novoed_course_stub` field to some random string
- Add a `BootcampRunEnrollment` record for the given application's bootcamp run and user

Now when you visit your application dashboard, the title of that bootcamp should be a link to your `NOVOED_SAML_LOGIN_URL` setting

#### Screenshots (if appropriate)
![ss 2020-10-07 at 12 17 02 ](https://user-images.githubusercontent.com/14932219/95363378-64440880-089d-11eb-9099-907a7b5ec10e.png)
