### PR TITLE
Added logic to fetch bootcamp runs by display title in mgmt commands

### DIFF
--- a/applications/management/commands/migrate_applications.py
+++ b/applications/management/commands/migrate_applications.py
@@ -20,13 +20,13 @@ class Command(BaseCommand):
         parser.add_argument(
             "--from-run",
             type=str,
-            help="The id or title of the bootcamp run that users have already applied to.",
+            help="The id, title, or display title of the bootcamp run that users have already applied to.",
             required=True,
         )
         parser.add_argument(
             "--to-run",
             type=str,
-            help="The id or title of the bootcamp run for which new applications should be created.",
+            help="The id, title, or display title of the bootcamp run for which new applications should be created.",
             required=True,
         )
         parser.add_argument(

--- a/applications/management/commands/save_derived_application_state.py
+++ b/applications/management/commands/save_derived_application_state.py
@@ -20,7 +20,10 @@ class Command(BaseCommand):
             required=True,
         )
         parser.add_argument(
-            "--run", type=str, help="The id or title of the bootcamp run", required=True
+            "--run",
+            type=str,
+            help="The id, title, or display title of the bootcamp run",
+            required=True,
         )
 
     def handle(self, *args, **options):

--- a/ecommerce/management/commands/refund.py
+++ b/ecommerce/management/commands/refund.py
@@ -8,7 +8,7 @@ from django.core.management import BaseCommand
 
 from ecommerce.api import process_refund
 from ecommerce.exceptions import EcommerceException
-from klasses.models import BootcampRun
+from klasses.api import fetch_bootcamp_run
 from profiles.api import fetch_user
 
 User = get_user_model()
@@ -17,17 +17,20 @@ User = get_user_model()
 class Command(BaseCommand):
     """Sets a user's enrollment to 'refunded' and deactivates it"""
 
-    help = "Sets a user's enrollment to 'refunded'"
+    help = __doc__
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--user",
             type=str,
