### PR TITLE
Filter submissions by run instead of bootcamp

### DIFF
--- a/applications/filters.py
+++ b/applications/filters.py
@@ -7,9 +7,8 @@ from applications.models import ApplicationStepSubmission
 class ApplicationStepSubmissionFilterSet(FilterSet):
     """FilterSet for ApplicationStepSubmission"""
 
-    bootcamp_id = NumberFilter(
-        field_name="bootcamp_application__bootcamp_run__bootcamp_id",
-        lookup_expr="exact",
+    bootcamp_run_id = NumberFilter(
+        field_name="bootcamp_application__bootcamp_run__id", lookup_expr="exact"
     )
 
     class Meta:

--- a/applications/filters_test.py
+++ b/applications/filters_test.py
@@ -19,7 +19,7 @@ def test_application_step_submission_filterset_bootcamp_id():
     matching = ApplicationStepSubmissionFactory.create()
     nonmatching = ApplicationStepSubmissionFactory.create()
 
-    params = {"bootcamp_id": matching.bootcamp_application.bootcamp_run.bootcamp.id}
+    params = {"bootcamp_run_id": matching.bootcamp_application.bootcamp_run.id}
 
     query = ApplicationStepSubmissionFilterSet(
         params, queryset=ApplicationStepSubmission.objects.all()

--- a/applications/views.py
+++ b/applications/views.py
@@ -131,19 +131,19 @@ class ReviewSubmissionPagination(LimitOffsetPagination):
             .order_by("count")
         )
         qs = (
-            queryset.values("bootcamp_application__bootcamp_run__bootcamp")
-            .filter(bootcamp_application__bootcamp_run__bootcamp=OuterRef("pk"))
+            queryset.values("bootcamp_application__bootcamp_run")
+            .filter(bootcamp_application__bootcamp_run=OuterRef("pk"))
             .order_by()
             .annotate(count=Count("*"))
             .values("count")
         )
-        bootcamps = (
-            Bootcamp.objects.values("id", "title")
+        bootcamp_runs = (
+            BootcampRun.objects.values("id", "title")
             .annotate(count=Subquery(qs, output_field=IntegerField()))
             .filter(count__gte=1)
             .distinct()
         )
-        return {"review_statuses": statuses, "bootcamps": bootcamps}
+        return {"review_statuses": statuses, "bootcamp_runs": bootcamp_runs}
 
 
 class ReviewSubmissionViewSet(

--- a/applications/views.py
+++ b/applications/views.py
@@ -138,7 +138,7 @@ class ReviewSubmissionPagination(LimitOffsetPagination):
             .values("count")
         )
         bootcamp_runs = (
-            BootcampRun.objects.values("id", "title", "start_date")
+            BootcampRun.objects.values("id", "title", "start_date", "end_date")
             .annotate(count=Subquery(qs, output_field=IntegerField()))
             .filter(count__gte=1)
             .distinct()

--- a/applications/views.py
+++ b/applications/views.py
@@ -30,9 +30,9 @@ from applications.models import (
 )
 from cms.models import LetterTemplatePage
 from ecommerce.models import Order
-from klasses.models import BootcampRun, Bootcamp
+from klasses.models import BootcampRun
 from main.permissions import UserIsOwnerPermission, UserIsOwnerOrAdminPermission
-from main.utils import serializer_date_format
+from main.utils import serializer_date_format, now_in_utc
 
 
 class BootcampApplicationViewset(
@@ -138,7 +138,7 @@ class ReviewSubmissionPagination(LimitOffsetPagination):
             .values("count")
         )
         bootcamp_runs = (
-            BootcampRun.objects.values("id", "title")
+            BootcampRun.objects.values("id", "title", "start_date")
             .annotate(count=Subquery(qs, output_field=IntegerField()))
             .filter(count__gte=1)
             .distinct()
@@ -164,6 +164,7 @@ class ReviewSubmissionViewSet(
         ApplicationStepSubmission.objects.filter(
             Q(submission_status=SUBMISSION_STATUS_SUBMITTED)
             & Q(bootcamp_application__state__in=REVIEWABLE_APP_STATES)
+            & Q(bootcamp_application__bootcamp_run__end_date__gte=now_in_utc())
         )
         .select_related(
             "bootcamp_application__user__profile",

--- a/applications/views_test.py
+++ b/applications/views_test.py
@@ -207,6 +207,7 @@ def test_review_submission_list(admin_drf_client, submission_factory):
                     "id": bootcamp_run.id,
                     "title": bootcamp_run.title,
                     "start_date": serializer_date_format(bootcamp_run.start_date),
+                    "end_date": serializer_date_format(bootcamp_run.end_date),
                     "count": 4,
                 }
                 for bootcamp_run in sorted(bootcamp_runs, key=lambda b: b.id)
@@ -275,6 +276,7 @@ def test_review_submission_list_query_bootcamp_run_id(admin_drf_client):
                     "id": bootcamp_run.id,
                     "title": bootcamp_run.title,
                     "start_date": serializer_date_format(bootcamp_run.start_date),
+                    "end_date": serializer_date_format(bootcamp_run.end_date),
                     "count": 1,
                 }
             ],
@@ -326,6 +328,7 @@ def test_review_submission_list_query_review_status(admin_drf_client, review_sta
                     "id": bootcamp_run.id,
                     "title": bootcamp_run.title,
                     "start_date": serializer_date_format(bootcamp_run.start_date),
+                    "end_date": serializer_date_format(bootcamp_run.end_date),
                     "count": 1,
                 }
             ],
@@ -390,6 +393,7 @@ def test_review_submission_list_query_review_status_in(
                     "id": bootcamp_run.id,
                     "title": bootcamp_run.title,
                     "start_date": serializer_date_format(bootcamp_run.start_date),
+                    "end_date": serializer_date_format(bootcamp_run.end_date),
                     "count": 1,
                 }
                 for bootcamp_run in sorted(bootcamp_runs, key=lambda b: b.id)

--- a/static/js/components/SubmissionFacets.js
+++ b/static/js/components/SubmissionFacets.js
@@ -8,7 +8,7 @@ import { identity } from "ramda"
 
 import {
   STATUS_FACET_KEY,
-  BOOTCAMP_FACET_KEY,
+  BOOTCAMP_RUN_FACET_KEY,
   FACET_DISPLAY_NAMES,
   FACET_OPTION_LABEL_KEYS,
   FACET_ORDER,
@@ -22,15 +22,15 @@ export const facetOptionSerialization = {
     qsKey:      "review_status",
     getQSValue: prop("review_status")
   },
-  [BOOTCAMP_FACET_KEY]: {
-    qsKey:      "bootcamp_id",
+  [BOOTCAMP_RUN_FACET_KEY]: {
+    qsKey:      "bootcamp_run_id",
     getQSValue: prop("id")
   }
 }
 
 export const facetOptionLabels = {
   [STATUS_FACET_KEY]:   status => REVIEW_STATUS_DISPLAY_MAP[status][0],
-  [BOOTCAMP_FACET_KEY]: identity
+  [BOOTCAMP_RUN_FACET_KEY]: identity
 }
 
 type OptionProps = {

--- a/static/js/components/SubmissionFacets.js
+++ b/static/js/components/SubmissionFacets.js
@@ -70,9 +70,11 @@ export function Option({ option, facetKey }: OptionProps) {
     facetIsActive ? "font-weight-bold" : ""
   }`.trim()
 
+  const facetLabelParams = labelKey.map(label => option[label])
+
   return (
     <div className={className} onClick={cb}>
-      {facetOptionLabels[facetKey](labelKey.map(label => option[label]))}
+      {facetOptionLabels[facetKey](facetLabelParams)}
     </div>
   )
 }

--- a/static/js/components/SubmissionFacets.js
+++ b/static/js/components/SubmissionFacets.js
@@ -4,7 +4,6 @@ import qs from "query-string"
 import urljoin from "url-join"
 import { prop, omit } from "ramda"
 import { useLocation, useHistory } from "react-router"
-import { identity } from "ramda"
 
 import {
   STATUS_FACET_KEY,
@@ -16,7 +15,7 @@ import {
 } from "../constants"
 
 import type { FacetOption, SubmissionFacetData } from "../flow/applicationTypes"
-import {formatReadableDateFromStr} from "../util/util"
+import { formatReadableDateFromStr } from "../util/util"
 
 export const facetOptionSerialization = {
   [STATUS_FACET_KEY]: {
@@ -30,8 +29,9 @@ export const facetOptionSerialization = {
 }
 
 export const facetOptionLabels = {
-  [STATUS_FACET_KEY]:   ([status]) => REVIEW_STATUS_DISPLAY_MAP[status][0],
-  [BOOTCAMP_RUN_FACET_KEY]: ([title, startDate]) => `${title}: ${startDate ? formatReadableDateFromStr(startDate) : "TBD"}`
+  [STATUS_FACET_KEY]:       ([status]) => REVIEW_STATUS_DISPLAY_MAP[status][0],
+  [BOOTCAMP_RUN_FACET_KEY]: ([title, startDate]) =>
+    `${title}: ${startDate ? formatReadableDateFromStr(startDate) : "TBD"}`
 }
 
 type OptionProps = {
@@ -72,7 +72,7 @@ export function Option({ option, facetKey }: OptionProps) {
 
   return (
     <div className={className} onClick={cb}>
-      {facetOptionLabels[facetKey](labelKey.map(label=>option[label]))}
+      {facetOptionLabels[facetKey](labelKey.map(label => option[label]))}
     </div>
   )
 }

--- a/static/js/components/SubmissionFacets.js
+++ b/static/js/components/SubmissionFacets.js
@@ -15,7 +15,7 @@ import {
 } from "../constants"
 
 import type { FacetOption, SubmissionFacetData } from "../flow/applicationTypes"
-import { formatReadableDateFromStr } from "../util/util"
+import { formatStartEndDateStrings } from "../util/util"
 
 export const facetOptionSerialization = {
   [STATUS_FACET_KEY]: {
@@ -30,8 +30,8 @@ export const facetOptionSerialization = {
 
 export const facetOptionLabels = {
   [STATUS_FACET_KEY]:       ([status]) => REVIEW_STATUS_DISPLAY_MAP[status][0],
-  [BOOTCAMP_RUN_FACET_KEY]: ([title, startDate]) =>
-    `${title}: ${startDate ? formatReadableDateFromStr(startDate) : "TBD"}`
+  [BOOTCAMP_RUN_FACET_KEY]: ([title, startDate, endDate]) =>
+    `${title}: ${formatStartEndDateStrings(startDate, endDate)}`
 }
 
 type OptionProps = {

--- a/static/js/components/SubmissionFacets.js
+++ b/static/js/components/SubmissionFacets.js
@@ -16,6 +16,7 @@ import {
 } from "../constants"
 
 import type { FacetOption, SubmissionFacetData } from "../flow/applicationTypes"
+import {formatReadableDateFromStr} from "../util/util"
 
 export const facetOptionSerialization = {
   [STATUS_FACET_KEY]: {
@@ -29,8 +30,8 @@ export const facetOptionSerialization = {
 }
 
 export const facetOptionLabels = {
-  [STATUS_FACET_KEY]:   status => REVIEW_STATUS_DISPLAY_MAP[status][0],
-  [BOOTCAMP_RUN_FACET_KEY]: identity
+  [STATUS_FACET_KEY]:   ([status]) => REVIEW_STATUS_DISPLAY_MAP[status][0],
+  [BOOTCAMP_RUN_FACET_KEY]: ([title, startDate]) => `${title}: ${startDate ? formatReadableDateFromStr(startDate) : "TBD"}`
 }
 
 type OptionProps = {
@@ -71,7 +72,7 @@ export function Option({ option, facetKey }: OptionProps) {
 
   return (
     <div className={className} onClick={cb}>
-      {facetOptionLabels[facetKey](option[labelKey])}
+      {facetOptionLabels[facetKey](labelKey.map(label=>option[label]))}
     </div>
   )
 }

--- a/static/js/components/SubmissionFacets_test.js
+++ b/static/js/components/SubmissionFacets_test.js
@@ -33,14 +33,17 @@ describe("SubmissionFacets", () => {
       .find(".facet")
       .at(0)
       .find("Option")
-    facets.bootcamp_runs.forEach(({ title, startDate }, i) => {
+    // $FlowFixMe
+    facets.bootcamp_runs.forEach(({ title, startDate, endDate }, i) => {
       assert.equal(
         bootcampFacetOptions.at(i).prop("facetKey"),
         BOOTCAMP_RUN_FACET_KEY
       )
       assert.equal(
         bootcampFacetOptions.at(i).text(),
-        `${title}: ${formatReadableDateFromStr(startDate)}`
+        `${title}: ${formatReadableDateFromStr(
+          startDate
+        )} - ${formatReadableDateFromStr(endDate)}`
       )
     })
 

--- a/static/js/components/SubmissionFacets_test.js
+++ b/static/js/components/SubmissionFacets_test.js
@@ -8,7 +8,7 @@ import SubmissionFacets from "./SubmissionFacets"
 import { makeApplicationFacets } from "../factories/application"
 import {
   STATUS_FACET_KEY,
-  BOOTCAMP_FACET_KEY,
+  BOOTCAMP_RUN_FACET_KEY,
   REVIEW_STATUS_DISPLAY_MAP
 } from "../constants"
 
@@ -35,7 +35,7 @@ describe("SubmissionFacets", () => {
     facets.bootcamps.forEach(({ title }, i) => {
       assert.equal(
         bootcampFacetOptions.at(i).prop("facetKey"),
-        BOOTCAMP_FACET_KEY
+        BOOTCAMP_RUN_FACET_KEY
       )
       assert.equal(bootcampFacetOptions.at(i).text(), title)
     })

--- a/static/js/components/SubmissionFacets_test.js
+++ b/static/js/components/SubmissionFacets_test.js
@@ -11,6 +11,7 @@ import {
   BOOTCAMP_RUN_FACET_KEY,
   REVIEW_STATUS_DISPLAY_MAP
 } from "../constants"
+import {formatReadableDateFromStr} from "../util/util"
 
 describe("SubmissionFacets", () => {
   let helper, facets, render
@@ -32,12 +33,12 @@ describe("SubmissionFacets", () => {
       .find(".facet")
       .at(0)
       .find("Option")
-    facets.bootcamps.forEach(({ title }, i) => {
+    facets.bootcamp_runs.forEach(({ title, startDate }, i) => {
       assert.equal(
         bootcampFacetOptions.at(i).prop("facetKey"),
         BOOTCAMP_RUN_FACET_KEY
       )
-      assert.equal(bootcampFacetOptions.at(i).text(), title)
+      assert.equal(bootcampFacetOptions.at(i).text(), `${title}: ${formatReadableDateFromStr(startDate)}`)
     })
 
     const reviewFacetOptions = wrapper
@@ -57,7 +58,7 @@ describe("SubmissionFacets", () => {
   it("should bold options that are currently selected", async () => {
     const url = `/?${qs.stringify({
       review_status: facets.review_statuses[0].review_status,
-      bootcamp_id:   facets.bootcamps[0].id
+      bootcamp_run_id:   facets.bootcamp_runs[0].id
     })}`
     helper.browserHistory.push(url)
 
@@ -89,7 +90,7 @@ describe("SubmissionFacets", () => {
 
     assert.equal(
       helper.currentLocation.search,
-      "?bootcamp_id=1&review_status=approved"
+      "?bootcamp_run_id=1&review_status=approved"
     )
   })
 })

--- a/static/js/components/SubmissionFacets_test.js
+++ b/static/js/components/SubmissionFacets_test.js
@@ -11,7 +11,7 @@ import {
   BOOTCAMP_RUN_FACET_KEY,
   REVIEW_STATUS_DISPLAY_MAP
 } from "../constants"
-import {formatReadableDateFromStr} from "../util/util"
+import { formatReadableDateFromStr } from "../util/util"
 
 describe("SubmissionFacets", () => {
   let helper, facets, render
@@ -38,7 +38,10 @@ describe("SubmissionFacets", () => {
         bootcampFacetOptions.at(i).prop("facetKey"),
         BOOTCAMP_RUN_FACET_KEY
       )
-      assert.equal(bootcampFacetOptions.at(i).text(), `${title}: ${formatReadableDateFromStr(startDate)}`)
+      assert.equal(
+        bootcampFacetOptions.at(i).text(),
+        `${title}: ${formatReadableDateFromStr(startDate)}`
+      )
     })
 
     const reviewFacetOptions = wrapper
@@ -57,8 +60,8 @@ describe("SubmissionFacets", () => {
 
   it("should bold options that are currently selected", async () => {
     const url = `/?${qs.stringify({
-      review_status: facets.review_statuses[0].review_status,
-      bootcamp_run_id:   facets.bootcamp_runs[0].id
+      review_status:   facets.review_statuses[0].review_status,
+      bootcamp_run_id: facets.bootcamp_runs[0].id
     })}`
     helper.browserHistory.push(url)
 

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -229,7 +229,7 @@ export const FACET_DISPLAY_NAMES = {
 
 export const FACET_OPTION_LABEL_KEYS = {
   [STATUS_FACET_KEY]:       ["review_status"],
-  [BOOTCAMP_RUN_FACET_KEY]: ["title", "start_date"]
+  [BOOTCAMP_RUN_FACET_KEY]: ["title", "start_date", "end_date"]
 }
 
 export const FACET_ORDER = [BOOTCAMP_RUN_FACET_KEY, STATUS_FACET_KEY]

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -220,19 +220,19 @@ export const ALLOWED_FILE_EXTENSIONS = {
 
 // Submission facets
 export const STATUS_FACET_KEY = "review_statuses"
-export const BOOTCAMP_FACET_KEY = "bootcamps"
+export const BOOTCAMP_RUN_FACET_KEY = "bootcamp_runs"
 
 export const FACET_DISPLAY_NAMES = {
   [STATUS_FACET_KEY]:   "Application Status",
-  [BOOTCAMP_FACET_KEY]: "Bootcamp"
+  [BOOTCAMP_RUN_FACET_KEY]: "Bootcamp Run"
 }
 
 export const FACET_OPTION_LABEL_KEYS = {
   [STATUS_FACET_KEY]:   "review_status",
-  [BOOTCAMP_FACET_KEY]: "title"
+  [BOOTCAMP_RUN_FACET_KEY]: "title"
 }
 
-export const FACET_ORDER = [BOOTCAMP_FACET_KEY, STATUS_FACET_KEY]
+export const FACET_ORDER = [BOOTCAMP_RUN_FACET_KEY, STATUS_FACET_KEY]
 
 export const CS_101 = "CS_101"
 export const CS_102 = "CS_102"

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -228,8 +228,8 @@ export const FACET_DISPLAY_NAMES = {
 }
 
 export const FACET_OPTION_LABEL_KEYS = {
-  [STATUS_FACET_KEY]:   "review_status",
-  [BOOTCAMP_RUN_FACET_KEY]: "title"
+  [STATUS_FACET_KEY]:   ["review_status"],
+  [BOOTCAMP_RUN_FACET_KEY]: ["title", "start_date"]
 }
 
 export const FACET_ORDER = [BOOTCAMP_RUN_FACET_KEY, STATUS_FACET_KEY]

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -223,12 +223,12 @@ export const STATUS_FACET_KEY = "review_statuses"
 export const BOOTCAMP_RUN_FACET_KEY = "bootcamp_runs"
 
 export const FACET_DISPLAY_NAMES = {
-  [STATUS_FACET_KEY]:   "Application Status",
+  [STATUS_FACET_KEY]:       "Application Status",
   [BOOTCAMP_RUN_FACET_KEY]: "Bootcamp Run"
 }
 
 export const FACET_OPTION_LABEL_KEYS = {
-  [STATUS_FACET_KEY]:   ["review_status"],
+  [STATUS_FACET_KEY]:       ["review_status"],
   [BOOTCAMP_RUN_FACET_KEY]: ["title", "start_date"]
 }
 

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -80,9 +80,10 @@ export const makeApplicationFacets = (): SubmissionFacetData => {
       review_status: status,
       count:         casual.integer(1, 10)
     })),
-    bootcamps: [1, 2, 3].map(id => ({
+    bootcamp_runs: [1, 2, 3].map(id => ({
       id,
       title: casual.title,
+      start_date: moment().format(),
       count: casual.integer(1, 10)
     }))
   }

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -84,6 +84,7 @@ export const makeApplicationFacets = (): SubmissionFacetData => {
       id,
       title:      casual.title,
       start_date: moment().format(),
+      end_date:   moment().format(),
       count:      casual.integer(1, 10)
     }))
   }

--- a/static/js/factories/application.js
+++ b/static/js/factories/application.js
@@ -82,9 +82,9 @@ export const makeApplicationFacets = (): SubmissionFacetData => {
     })),
     bootcamp_runs: [1, 2, 3].map(id => ({
       id,
-      title: casual.title,
+      title:      casual.title,
       start_date: moment().format(),
-      count: casual.integer(1, 10)
+      count:      casual.integer(1, 10)
     }))
   }
 

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -99,6 +99,7 @@ type BootcampFacetOption = {
   id:    number,
   title: string,
   start_date: string,
+  end_date: string,
   count: number
 }
 
@@ -110,7 +111,7 @@ type ReviewStatusFacetOption = {
 export type FacetOption = BootcampFacetOption | ReviewStatusFacetOption
 
 export type SubmissionFacetData = {
-  bootcamps:       Array<BootcampFacetOption>,
+  bootcamp_runs:   Array<BootcampFacetOption>,
   review_statuses: Array<ReviewStatusFacetOption>
 }
 

--- a/static/js/flow/applicationTypes.js
+++ b/static/js/flow/applicationTypes.js
@@ -98,6 +98,7 @@ export type SubmissionReviewState = {
 type BootcampFacetOption = {
   id:    number,
   title: string,
+  start_date: string,
   count: number
 }
 

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -4,14 +4,7 @@ import * as R from "ramda"
 import _ from "lodash"
 import moment from "moment"
 
-import {
-  BOOTCAMP_RUN_FACET_KEY,
-  CS_DEFAULT,
-  CS_ERROR_MESSAGES,
-  ORDER_FULFILLED,
-  REVIEW_STATUS_DISPLAY_MAP,
-  STATUS_FACET_KEY
-} from "../constants"
+import { CS_DEFAULT, CS_ERROR_MESSAGES, ORDER_FULFILLED } from "../constants"
 
 import type { BootcampRun } from "../flow/bootcampTypes"
 import type { HttpResponse } from "../flow/httpTypes"

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -4,7 +4,14 @@ import * as R from "ramda"
 import _ from "lodash"
 import moment from "moment"
 
-import { CS_DEFAULT, CS_ERROR_MESSAGES, ORDER_FULFILLED } from "../constants"
+import {
+  BOOTCAMP_RUN_FACET_KEY,
+  CS_DEFAULT,
+  CS_ERROR_MESSAGES,
+  ORDER_FULFILLED,
+  REVIEW_STATUS_DISPLAY_MAP,
+  STATUS_FACET_KEY
+} from "../constants"
 
 import type { BootcampRun } from "../flow/bootcampTypes"
 import type { HttpResponse } from "../flow/httpTypes"


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1061 

#### What's this PR do?
- Changes the submissions view to filter by BootcampRun instead of Bootcamp, and to omit runs that have ended
- Updates frontend code to reflect the above, and displays title + start date for each run facet

#### How should this be manually tested?
- Log in as an admin and go to `/review`.  You should be able to filter by bootcamp run.
- Change a bootcamp run's end date to the past.  Go back to the `/review` page and there should be no submissions displayed for that run.

#### Screenshots (if appropriate)
<img width="1127" alt="Screen Shot 2020-10-20 at 1 28 25 PM" src="https://user-images.githubusercontent.com/187676/96625558-57330a80-12dc-11eb-9e84-d99520059df4.png">

