### PR TITLE
Make sure waait is transpiled to ES5

### DIFF
--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -47,7 +47,8 @@ module.exports = {
       // and some of its dependencies to ES5.
       path.resolve(__dirname, "node_modules/query-string"),
       path.resolve(__dirname, "node_modules/strict-uri-encode"),
-      path.resolve(__dirname, "node_modules/split-on-first")
+      path.resolve(__dirname, "node_modules/split-on-first"),
+      path.resolve(__dirname, "node_modules/waait")
     ],
     loader:  "babel-loader",
     query:   {


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1123 

#### What's this PR do?
Adds the 'waait' library to the loader config so it gets transpiled to ES5

The sentry error fingers lodash but the offending module is actually waait. 

#### How should this be manually tested?
Create a production bundle (yarn run webpack:prod) and check that '=>' does not appear anywhere in the resulting bundle (/static/bundles/root*.js or /static/bundles/header*.js)

