### PR TITLE
Added field validation on first and last name

### DIFF
--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -19,7 +19,13 @@ log = logging.getLogger()
 US_POSTAL_RE = re.compile(r"[0-9]{5}(-[0-9]{4}){0,1}")
 CA_POSTAL_RE = re.compile(r"[A-Z]\d[A-Z] \d[A-Z]\d$", flags=re.I)
 USER_NAME_RE = re.compile(
-    r"^(?![~!@&)(+:'.?/,`-]+)([^/^$#*=\[\]`%_;<>{}\"|]+)$", flags=re.I
+    r"""
+    ^                               # Start of string
+    (?![~!@&)(+:'.?/,`-]+)          # String should not start from character(s) in this set - They can exist in elsewhere
+    ([^/^$#*=\[\]`%_;<>{}\"|]+)     # String should not contain characters(s) from this set - All invalid characters
+    $                               # End of string
+    """,
+    flags=re.I | re.VERBOSE | re.MULTILINE,
 )
 
 User = get_user_model()

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -18,6 +18,9 @@ log = logging.getLogger()
 
 US_POSTAL_RE = re.compile(r"[0-9]{5}(-[0-9]{4}){0,1}")
 CA_POSTAL_RE = re.compile(r"[A-Z]\d[A-Z] \d[A-Z]\d$", flags=re.I)
+USER_NAME_RE = re.compile(
+    r"^(?![~!@&)(+:'.?/,`-]+)([^/^$#*=\[\]`%_;<>{}\"|]+)$", flags=re.I
+)
 
 User = get_user_model()
 
@@ -37,6 +40,18 @@ class LegalAddressSerializer(serializers.ModelSerializer):
     # only required in the US/CA
     state_or_territory = serializers.CharField(max_length=255, allow_blank=True)
     postal_code = serializers.CharField(max_length=10, allow_blank=True)
+
+    def validate_first_name(self, value):
+        """Validates first name of the user"""
+        if value and not USER_NAME_RE.match(value):
+            raise serializers.ValidationError("First name is not valid")
+        return value
+
+    def validate_last_name(self, value):
+        """Validates last name of the user"""
+        if value and not USER_NAME_RE.match(value):
+            raise serializers.ValidationError("Last name is not valid")
+        return value
 
     def validate_street_address(self, value):
         """Validates an incoming street address list"""

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -227,3 +227,27 @@ def test_update_user_email(user):
 
     user.refresh_from_db()
     assert user.email == new_email
+
+
+def test_legal_address_serializer_invalid_name(sample_address):
+    """ Test that LegalAddressSerializer raises an exception if first/last name is not valid """
+
+    # To make sure that this test isn't flaky, Checking all the character and sequences that should match our name regex
+
+    # Case 1: Make sure that invalid character(s) doesn't exist within the name
+    for invalid_character in "~!@&)(+:'.?/,`-":
+        # Replace the invalid character on 3 different places within name for rigorous testing of this case
+        sample_address["first_name"] = "{0}First{0} Name{0}".format(invalid_character)
+        sample_address["last_name"] = "{0}Last{0} Name{0}".format(invalid_character)
+        serializer = LegalAddressSerializer(data=sample_address)
+        with pytest.raises(ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+    # Case 2: Make sure that name doesn't start with valid special character(s)
+    # These characters are valid for a name but they shouldn't be at the start of it
+    for valid_character in '^/^$#*=[]`%_;<>{}"|':
+        sample_address["first_name"] = "{}First".format(valid_character)
+        sample_address["last_name"] = "{}Last".format(valid_character)
+        serializer = LegalAddressSerializer(data=sample_address)
+        with pytest.raises(ValidationError):
+            serializer.is_valid(raise_exception=True)

--- a/static/js/components/forms/RegisterDetailsForm_test.js
+++ b/static/js/components/forms/RegisterDetailsForm_test.js
@@ -210,4 +210,93 @@ describe("RegisterDetailsForm", () => {
       )
     })
   })