-            help="The id, email, or username of the enrolled User",
+            help="The id, email, or username of the enrolled user",
             required=True,
         )
         parser.add_argument(
-            "--run", type=int, help="The id for an enrolled BootcampRun", required=True
+            "--run",
+            type=str,
+            help="The id, title, or display title of the enrolled bootcamp run",
+            required=True,
         )
         parser.add_argument(
             "--amount", type=Decimal, help="The amount of the refund", required=True
@@ -37,7 +40,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Handle command execution"""
         user = fetch_user(options["user"])
-        bootcamp_run = BootcampRun.objects.get(id=options["run"])
+        bootcamp_run = fetch_bootcamp_run(options["run"])
         amount = Decimal(options["amount"])
 
         try:

--- a/klasses/api.py
+++ b/klasses/api.py
@@ -1,6 +1,11 @@
 """
 API functionality for bootcamps
 """
+from datetime import datetime, timedelta
+
+import pytz
+
+from klasses.constants import DATE_RANGE_MONTH_FMT
 from klasses.models import BootcampRun
 
 
@@ -20,6 +25,58 @@ def deactivate_run_enrollment(run_enrollment, change_status):
     run_enrollment.save()
 
 
+def _parse_formatted_date_range(date_range_str):
+    """
+    Parses a string representing a date range (e.g.: "May 1, 2020 - Jan 30, 2021")
+
+    Args:
+        date_range_str (str): A string representing a date range
+
+    Returns:
+        Tuple[datetime.datetime, Optional[datetime.datetime]]: A tuple containing the two dates that were parsed from
+            the string
+    """
+    if "-" not in date_range_str:
+        date1_string = date_range_str
+        date2_string = None
+    else:
+        date1_string, date2_string = date_range_str.split("-")
+    date1_parts = date1_string.split(",")
+    date1_monthday = date1_parts[0].strip().split(" ")
+    month1, day1 = date1_monthday[0], int(date1_monthday[1])
+    if not date2_string:
+        year1 = int(date1_parts[1].strip())
+        month2, day2, year2 = None, None, None
+    else:
+        date2_parts = date2_string.split(",")
+        date2_monthday = date2_parts[0].strip().split(" ")
+        year2 = int(date2_parts[1].strip())
+        year1 = year2 if len(date1_parts) < 2 else int(date1_parts[1].strip())
+        if len(date2_monthday) < 2:
+            month2 = month1
+            day2 = int(date2_monthday[0])
+        else:
+            month2 = date2_monthday[0]
+            day2 = int(date2_monthday[1])
+    date1 = datetime(
+        year=year1,
+        month=datetime.strptime(month1, DATE_RANGE_MONTH_FMT).month,
+        day=day1,
+        tzinfo=pytz.UTC,
+    )
+    date2 = (
+        None
+        if not date2_string
+        else datetime(
+            year=year2,
+            month=datetime.strptime(month2, DATE_RANGE_MONTH_FMT).month,
+            day=day2,
+            tzinfo=pytz.UTC,
+        )
+    )
+    return date1, date2
+
+
 def fetch_bootcamp_run(run_property):
     """
     Fetches a bootcamp run that has a field value (id, title, etc.) that matches the given property
@@ -32,4 +89,41 @@ def fetch_bootcamp_run(run_property):
     """
     if run_property.isdigit():
         return BootcampRun.objects.get(id=run_property)
-    return BootcampRun.objects.get(title=run_property)
+    run = BootcampRun.objects.filter(title=run_property).first()
+    if run is not None:
+        return run
+    # If run_property is a string and didn't match a title, it might be a 'display_title' property value.
+    # Attempt to parse that and match it to a run.
+    if run is None and "," not in run_property:
+        return BootcampRun.objects.get(bootcamp__title=run_property)
+    potential_bootcamp_title, potential_date_range = run_property.split(",", maxsplit=1)
+    potential_start_date, potential_end_date = _parse_formatted_date_range(
+        potential_date_range
+    )
+    run_filters = dict(bootcamp__title=potential_bootcamp_title)
+    if potential_start_date:
+        run_filters.update(
+            dict(
+                start_date__gte=potential_start_date,
+                start_date__lt=potential_start_date + timedelta(days=1),
+            )
+        )
+    else:
+        run_filters["start_date"] = None
+    if potential_end_date:
+        run_filters.update(
+            dict(
+                end_date__gte=potential_end_date,
+                end_date__lt=potential_end_date + timedelta(days=1),
+            )
+        )
+    else:
+        run_filters["end_date"] = None
+    try:
+        return BootcampRun.objects.get(**run_filters)
+    except BootcampRun.DoesNotExist as exc:
+        raise BootcampRun.DoesNotExist(
+            "Could not find BootcampRun with the following filters: {}".format(
+                run_filters
+            )
+        ) from exc

--- a/klasses/api_test.py
+++ b/klasses/api_test.py
@@ -1,8 +1,10 @@
 """
 klasses API tests
 """
+import datetime
 
 import pytest
+import pytz
 
 from klasses.api import deactivate_run_enrollment, fetch_bootcamp_run
 from klasses.constants import ENROLL_CHANGE_STATUS_REFUNDED
@@ -24,9 +26,38 @@ def test_deactivate_run_enrollment():
 @pytest.mark.django_db
 def test_fetch_bootcamp_run():
     """fetch_bootcamp_run should fetch a bootcamp run with a field value that matches the given property"""
-    title = "Run 1"
-    run = BootcampRunFactory.create(title=title)
+    run = BootcampRunFactory.create(
+        bootcamp__title="Bootcamp 1", title="Run 1", start_date=None, end_date=None
+    )
     assert fetch_bootcamp_run(str(run.id)) == run
-    assert fetch_bootcamp_run(title) == run
+    assert fetch_bootcamp_run(run.title) == run
+    assert fetch_bootcamp_run(run.display_title) == run
+    with pytest.raises(BootcampRun.DoesNotExist):
+        fetch_bootcamp_run("invalid")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "end_date_params",
+    [
+        dict(year=2020, month=1, day=15),
+        dict(year=2020, month=2, day=1),
+        dict(year=2021, month=1, day=1),
+        None,
+    ],
+)
+def test_fetch_bootcamp_run_dates(end_date_params):
+    """fetch_bootcamp_run should fetch a bootcamp run by display title regardless of the start/end date ranges"""
+    run = BootcampRunFactory.create(
+        bootcamp__title="Bootcamp 1",
+        title="Run 1",
+        start_date=datetime.datetime(year=2020, month=1, day=1, tzinfo=pytz.UTC),
+        end_date=(
+            None
+            if not end_date_params
+            else datetime.datetime(**end_date_params, tzinfo=pytz.UTC)
+        ),
+    )
+    assert fetch_bootcamp_run(run.display_title) == run
     with pytest.raises(BootcampRun.DoesNotExist):
         fetch_bootcamp_run("invalid")

--- a/klasses/constants.py
+++ b/klasses/constants.py
@@ -10,6 +10,8 @@ class ApplicationSource:
     SOURCE_CHOICES = [None, SMAPPLY, FLUIDREVIEW]
 
 
+DATE_RANGE_MONTH_FMT = "%b"
+
 INTEGRATION_PREFIX_PRODUCT = "BootcampProduct-"
 
 ENROLL_CHANGE_STATUS_REFUNDED = "refunded"

--- a/klasses/models_test.py
+++ b/klasses/models_test.py
@@ -62,28 +62,31 @@ def test_bootcamp_run_payment_deadline():
     assert bootcamp_run.payment_deadline == installment_2.deadline
 
 
-def test_bootcamp_run_formatted_date_range():
+@pytest.mark.parametrize(
+    "start_date,end_date,exp_result",
+    [
+        [
+            datetime.strptime("01/01/2020", "%m/%d/%Y"),
+            datetime.strptime("01/01/2021", "%m/%d/%Y"),
+            "Jan 1, 2020 - Jan 1, 2021",
+        ],
+        [
+            datetime.strptime("01/01/2020", "%m/%d/%Y"),
+            datetime.strptime("02/01/2020", "%m/%d/%Y"),
+            "Jan 1 - Feb 1, 2020",
+        ],
+        [
+            datetime.strptime("01/01/2020", "%m/%d/%Y"),
+            datetime.strptime("01/15/2020", "%m/%d/%Y"),
+            "Jan 1 - 15, 2020",
+        ],
+        [datetime.strptime("01/01/2020", "%m/%d/%Y"), None, "Jan 1, 2020"],
+    ],
+)
+def test_bootcamp_run_formatted_date_range(start_date, end_date, exp_result):
     """Test that the formatted_date_range property returns expected values with various start/end dates"""
-    base_date = datetime(year=2017, month=1, day=1)
-    date_same_month = datetime(year=2017, month=1, day=10)
-    date_different_month = datetime(year=2017, month=2, day=1)
-    date_different_year = datetime(year=2018, month=1, day=1)
-    bootcamp_run = BootcampRunFactory.build(
-        start_date=base_date, end_date=date_same_month
-    )
-    assert bootcamp_run.formatted_date_range == "Jan 1 - 10, 2017"
-    bootcamp_run = BootcampRunFactory.build(
-        start_date=base_date, end_date=date_different_month
-    )
-    assert bootcamp_run.formatted_date_range == "Jan 1 - Feb 1, 2017"
-    bootcamp_run = BootcampRunFactory.build(
-        start_date=base_date, end_date=date_different_year
-    )
-    assert bootcamp_run.formatted_date_range == "Jan 1, 2017 - Jan 1, 2018"
-    bootcamp_run = BootcampRunFactory.build(start_date=base_date, end_date=None)
-    assert bootcamp_run.formatted_date_range == "Jan 1, 2017"
-    bootcamp_run = BootcampRunFactory.build(start_date=None, end_date=None)
-    assert bootcamp_run.formatted_date_range == ""
+    bootcamp_run = BootcampRunFactory.build(start_date=start_date, end_date=end_date)
+    assert bootcamp_run.formatted_date_range == exp_result
 
 
 def test_bootcamp_run_display_title():

--- a/localdev/seed/management/commands/set_application_state.py
+++ b/localdev/seed/management/commands/set_application_state.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--run",
             type=str,
-            help="The id or title of the bootcamp run",
+            help="The id, title, or display title of the bootcamp run",
             required=False,
         )
         parser.add_argument(

--- a/main/utils.py
+++ b/main/utils.py
@@ -401,3 +401,19 @@ def serializer_date_format(dt):
         Optional[str]: The string representing the datetime (or None)
     """
     return serializers.DateTimeField().to_representation(dt)
+
+
+def format_month_day(dt, month_fmt="%b"):
+    """
+    Formats the month and day of a datetime
+
+    Args:
+        dt (datetime.datetime): The datetime to be formatted
+        month_fmt (Optional[str]): The strftime-compatible month format
+
+    Returns:
+        str: The formatted month and day
+    """
+    # NOTE: This function is used instead of just 'strftime' because the '%-d' directive, which is used to produce a
+    # formatted day without trailing zeros, is platform-dependent.
+    return "{} {}".format(dt.strftime(month_fmt), dt.day)

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -32,6 +32,7 @@ from main.utils import (
     filter_dict_by_key_set,
     partition_around_index,
     partition_to_lists,
+    format_month_day,
 )
 from main.test_utils import MockResponse, format_as_iso8601
 
@@ -318,3 +319,13 @@ def test_chunks_iterable():
     for chunk in chunk_output:
         range_list += chunk
     assert range_list == list(range(count))
+
+
+def test_format_month_day():
+    """
+    format_month_day should format the month and day from a datetime
+    """
+    dt = datetime.datetime(year=2020, month=1, day=1, tzinfo=pytz.UTC)
+    assert format_month_day(dt) == "Jan 1"
+    assert format_month_day(dt, month_fmt="%b") == "Jan 1"
+    assert format_month_day(dt, month_fmt="%B") == "January 1"

--- a/novoed/management/commands/backfill_novoed_enrollments.py
+++ b/novoed/management/commands/backfill_novoed_enrollments.py
@@ -1,7 +1,8 @@
 """Management command to enroll users in a NovoEd course"""
 from django.core.management.base import BaseCommand, CommandError
 
-from klasses.models import BootcampRunEnrollment, BootcampRun
+from klasses.api import fetch_bootcamp_run
+from klasses.models import BootcampRunEnrollment
 from profiles.api import fetch_user
 from novoed.tasks import enroll_users_in_novoed_course
 
@@ -13,7 +14,10 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--run", type=str, help="The id or title of the bootcamp run", required=True
+            "--run",
+            type=str,
+            help="The id, title, or display title of the bootcamp run",
+            required=True,
         )
         parser.add_argument(
             "--user",
@@ -23,11 +27,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        run_property = options["run"]
-        if run_property.isdigit():
-            bootcamp_run = BootcampRun.objects.get(id=run_property)
-        else:
-            bootcamp_run = BootcampRun.objects.get(title=run_property)
+        bootcamp_run = fetch_bootcamp_run(options["run"])
         if bootcamp_run.novoed_course_stub is None:
             raise CommandError(
                 f"Bootcamp run '{bootcamp_run.title}' does not have a novoed_course_stub value"


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket. Helps usability with commands like #1084

#### What's this PR do?
In management commands that require a bootcamp run, the run parameter can now be passed in as the `display_title` value of a bootcamp run (e.g.: "Seed Differential Equations, Oct 10, 2020 - Jan 8, 2021")

#### How should this be manually tested?
Use a command like `set_application_state` or `migrate_applications` and provide a `display_title` value as the `--run` param. The command should execute without any errors related to fetching the bootcamp run

#### Any background context you want to provide?
I use these management commands quite a bit, and in almost all cases in the app, we represent bootcamp runs using the `display_title` property. Being able to just copy and paste a display title value makes it _much_ easier to use the management commands
