### PR TITLE
Prevented payment if bootcamp run start date is in the past

### DIFF
--- a/klasses/models.py
+++ b/klasses/models.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.db import models
 
 from main.models import TimestampedModel
+from main.utils import now_in_utc
 from klasses.constants import (
     ApplicationSource,
     INTEGRATION_PREFIX_PRODUCT,
@@ -153,6 +154,20 @@ class BootcampRun(models.Model):
             str: the integration id
         """
         return f"{INTEGRATION_PREFIX_PRODUCT}{self.id}"
+
+    @property
+    def is_payable(self):
+        """
+        Returns True if the start date is set and is in the future
+
+        Returns:
+            bool: True if the start date is set and is in the future
+        """
+        # NOTE: We have an Installment model with a 'deadline' property. Those installments are meant to
+        # specify increments when a user should pay for the bootcamp run. Practically, those deadlines are just
+        # "suggestions". For now, we're making a conscious decision to prevent a user from making payments based on
+        # the bootcamp run start date rather than the last installment deadline date.
+        return self.start_date is not None and now_in_utc() < self.start_date
 
     def personal_price(self, user):
         """

--- a/klasses/models_test.py
+++ b/klasses/models_test.py
@@ -101,6 +101,21 @@ def test_bootcamp_run_display_title():
     assert bootcamp_run_without_dates.display_title == bootcamp_title
 
 
+@pytest.mark.parametrize(
+    "future_start_date,expected_result", [[True, True], [False, False], [None, False]]
+)
+def test_bootcamp_run_is_payable(future_start_date, expected_result):
+    """is_payable should return True if the start date is set and is in the future"""
+    if future_start_date is None:
+        start_date = None
+    elif future_start_date:
+        start_date = now_in_utc() + timedelta(days=10)
+    else:
+        start_date = now_in_utc() - timedelta(days=10)
+    run = BootcampRunFactory.build(start_date=start_date)
+    assert run.is_payable is expected_result
+
+
 def test_next_installment():
     """
     It should return the installment with the closest date to now in the future

--- a/klasses/serializers.py
+++ b/klasses/serializers.py
@@ -54,6 +54,7 @@ class BootcampRunSerializer(serializers.ModelSerializer):
             "novoed_course_stub",
             "start_date",
             "end_date",
+            "is_payable",
             "installments",
         ]
 

--- a/klasses/serializers_test.py
+++ b/klasses/serializers_test.py
@@ -1,6 +1,8 @@
 """
 Tests for bootcamp serializers
 """
+from datetime import timedelta
+
 import pytest
 
 from cms.factories import BootcampRunPageFactory
@@ -11,7 +13,7 @@ from klasses.serializers import (
     BootcampRunSerializer,
     InstallmentSerializer,
 )
-from main.utils import serializer_date_format
+from main.utils import serializer_date_format, now_in_utc
 
 # pylint: disable=missing-docstring,redefined-outer-name,unused-argument
 
@@ -42,7 +44,7 @@ def test_bootcamp_serializer():
 
 def test_bootcamp_run_serializer():
     """BootcampRunSerializer should serialize the bootcamp run"""
-    run = BootcampRunFactory.create()
+    run = BootcampRunFactory.create(start_date=now_in_utc() + timedelta(days=10))
     installment = InstallmentFactory.create(bootcamp_run=run)
     assert BootcampRunSerializer(run).data == {
         "id": run.id,
@@ -54,6 +56,7 @@ def test_bootcamp_run_serializer():
         "run_key": run.run_key,
         "installments": [InstallmentSerializer(installment).data],
         "novoed_course_stub": run.novoed_course_stub,
+        "is_payable": True,
     }
 
 

--- a/static/js/factories/index.js
+++ b/static/js/factories/index.js
@@ -43,7 +43,8 @@ export const generateFakeRun = (): BootcampRun => ({
     id:    incr.next().value,
     title: casual.title
   },
-  installments: _.times(2).map(() => generateFakeInstallment())
+  installments: _.times(2).map(() => generateFakeInstallment()),
+  is_payable:   casual.boolean
 })
 
 export const generateFakePayableRuns = (

--- a/static/js/flow/bootcampTypes.js
+++ b/static/js/flow/bootcampTypes.js
@@ -38,6 +38,7 @@ export type BootcampRun = {
   bootcamp: Bootcamp,
   page?: ?BootcampRunPage,
   installments: Array<Installment>,
+  is_payable: boolean
 }
 
 export type BootcampRunEnrollment = {

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -372,7 +372,7 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
       />
     )
 
-    let stepFulfilled, submissionApproved
+    let stepFulfilled, submissionApproved, paymentReady
     const submissionStepRows = applicationDetail.run_application_steps.map(
       (step: ApplicationRunStep) => {
         // If this is the first required submission, the user should only be able
@@ -415,10 +415,15 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
       }
     )
 
-    // If there are no submissions required for this application, payment should be ready after the resume
-    // requirement is fulfilled. Otherwise, it should only be ready if the last submission was approved.
-    const paymentReady =
-      submissionApproved === undefined ? resumeFulfilled : submissionApproved
+    if (!application.bootcamp_run.is_payable) {
+      paymentReady = false
+    } else {
+      // If there are no submissions required for this application, payment should be ready after the resume
+      // requirement is fulfilled. Otherwise, it should only be ready if the last submission was approved.
+      paymentReady =
+        submissionApproved === undefined ? resumeFulfilled : submissionApproved
+    }
+
     const paymentRow = (
       <PaymentDetail
         ready={paymentReady}

--- a/static/js/pages/applications/ApplicationDashboardPage_test.js
+++ b/static/js/pages/applications/ApplicationDashboardPage_test.js
@@ -350,11 +350,14 @@ describe("ApplicationDashboardPage", () => {
 
     //
     ;[
-      [false, false, "before submissions are approved"],
-      [true, false, "before the user finishes paying"],
-      [true, true, "after payment is complete"]
-    ].forEach(([submissionsComplete, hasPaid, desc]) => {
+      [false, false, true, "before submissions are approved"],
+      [true, false, true, "before the user finishes paying"],
+      [true, true, true, "after payment is complete"],
+      [true, true, false, "if the run is no longer payable"]
+    ].forEach(([submissionsComplete, hasPaid, isPayable, desc]) => {
       it(`shows details about payment status ${desc}`, async () => {
+        const newApplication = Object.assign({}, application)
+        newApplication.bootcamp_run.is_payable = isPayable
         let newApplicationDetail = Object.assign({}, applicationDetail)
         if (!submissionsComplete) {
           newApplicationDetail = setToAwaitingReview(newApplicationDetail)
@@ -365,6 +368,7 @@ describe("ApplicationDashboardPage", () => {
         }
         const props = {
           ...defaultProps,
+          applications:         [newApplication],
           allApplicationDetail: {
             [application.id]: newApplicationDetail
           }
@@ -374,7 +378,7 @@ describe("ApplicationDashboardPage", () => {
         const paymentDetail = wrapper.find("PaymentDetail")
         assert.isTrue(paymentDetail.exists())
         assert.deepEqual(paymentDetail.props(), {
-          ready:             submissionsComplete,
+          ready:             submissionsComplete && isPayable,
           fulfilled:         hasPaid,
           openDrawer:        openDrawerStub,
           applicationDetail: newApplicationDetail


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
Fixes issue where users are still able to pay after the bootcamp run has started

#### How should this be manually tested?
Set your application to the awaiting payment state, and set the bootcamp run start date in the future. You should see a link to submit payment. Then set the start date to the past and reload the page. That link should no longer be shown

#### Any background context you want to provide?
There's a code comment that explains why we're using bootcamp run start date instead of installment deadlines to determine whether or not a user should be shown a payment link