+
+  // Tests name regex for first & last name
+  const invalidNameMessage =
+    "Name cannot start with a special character, And it cannot contain any character from {/^$#*=[]`%_;<>{}}"
+  ;["legal_address.first_name", "legal_address.last_name"].forEach(
+    fieldName => {
+      const wrapper = renderForm()
+      const field = wrapper.find(`input[name="${fieldName}"]`)
+
+      // List of valid character but they couldn't exist in the start of name
+      ;[
+        "~",
+        "!",
+        "@",
+        "&",
+        ")",
+        "(",
+        "+",
+        ":",
+        ".",
+        "?",
+        "/",
+        ",",
+        "`",
+        "-"
+      ].forEach(validCharacter => {
+        it(`validates the field name=${fieldName}, value=${JSON.stringify(
+          `${validCharacter}Name`
+        )} and expects error=${JSON.stringify(
+          invalidNameMessage
+        )}`, async () => {
+          // Prepend the character to start if the name value
+          const value = `${validCharacter}Name`
+          field.simulate("change", {
+            persist: () => {},
+            target:  { name: fieldName, value: value }
+          })
+          field.simulate("blur")
+          await wait()
+          wrapper.update()
+          assert.deepEqual(
+            findFormikErrorByName(wrapper, fieldName).text(),
+            invalidNameMessage
+          )
+        })
+      })
+      // List of invalid characters that cannot exist anywhere in name
+      ;[
+        "/",
+        "^",
+        "$",
+        "#",
+        "*",
+        "=",
+        "[",
+        "]",
+        "`",
+        "%",
+        "_",
+        ";",
+        "<",
+        ">",
+        "{",
+        "}",
+        '"',
+        "|"
+      ].forEach(invalidCharacter => {
+        it(`validates the field name=${fieldName}, value=${JSON.stringify(
+          `${invalidCharacter}Name${invalidCharacter}`
+        )} and expects error=${JSON.stringify(
+          invalidNameMessage
+        )}`, async () => {
+          // Prepend the character to start if the name value
+          const value = `${invalidCharacter}Name${invalidCharacter}`
+          field.simulate("change", {
+            persist: () => {},
+            target:  { name: fieldName, value: value }
+          })
+          field.simulate("blur")
+          await wait()
+          wrapper.update()
+          assert.deepEqual(
+            findFormikErrorByName(wrapper, fieldName).text(),
+            invalidNameMessage
+          )
+        })
+      })
+    }
+  )
 })

