### PR TITLE
cryptography version update from 3.1 to 3.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ celery==4.3.0             # via -r requirements.in, django-server-status
 certifi==2018.10.15       # via requests, sentry-sdk
 cffi==1.14.0              # via cryptography, pynacl
 chardet==3.0.4            # via requests
-cryptography==3.1         # via pyopenssl, pysaml2
+cryptography==3.2.1       # via pyopenssl, pysaml2
 cssselect==1.1.0          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.0.11         # via ipython, traitlets


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/bootcamp-ecommerce/issues/1074

#### What's this PR do?
cryptography version update from 3.1 to 3.2.1

#### How should this be manually tested?
Install requirements and test the whole platform.
