### PR TITLE
add dynamic cache controlling via env variable

### DIFF
--- a/app.json
+++ b/app.json
@@ -131,6 +131,10 @@
       "description": "Use S3 for storage backend (required on Heroku)",
       "required": false
     },
+    "CACHEABLE_ENDPOINTS": {
+      "description": "A list of cacheable endpoints.",
+      "required": false
+    },
     "CELERY_BROKER_URL": {
       "description": "Where celery should get tasks, default is Redis URL",
       "required": false

--- a/app.json
+++ b/app.json
@@ -135,6 +135,10 @@
       "description": "A list of cacheable endpoints.",
       "required": false
     },
+    "CACHEABLE_ENDPOINTS_CACHE_VALUE": {
+      "description": "Cache-Control value for cacheable endpoints.",
+      "required": false
+    },
     "CELERY_BROKER_URL": {
       "description": "Where celery should get tasks, default is Redis URL",
       "required": false

--- a/main/envs.py
+++ b/main/envs.py
@@ -72,7 +72,6 @@ def var_parser(parser_func):
 
         if name in configured_envs:
             raise ValueError(f"Environment variable '{name}' was used more than once")
-
         value = environ.get(name, default)
 
         # attempt to parse the value before we store it in configured_envs
@@ -186,9 +185,10 @@ def parse_list(name, value, default):  # pylint: disable=unused-argument
             parsed_value = [
                 item.strip(" ").lstrip('"').rstrip('"')
                 for item in parsed_value.lstrip("[").rstrip("]").split(",")
+                if item
             ]
         else:
-            parsed_value = [item.strip(" ") for item in parsed_value.split(",")]
+            parsed_value = [item.strip(" ") for item in parsed_value.split(",") if item]
     return parsed_value
 
 

--- a/main/middleware.py
+++ b/main/middleware.py
@@ -9,7 +9,7 @@ class CachelessAPIMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         """ Add a Cache-Control header to an API response """
         if request.path.startswith(settings.CACHEABLE_ENDPOINTS):
-            response["Cache-Control"] = "max-age=3600, public"
+            response["Cache-Control"] = settings.CACHEABLE_ENDPOINTS_CACHE_VALUE
         elif request.path.startswith("/api/"):
             response["Cache-Control"] = "private, no-store"
         return response

--- a/main/middleware.py
+++ b/main/middleware.py
@@ -1,4 +1,5 @@
 """ Middleware classes for the main app"""
+from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
 
@@ -7,6 +8,8 @@ class CachelessAPIMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         """ Add a Cache-Control header to an API response """
-        if request.path.startswith("/api/"):
+        if request.path.startswith(settings.CACHEABLE_ENDPOINTS):
+            response["Cache-Control"] = "max-age=3600, public"
+        elif request.path.startswith("/api/"):
             response["Cache-Control"] = "private, no-store"
         return response

--- a/main/middleware_test.py
+++ b/main/middleware_test.py
@@ -1,15 +1,21 @@
 """ Tests for main.middleware """
 import pytest
+from django.test import override_settings
 from django.urls import reverse
 
 from main.middleware import CachelessAPIMiddleware
 
 
 @pytest.mark.parametrize(
-    "view, cache_value",
-    [["applications", None], ["applications_api-list", "private, no-store"]],
+    "view, cache_value, cacheable_endpoint_cache_value",
+    [
+        ["applications", None, "max-age=3600, public"],
+        ["applications_api-list", "private, no-store", "max-age=3600, public"],
+    ],
 )
-def test_cacheless_api_middleware(rf, view, cache_value):
+def test_cacheless_api_middleware(
+    rf, view, cache_value, cacheable_endpoint_cache_value
+):
     """Tests that the response has a cache-control header for API URLs"""
     request = rf.get(reverse(view))
     middleware = CachelessAPIMiddleware()
@@ -17,3 +23,9 @@ def test_cacheless_api_middleware(rf, view, cache_value):
         middleware.process_response(request, {}).get("Cache-Control", None)
         == cache_value
     )
+    with override_settings(CACHEABLE_ENDPOINTS=(reverse(view),)):
+        request = rf.get(reverse(view))
+        assert (
+            middleware.process_response(request, {}).get("Cache-Control", None)
+            == cacheable_endpoint_cache_value
+        )

--- a/main/middleware_test.py
+++ b/main/middleware_test.py
@@ -7,14 +7,14 @@ from main.middleware import CachelessAPIMiddleware
 
 
 @pytest.mark.parametrize(
-    "view, cache_value, cacheable_endpoint_cache_value",
+    "view, cache_value, cacheable_endpoints_cache_value",
     [
         ["applications", None, "max-age=3600, public"],
         ["applications_api-list", "private, no-store", "max-age=3600, public"],
     ],
 )
 def test_cacheless_api_middleware(
-    rf, view, cache_value, cacheable_endpoint_cache_value
+    rf, view, cache_value, cacheable_endpoints_cache_value
 ):
     """Tests that the response has a cache-control header for API URLs"""
     request = rf.get(reverse(view))
@@ -23,9 +23,12 @@ def test_cacheless_api_middleware(
         middleware.process_response(request, {}).get("Cache-Control", None)
         == cache_value
     )
-    with override_settings(CACHEABLE_ENDPOINTS=(reverse(view),)):
+    with override_settings(
+        CACHEABLE_ENDPOINTS=(reverse(view),),
+        CACHEABLE_ENDPOINTS_CACHE_VALUE=cacheable_endpoints_cache_value,
+    ):
         request = rf.get(reverse(view))
         assert (
             middleware.process_response(request, {}).get("Cache-Control", None)
-            == cacheable_endpoint_cache_value
+            == cacheable_endpoints_cache_value
         )

--- a/main/settings.py
+++ b/main/settings.py
@@ -228,6 +228,13 @@ CACHEABLE_ENDPOINTS = tuple(
     )
 )
 
+CACHEABLE_ENDPOINTS_CACHE_VALUE = get_string(
+    "CACHEABLE_ENDPOINTS_CACHE_VALUE",
+    "max-age=3600, public",
+    description="Cache-Control value for cacheable endpoints.",
+    required=False,
+)
+
 # use our own strategy because our pipeline is dependent on methods defined there
 SOCIAL_AUTH_STRATEGY = "authentication.strategy.DefaultStrategy"
 SOCIAL_AUTH_PIPELINE = (

--- a/main/settings.py
+++ b/main/settings.py
@@ -219,6 +219,15 @@ EDXORG_BASE_URL = get_string(
     required=True,
 )
 
+CACHEABLE_ENDPOINTS = tuple(
+    get_list(
+        "CACHEABLE_ENDPOINTS",
+        [],
+        description="A list of cacheable endpoints.",
+        required=False,
+    )
+)
+
 # use our own strategy because our pipeline is dependent on methods defined there
 SOCIAL_AUTH_STRATEGY = "authentication.strategy.DefaultStrategy"
 SOCIAL_AUTH_PIPELINE = (


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes: https://github.com/mitodl/bootcamp-ecommerce/issues/887

#### What's this PR do?
Allows changing cache-control headers via an environment variable CACHEABLE_ENDPOINTS

#### How should this be manually tested?
Add a `List of Endpoints` to a variable named `CACHEABLE_ENDPOINTS` in your local `.env`.
You will observe that cache-control headers are changed in the network tab of the browser.

#### How to configure it on PROD?
Simply add `All the Endpoints` you want to cache to `CACHEABLE_ENDPOINTS` variable as a list in Prod's environment.

#### Where should the reviewer start?
https://docs.fastly.com/en/guides/configuring-caching
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control