### PR TITLE
Added flag to run python tests only without pylint/cov/warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,9 +8,37 @@ from fixtures.cybersource import *
 TEST_MEDIA_ROOT = "/var/media/test_media_root"
 
 
-def pytest_configure():
+def pytest_addoption(parser):
+    """Pytest hook that adds command line parameters"""
+    parser.addoption(
+        "--simple",
+        action="store_true",
+        help="Run tests only (no cov, no pylint, warning output silenced)",
+    )
+
+
+def pytest_cmdline_main(config):
+    """Pytest hook that runs after command line options are parsed"""
+    if getattr(config.option, "simple") is True:
+        # Switch off pylint plugin
+        config.option.pylint = False
+        config.option.no_pylint = True
+
+
+def pytest_configure(config):
     """Pytest hook to perform some initial configuration"""
     # HACK: Overwriting MEDIA_ROOT setting to ensure that files end up in a temp directory. pytest-django's 'settings'
     # fixture can't be used here, and an environment variable can't be used because we don't yet have a way to define
     # env vars that will be set exclusively for the test suite when Docker containers are spun up.
     settings.MEDIA_ROOT = TEST_MEDIA_ROOT
+    if getattr(config.option, "simple") is True:
+        # NOTE: These plugins are already configured by the time the pytest_cmdline_main hook is run, so we can't
+        #       simply add/alter the command line options in that hook. This hook is being used to
+        #       reconfigure/unregister plugins that we can't change via the pytest_cmdline_main hook.
+        # Switch off coverage plugin
+        cov = config.pluginmanager.get_plugin("_cov")
+        cov.options.no_cov = True
+        # Remove warnings plugin to suppress warnings
+        if config.pluginmanager.has_plugin("warnings"):
+            warnings_plugin = config.pluginmanager.get_plugin("warnings")
+            config.pluginmanager.unregister(warnings_plugin)


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket
#### What's this PR do?
Adds a pytest flag that allows us to run Python tests only without pylint and coverage, and with warnings suppressed

#### How should this be manually tested?
Run bash in a web container, then run `pytest --simple`. You should see the test suite run without pylint, without a coverage report, and with no warnings output

#### Any background context you want to provide?
This was done for xpro in this PR: https://github.com/mitodl/mitxpro/pull/1983

This flag will be particularly helpful while hacking on tests in a local branch. Most of the time you just need the tests to run and to have the console output limited to which tests passed and failed.

![ss 2020-11-20 at 16 33 01 ](https://user-images.githubusercontent.com/14932219/99852037-28fc5100-2b4e-11eb-992b-4e34bd5b3dc9.png)
