### PR TITLE
add management commands for certificates

### DIFF
--- a/klasses/management/commands/manage_certificates.py
+++ b/klasses/management/commands/manage_certificates.py
@@ -1,0 +1,114 @@
+"""
+Management command to manage certificates.
+"""
+from django.core.management.base import BaseCommand, CommandError
+
+from klasses.api import fetch_bootcamp_run
+from klasses.utils import (
+    generate_single_certificate,
+    generate_batch_certificates,
+    revoke_certificate,
+    unrevoke_certificate,
+)
+from profiles.api import fetch_user
+
+
+class Command(BaseCommand):
+    """
+    Command to manage certificates.
+    """
+
+    help = "Creates, assigns and revokes certificates"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="The id, email or username of the enrolled User",
+            required=False,
+        )
+        parser.add_argument(
+            "--run",
+            type=str,
+            help="The 'bootcamprun_id' value for a bootcamprun",
+            required=True,
+        )
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--revoke",
+            help="Flag to revoke single certificate",
+            dest="revoke",
+            action="store_true",
+            required=False,
+        )
+        group.add_argument(
+            "--unrevoke",
+            help="Flag to unrevoke single certificate",
+            dest="unrevoke",
+            action="store_true",
+            required=False,
+        )
+        group.add_argument(
+            "--generate",
+            help="Flag for single certificate generation",
+            dest="generate",
+            action="store_true",
+            required=False,
+        )
+        group.add_argument(
+            "--generate-batch",
+            help="Flag for batch certificate generation",
+            dest="generate_batch",
+            action="store_true",
+            required=False,
+        )
+
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):  # pylint: disable=too-many-locals
+        """Handle command execution"""
+        try:
+            user = fetch_user(options["user"]) if options["user"] else None
+            generate_single = options.get("generate")
+            generate_batch = options.get("generate_batch")
+            bootcamp_run = fetch_bootcamp_run(options.get("run"))
+            revoke = options.get("revoke")
+            unrevoke = options.get("unrevoke")
+        except:
+            raise CommandError("Provided values are not valid.")
+
+        if generate_single and (not user or not bootcamp_run):
+            raise CommandError(
+                "A valid 'user' and 'run' must be provided with 'generate'."
+            )
+        if generate_batch and not bootcamp_run:
+            raise CommandError("A valid 'run' must be provided with 'generate-batch'.")
+        if (revoke or unrevoke) and (not user or not bootcamp_run):
+            raise CommandError(
+                "A valid 'user' and 'run' must be provided with 'revoke' or 'unrevoke'"
+            )
+
+        if revoke and user and bootcamp_run:
+            result = revoke_certificate(user, bootcamp_run)
+            self.show_message(**result)
+        elif unrevoke and user and bootcamp_run:
+            result = unrevoke_certificate(user, bootcamp_run)
+            self.show_message(**result)
+        elif generate_single and bootcamp_run and user:
+            result = generate_single_certificate(user, bootcamp_run)
+            self.show_message(**result)
+        elif generate_batch and bootcamp_run:
+            result = generate_batch_certificates(bootcamp_run)
+            self.show_message(**result)
+        else:
+            raise CommandError(
+                "Provided values are not enough to govern any process, kidnly use --help for more details"
+            )
+
+    def show_message(self, updated, msg):
+        """Displays messages on console"""
+        self.stdout.write(
+            self.style.SUCCESS(msg)
+            if updated
+            else self.style.WARNING("No changes were made.\n{}".format(msg))
+        )

--- a/klasses/models.py
+++ b/klasses/models.py
@@ -290,6 +290,18 @@ class BaseCertificate(models.Model):
     class Meta:
         abstract = True
 
+    def revoke(self):
+        """Revokes certificate"""
+        self.is_revoked = True
+        self.save()
+        return self
+
+    def unrevoke(self):
+        """Unrevokes certificate"""
+        self.is_revoked = False
+        self.save()
+        return self
+
     def get_certified_object_id(self):
         """Gets the id of the certificate's bootcamp program/run"""
         raise NotImplementedError