--- a/static/js/components/forms/RegisterDetailsForm_test.js
+++ b/static/js/components/forms/RegisterDetailsForm_test.js
@@ -213,7 +213,7 @@ describe("RegisterDetailsForm", () => {
 
   // Tests name regex for first & last name
   const invalidNameMessage =
-    "Name cannot start with a special character, And it cannot contain any character from {/^$#*=[]`%_;<>{}}"
+    "Name cannot start with a special character, and it cannot contain any character from {/^$#*=[]`%_;<>{}}"
   ;["legal_address.first_name", "legal_address.last_name"].forEach(
     fieldName => {
       const wrapper = renderForm()

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -95,6 +95,8 @@ export const CA_ALPHA_2 = "CA"
 
 export const US_POSTAL_CODE_REGEX = /[0-9]{5}(-[0-9]{4}){0,1}/
 export const CA_POSTAL_CODE_REGEX = /[A-Z][0-9][A-Z] [0-9][A-Z][0-9]/
+export const NAME_REGEX = /^(?![~!@&)(+:'.?/,`-]+)([^/^$#*=[\]`%_;<>{}"|]+)$/
+
 export const COUNTRIES_REQUIRING_POSTAL_CODE = [US_ALPHA_2, CA_ALPHA_2]
 export const COUNTRIES_REQUIRING_STATE = [US_ALPHA_2, CA_ALPHA_2]
 

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -236,6 +236,10 @@ export const FACET_OPTION_LABEL_KEYS = {
 
 export const FACET_ORDER = [BOOTCAMP_RUN_FACET_KEY, STATUS_FACET_KEY]
 
+// Field Error messages
+export const NAME_REGEX_FAIL_MESSAGE =
+  "Name cannot start with a special character, And it cannot contain any character from {/^$#*=[]`%_;<>{}}"
+
 export const CS_101 = "CS_101"
 export const CS_102 = "CS_102"
 export const CS_DEFAULT = "CS_DEFAULT"

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -238,7 +238,7 @@ export const FACET_ORDER = [BOOTCAMP_RUN_FACET_KEY, STATUS_FACET_KEY]
 
 // Field Error messages
 export const NAME_REGEX_FAIL_MESSAGE =
-  "Name cannot start with a special character, And it cannot contain any character from {/^$#*=[]`%_;<>{}}"
+  "Name cannot start with a special character, and it cannot contain any character from {/^$#*=[]`%_;<>{}}"
 
 export const CS_101 = "CS_101"
 export const CS_102 = "CS_102"

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -7,6 +7,7 @@ import {
   CA_POSTAL_CODE_REGEX,
   COUNTRIES_REQUIRING_STATE,
   NAME_REGEX,
+  NAME_REGEX_FAIL_MESSAGE,
   US_ALPHA_2,
   US_POSTAL_CODE_REGEX
 } from "../constants"
@@ -79,13 +80,13 @@ export const legalAddressValidation = yup.object().shape({
       .string()
       .label("First Name")
       .trim()
-      .matches(NAME_REGEX, "Invalid First Name")
+      .matches(NAME_REGEX, NAME_REGEX_FAIL_MESSAGE)
       .required(),
     last_name: yup
       .string()
       .label("Last Name")
       .trim()
-      .matches(NAME_REGEX, "Invalid Last Name")
+      .matches(NAME_REGEX, NAME_REGEX_FAIL_MESSAGE)
       .required(),
     city: yup
       .string()

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -6,6 +6,7 @@ import {
   CA_ALPHA_2,
   CA_POSTAL_CODE_REGEX,
   COUNTRIES_REQUIRING_STATE,
+  NAME_REGEX,
   US_ALPHA_2,
   US_POSTAL_CODE_REGEX
 } from "../constants"
@@ -78,11 +79,13 @@ export const legalAddressValidation = yup.object().shape({
       .string()
       .label("First Name")
       .trim()
+      .matches(NAME_REGEX, "Invalid First Name")
       .required(),
     last_name: yup
       .string()
       .label("Last Name")
       .trim()
+      .matches(NAME_REGEX, "Invalid Last Name")
       .required(),
     city: yup
       .string()


### PR DESCRIPTION
#### What are the relevant tickets?
Fixed #1082 

#### What's this PR do?
It adds validation on the first and last name of the user in the registration form.

**Note:**
While the associated ticket shows Period `.` as invalid input for the first name but in this PR I tried to generate a regex to handle possible invalid values for both first and last name fields and added validation on the front end so that error-prone input doesn't pass through compliance API.

Reference details mentioned by cybersource could be found [here](https://developer.cybersource.com/library/documentation/dev_guides/EChecks_SCMP_API/html/Topics/app_fields_SCMP.htm#XREF_53480_SCMP_API_Fields) & [here](https://developer.cybersource.com/library/documentation/dev_guides/Verification_Svcs_SO_API/Verification_Svcs_SO_API.pdf) (Formatting restrictions part)

Since documentation wasn't very clear about the formatting details so I tested it manually,
**Some cases** were identified during the search and testing of compliance API.

Acceptable Special characters were ```~!@&)(+:'.?/,`-```

Non Acceptable special characters were: ```/^$#*=[\]`%_;<>{}"|```

1. API doesn't accept names containing only special characters such as `.`, `...`, `.@~` (Failing case in associated ticket)
2. API doesn't accept names starting with special characters e.g. `@Name` or `.Name`
3. Some of the special characters that ware not accepted If present anywhere in first/last name string were: `#,$,&,^,_`
4. API accepts names starting at least with an `alphanumeric` and then containing any `sequence of alphanumeric or special characters`.

The `regex` used in the PR is created based on the above scenarios.

**Solution Applied:**
To be on the safe side and not to block users, It will only reject those sequences/values about which we will be sure that are invalid based on the above 4 points, For all other values we'll keep it open-ended, we'll let them pass to compliance API and let it decide their validity (Only in this case we'll now see a general error message).

#### How should this be manually tested?
Testing instructions are mentioned in the associated ticket above.

#### Where should the reviewer start?
Register account for bootcamps app.

#### Any background context you want to provide?
So far, we were handling validation errors from compliance API as generic since we knew we are only validating the user's name and address through compliance during the register so we'd show an error regarding name & address whenever there is a validation error from compliance API.

#### Screenshots (if appropriate)
<img width="768" alt="Screenshot 2020-12-08 at 8 55 36 PM" src="https://user-images.githubusercontent.com/34372316/101507002-e208bb00-3997-11eb-87e7-80db9f101d22.png">
<img width="742" alt="Screenshot 2020-12-08 at 8 55 54 PM" src="https://user-images.githubusercontent.com/34372316/101507079-fbaa0280-3997-11eb-93ae-a32b55a05ab0.png">
