### PR TITLE
Fixed file handling for set_application_state command

### DIFF
--- a/localdev/seed/app_state_api.py
+++ b/localdev/seed/app_state_api.py
@@ -283,8 +283,7 @@ class AwaitingResumeStep(AppStep):
     @staticmethod
     def _fulfill(application, **kwargs):
         with open(
-            os.path.join(settings.BASE_DIR, DUMMY_RESUME_FILEPATH),
-            encoding=DUMMY_RESUME_ENCODING,
+            os.path.join(settings.BASE_DIR, DUMMY_RESUME_FILEPATH), "rb"
         ) as resume_file:
             application.add_resume(
                 resume_file=File(resume_file, name=DUMMY_RESUME_FILENAME),


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket - fixes issue with #1084 

#### What's this PR do?
Changes the way that the example resume file is handled so it works correctly with S3 as the storage backen

#### How should this be manually tested?
See #1084. You'll just need to run the command to set the state to `AWAITING_USER_SUBMISSIONS` and check that your bootcamp application has a resume file attached