--- a/klasses/utils.py
+++ b/klasses/utils.py
@@ -1,0 +1,152 @@
+"""Utility functions for Klasses"""
+
+from klasses.models import BootcampRunCertificate, BootcampRunEnrollment
+
+
+def generate_single_certificate(user, bootcamp_run):
+    """Generates certificate for a single user if its enrollment is active"""
+    result = {"updated": False}
+    if user and bootcamp_run:
+        certificate = BootcampRunCertificate.all_objects.filter(
+            user=user, bootcamp_run=bootcamp_run
+        ).first()
+        if certificate:
+            result[
+                "msg"
+            ] = "A {} certificate:{} already exists for user:{} in bootcamp-run:{}".format(
+                "revoked" if certificate.is_revoked else "",
+                certificate.link,
+                user.email,
+                bootcamp_run,
+            )
+        elif BootcampRunEnrollment.objects.filter(
+            user=user, bootcamp_run=bootcamp_run, active=True
+        ).exists():
+            certificate = BootcampRunCertificate.objects.create(
+                user=user, bootcamp_run=bootcamp_run
+            )
+            result.update(
+                {
+                    "updated": True,
+                    "msg": "A certificate:{} has been generated for user:{} in bootcamp-run:{}".format(
+                        certificate.link, user.email, bootcamp_run
+                    ),
+                }
+            )
+        else:
+            result[
+                "msg"
+            ] = "User:{} doesn't have an active enrollment in bootcamp-run:{}".format(
+                user.email, bootcamp_run
+            )
+    else:
+        result["msg"] = "Valid user and bootcamp_run must be provided."
+
+    return result
+
+
+def generate_batch_certificates(bootcamp_run):
+    """Generates certificates for all the users who have active enrollments in a bootcamp-run"""
+    result = {"updated": False}
+    if bootcamp_run:
+        certificates = BootcampRunCertificate.objects.bulk_create(
+            [
+                BootcampRunCertificate(user=enrollment.user, bootcamp_run=bootcamp_run)
+                for enrollment in BootcampRunEnrollment.objects.filter(
+                    bootcamp_run=bootcamp_run, active=True
+                )
+                if not BootcampRunCertificate.all_objects.filter(
+                    user=enrollment.user, bootcamp_run=bootcamp_run
+                ).exists()
+            ],
+            ignore_conflicts=True,
+        )
+        if len(certificates):
+            result.update(
+                {
+                    "updated": True,
+                    "msg": "{} new certificates have been created for bootcamp-run:{}".format(
+                        len(certificates), bootcamp_run
+                    ),
+                }
+            )
+        else:
+            result["msg"] = "No new certificates were made for bootcamp-run:{}".format(
+                bootcamp_run
+            )
+    else:
+        result["msg"] = "A valid bootcamp_run must be provided."
+
+    return result
+
+
+def revoke_certificate(user, bootcamp_run):
+    """Revokes certificate for the given user and bootcamp-run"""
+    result = {"updated": False}
+    if user and bootcamp_run:
+        certificate = BootcampRunCertificate.all_objects.filter(
+            user=user, bootcamp_run=bootcamp_run
+        ).first()
+        if certificate:
+            if not certificate.is_revoked:
+                certificate.revoke()
+                result.update(
+                    {
+                        "updated": True,
+                        "msg": "Certificate:{} has been revoked for user:{} in bootcamp-run:{}".format(
+                            certificate.link, user.email, bootcamp_run
+                        ),
+                    }
+                )
+            else:
+                result[
+                    "msg"
+                ] = "Certificate:{} is already in revoked state for user:{} in bootcamp-run:{}".format(
+                    certificate.link, user.email, bootcamp_run
+                )
+        else:
+            result[
+                "msg"
+            ] = "No Certificate found for user:{} in bootcamp-run:{}".format(
+                user.email, bootcamp_run
+            )
+    else:
+        result["msg"] = "Valid user and bootcamp_run must be provided."
+
+    return result
+
+
+def unrevoke_certificate(user, bootcamp_run):
+    """Unrevokes certificate for the given user and bootcamp-run"""
+    result = {"updated": False}
+    if user and bootcamp_run:
+        certificate = BootcampRunCertificate.all_objects.filter(
+            user=user, bootcamp_run=bootcamp_run
+        ).first()
+        if certificate:
+            if certificate.is_revoked:
+                certificate.unrevoke()
+                result.update(
+                    {
+                        "updated": True,
+                        "msg": "Certificate:{} has been unrevoked for user:{} in bootcamp-run:{}".format(
+                            certificate.link, user.email, bootcamp_run
+                        ),
+                    }
+                )
+            else:
+                result[
+                    "msg"
+                ] = "Certificate:{} is already in unrevoked state for user:{} in bootcamp-run:{}".format(
+                    certificate.link, user.email, bootcamp_run
+                )
+        else:
+            result[
+                "msg"
+            ] = "No Certificate found for user:{} in bootcamp-run:{}".format(
+                user.email, bootcamp_run
+            )
+    else:
+        result["msg"] = "Valid user and bootcamp_run must be provided."
+
+    return result


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/bootcamp-ecommerce/issues/1104

#### What's this PR do?
add management commands for certificates

#### How should this be manually tested?
You can test these commands via executing management commands in the web container, it supports 4 processes:
1) "./manage.py manage_certificates `--user <USER-ID>` `--run <BOOTCAMP-RUN-ID>` `--revoke`"  # To revoke certificates
2) "./manage.py manage_certificates `--user <USER-ID>` `--run <BOOTCAMP-RUN-ID>` `--unrevoke`"  # To unrevoke certificates
3) "./manage.py manage_certificates `--user <USER-ID>` `--run <BOOTCAMP-RUN-ID>` `--generate`"  # To generate certificates
4) "./manage.py manage_certificates `--run <BOOTCAMP-RUN-ID>` `--generate-batch`" # To generate certificates for everyone whose enrollment is active 
