### PR TITLE
Fixed buggy personal price adjustment behavior

### DIFF
--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -133,6 +133,7 @@ class OrderFulfillmentView(APIView):
         if decision != CYBERSOURCE_DECISION_ACCEPT:
             handle_rejected_order(order=order, decision=decision)
         else:
+            # import pdb; pdb.set_trace()
             complete_successful_order(order)
 
         # Sync order data with hubspot

--- a/klasses/api.py
+++ b/klasses/api.py
@@ -1,28 +1,107 @@
 """
 API functionality for bootcamps
 """
+import logging
 from datetime import datetime, timedelta
 
 import pytz
+from django.db.models import Sum
 
+from applications.constants import AppStates
+from ecommerce.models import Line
 from klasses.constants import DATE_RANGE_MONTH_FMT
-from klasses.models import BootcampRun
+from klasses.models import BootcampRun, BootcampRunEnrollment
+from main import features
+from novoed import tasks as novoed_tasks
 
 
-def deactivate_run_enrollment(run_enrollment, change_status):
+log = logging.getLogger(__name__)
+
+
+def deactivate_run_enrollment(
+    *, run_enrollment=None, user=None, bootcamp_run=None, change_status=None
+):
     """
-    Helper method to deactivate a BootcampRunEnrollment
+    Helper method to deactivate a BootcampRunEnrollment. Can accept a BootcampRunEnrollment as an argument, or a
+    User and BootcampRun that can be used to find the enrollment.
 
     Args:
-        run_enrollment (BootcampRunEnrollment): The bootcamp run enrollment to deactivate
-        change_status (str): The change status to set on the enrollment when deactivating
+        run_enrollment (Optional[BootcampRunEnrollment]): The bootcamp run enrollment to deactivate
+        user (Optional[User]): The enrolled user (only required if run_enrollment is not provided)
+        bootcamp_run (Optional[BootcampRun]): The enrolled bootcamp run (only required if run_enrollment
+            is not provided)
+        change_status (Optional[str]): The change status to set on the enrollment when deactivating
 
     Returns:
-        BootcampRunEnrollment: The updated enrollment
+        Optional[BootcampRunEnrollment]: The updated enrollment (or None if the enrollment doesn't exist)
     """
+    if run_enrollment is None and (user is None or bootcamp_run is None):
+        raise ValueError("Must provide run_enrollment, or both user and bootcamp_run")
+    if run_enrollment is None:
+        run_enrollment = BootcampRunEnrollment.objects.filter(
+            user=user, bootcamp_run=bootcamp_run
+        ).first()
+        if run_enrollment is None:
+            return
     run_enrollment.active = False
     run_enrollment.change_status = change_status
     run_enrollment.save()
+    if (
+        features.is_enabled(features.NOVOED_INTEGRATION)
+        and run_enrollment.bootcamp_run.novoed_course_stub
+    ):
+        novoed_tasks.unenroll_user_from_novoed_course.delay(
+            user_id=run_enrollment.user.id,
+            novoed_course_stub=run_enrollment.bootcamp_run.novoed_course_stub,
+        )
+    return run_enrollment
+
+
+def adjust_app_state_for_new_price(user, bootcamp_run, new_price=None):
+    """
+    Given a new price for a bootcamp run, updated user's bootcamp application if (a) it exists, and (b) the new price
+    is such that the bootcamp application state is no longer valid (e.g.: the new price is greater than the
+    amount that the user has paid, but the application is in the "complete" state)
+
+    Args:
+        user (User): The user whose application may be affected
+        bootcamp_run (BootcampRun): The bootcamp run of the application that may be affected
+        new_price (Optional[Any[int, Decimal]]): The new total price of the bootcamp run (if None, the bootcamp run's
+            normal price will be used)
+
+    Returns:
+        Optional[BootcampApplication]: The bootcamp application for the user/run referred to by the personal price
+            if it was modified (otherwise, None will be returned)
+    """
+    total_paid_qset = Line.objects.filter(
+        order__user=user, bootcamp_run=bootcamp_run
+    ).aggregate(aggregate_total_paid=Sum("price"))
+    total_paid = total_paid_qset["aggregate_total_paid"] or 0
+    needs_payment = total_paid < (new_price or bootcamp_run.price)
+    application = user.bootcamp_applications.filter(
+        bootcamp_run=bootcamp_run,
+        # The state needs to change if (a) it's currently complete and now needs more payment, or (b) it's currently
+        # awaiting payment and the new price means they don't need to pay any more.
+        state=(
+            AppStates.COMPLETE.value
+            if needs_payment
+            else AppStates.AWAITING_PAYMENT.value
+        ),
+    ).first()
+    if application is None:
+        return
+    if needs_payment:
+        application.await_further_payment()
+    else:
+        application.complete()
+    application.save()
+    log.info(
+        "Personal price update caused application state change (user: %s, run: '%s', new state: %s)",
+        user.email,
+        bootcamp_run.title,
+        application.state,
+    )
+    return application
 
 
 def _parse_formatted_date_range(date_range_str):

--- a/klasses/models.py
+++ b/klasses/models.py
@@ -224,6 +224,9 @@ class PersonalPrice(models.Model):
     class Meta:
         unique_together = ("bootcamp_run", "user")
 
