### PR TITLE
Added cms-login to bootcamp-login redirection

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -13,7 +13,7 @@ from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.images.views.serve import ServeView
 
-from main.views import react, BackgroundImagesCSSView
+from main.views import react, BackgroundImagesCSSView, cms_login_redirect_view
 
 root_urlpatterns = [url("", include(wagtail_urls))]
 
@@ -68,6 +68,7 @@ urlpatterns = (
         ),
         re_path(r"^review/", react, name="review"),
         # Wagtail
+        re_path(r"^cms/login", cms_login_redirect_view, name="wagtailadmin_login"),
         re_path(
             r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
             ServeView.as_view(),

--- a/main/urls.py
+++ b/main/urls.py
@@ -68,12 +68,12 @@ urlpatterns = (
         ),
         re_path(r"^review/", react, name="review"),
         # Wagtail
-        re_path(r"^cms/login", cms_login_redirect_view, name="wagtailadmin_login"),
         re_path(
             r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
             ServeView.as_view(),
             name="wagtailimages_serve",
         ),
+        re_path(r"^cms/login", cms_login_redirect_view, name="wagtailadmin_login"),
         re_path(r"^cms/", include(wagtailadmin_urls)),
         re_path(r"^documents/", include(wagtaildocs_urls)),
         re_path(r"^idp/", include("djangosaml2idp.urls")),

--- a/main/views.py
+++ b/main/views.py
@@ -3,10 +3,11 @@ bootcamp views
 """
 import json
 
+from django.contrib.auth.views import redirect_to_login
 from django.shortcuts import render, redirect, reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
-
+from main import settings
 from main.utils import has_all_keys
 
 
@@ -96,3 +97,10 @@ def page_500(request, *args, **kwargs):  # pylint: disable=unused-argument
     Overridden handler for the 404 error pages.
     """
     return standard_error_page(request, 500, "500.html")
+
+
+def cms_login_redirect_view(request):
+    """
+    Redirects wagtain's login page to site's login page
+    """
+    return redirect_to_login(reverse("wagtailadmin_home"), login_url=settings.LOGIN_URL)

--- a/main/views.py
+++ b/main/views.py
@@ -3,11 +3,12 @@ bootcamp views
 """
 import json
 
+from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
 from django.shortcuts import render, redirect, reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
-from main import settings
+
 from main.utils import has_all_keys
 
 
@@ -101,6 +102,6 @@ def page_500(request, *args, **kwargs):  # pylint: disable=unused-argument
 
 def cms_login_redirect_view(request):
     """
-    Redirects wagtain's login page to site's login page
+    Redirects cms login page to site's login page
     """
     return redirect_to_login(reverse("wagtailadmin_home"), login_url=settings.LOGIN_URL)

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -61,3 +61,12 @@ def test_cybersource_context(client, user):
         "bootcamp_run_purchased": fake_title,
         "purchase_date_utc": fake_datetime,
     }
+
+
+@pytest.mark.django_db
+def test_cms_login_redirection(client, settings):
+    """
+    Test that login page of cms redirects user to login page of site
+    """
+    response = client.get("/cms", follow=True)
+    assert response.request["PATH_INFO"] == settings.LOGIN_URL


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1059 

#### What's this PR do?
This PR is an attempt to fix the ambiguity issue where we had two different login pages for site and cms. Now whenever users would open CMS's login page he will they will be redirected to the login page of the site instead of cms, hence creating a single entry point for login.

#### How should this be manually tested?
Open login page of cms. e.g. log out of bootcamps and then hit `/cms` URL. you should be redirected to the site's login page instead.