+    def __str__(self):
+        return f"user='{self.user.email}', run='{self.bootcamp_run.title}', price={self.price}"
+
 
 class BootcampRunEnrollment(TimestampedModel):
     """An enrollment in a bootcamp run by a user"""

--- a/klasses/signals.py
+++ b/klasses/signals.py
@@ -1,16 +1,42 @@
 """Signals for ecommerce models"""
 from django.db.transaction import on_commit
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
 from hubspot.task_helpers import sync_hubspot_product
-from klasses.models import BootcampRun
+from klasses.api import adjust_app_state_for_new_price
+from klasses.models import BootcampRun, PersonalPrice
 
 
 @receiver(post_save, sender=BootcampRun, dispatch_uid="bootcamp__run_post_save")
 def sync_bootcamp_run(
     sender, instance, created, **kwargs
 ):  # pylint:disable=unused-argument
-
     """Sync bootcamp run to hubspot"""
     on_commit(lambda: sync_hubspot_product(instance))
+
+
+@receiver(post_save, sender=PersonalPrice, dispatch_uid="personal_price_post_save")
+def personal_price_post_save(
+    sender, instance, created, **kwargs
+):  # pylint:disable=unused-argument
+    """Handles the 'post_save' signal from the PersonalPrice model"""
+    on_commit(
+        lambda: adjust_app_state_for_new_price(
+            user=instance.user,
+            bootcamp_run=instance.bootcamp_run,
+            new_price=instance.price,
+        )
+    )
+
+
+@receiver(post_delete, sender=PersonalPrice, dispatch_uid="personal_price_post_delete")
+def personal_price_post_delete(
+    sender, instance, **kwargs
+):  # pylint:disable=unused-argument
+    """Handles the 'post_save' signal from the PersonalPrice model"""
+    on_commit(
+        lambda: adjust_app_state_for_new_price(
+            user=instance.user, bootcamp_run=instance.bootcamp_run
+        )
+    )

--- a/klasses/signals_test.py
+++ b/klasses/signals_test.py
@@ -1,7 +1,8 @@
 """ Tests for applications.signals"""
 import pytest
 
-from klasses.factories import BootcampRunFactory
+from klasses.factories import BootcampRunFactory, PersonalPriceFactory
+from klasses.signals import personal_price_post_save, personal_price_post_delete
 
 pytestmark = pytest.mark.django_db
 
@@ -15,3 +16,40 @@ def test_bootcamp_run_signal(mocker):
     bootcamp.save()
     bootcamp.save()
     assert mock_on_commit.call_count == 3  # Once for creation, twice for updates
+
+
+def test_personal_price_save_signal(mocker):
+    """An API method to update a bootcamp application should be called after a personal price is created/saved"""
+    mock_on_commit = mocker.patch("klasses.signals.on_commit")
+    personal_price = PersonalPriceFactory.create()
+    # This signal is called twice when the record is created (as opposed to just being saved)
+    assert mock_on_commit.call_count == 2
+    personal_price.save()
+    assert mock_on_commit.call_count == 3
+    # Test the function call from the signal handler
+    patched_adjust_app = mocker.patch("klasses.signals.adjust_app_state_for_new_price")
+    personal_price_post_save(mocker.Mock(), personal_price, False)
+    # Call the function that was passed into "on_commit", which in this case should be our patched API function
+    mock_on_commit.call_args[0][0]()
+    patched_adjust_app.assert_called_once_with(
+        user=personal_price.user,
+        bootcamp_run=personal_price.bootcamp_run,
+        new_price=personal_price.price,
+    )
+
+
+def test_personal_price_delete_signal(mocker):
+    """An API method to update a bootcamp application should be called after a personal price is deleted"""
+    mock_on_commit = mocker.patch("klasses.signals.on_commit")
+    personal_price = PersonalPriceFactory.create()
+    prev_call_count = mock_on_commit.call_count
+    personal_price.delete()
+    assert mock_on_commit.call_count == prev_call_count + 1
+    # Test the function call from the signal handler
+    patched_adjust_app = mocker.patch("klasses.signals.adjust_app_state_for_new_price")
+    personal_price_post_delete(mocker.Mock(), personal_price)
+    # Call the function that was passed into "on_commit", which in this case should be our patched API function
+    mock_on_commit.call_args[0][0]()
+    patched_adjust_app.assert_called_once_with(
+        user=personal_price.user, bootcamp_run=personal_price.bootcamp_run
+    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,4 @@ env =
   BOOTCAMP_NOTIFICATION_EMAIL_BACKEND=anymail.backends.test.EmailBackend
   RECAPTCHA_SITE_KEY=
   RECAPTCHA_SECRET_KEY=
+  NOVOED_API_BASE_URL=http://localhost


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1013
Fixes #1036

#### What's this PR do?
Fixes bug where adjusting a user's personal price did not change the state of their bootcamp application when appropriate 

#### How should this be manually tested?
1. Start out with a user with an application that is awaiting payment (use the `set_application_state` command)
1. Add an `Order`/`Line` to represent a partial payment toward the total amount owed for that run
1. Create/update a personal price for that user/run so that the amount is less than the amount your user has already paid

This is signals-based, so your application should be automatically set to "complete"

Next, do the same, only start off with a fully-paid application in the "complete" state, and set the personal price to an amount that is greater than the amount already paid. Your application should be automatically set to "awaiting payment"

This should also work if you have a personal price in the database then delete it. The original bootcamp run price will be used in this case.