### PR TITLE
#1125 Certificates: don't abbreviate dates

### DIFF
--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -62,7 +62,7 @@
             {% else %}
               <span class="general-text">Certificate of Completion</span>
             {% endif %}
-            <span class="general-text">{{end_date|date}}</span>
+            <span class="general-text">{{end_date|date:"F j, Y"}}</span>
             {% if location %}
               <span class="location-text">{{location}}</span>
             {% endif %}


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1125

#### What's this PR do?
Certificates: don't abbreviate dates

#### How should this be manually tested?
Just see the certificate before and now

#### Screenshots

**Now**

<img width="909" alt="Screenshot 2021-01-06 at 16 19 55" src="https://user-images.githubusercontent.com/4043989/103763472-b121b180-503b-11eb-8f8f-ed2c9d8b9830.png">

**Before**

<img width="939" alt="Screenshot 2021-01-06 at 16 14 52" src="https://user-images.githubusercontent.com/4043989/103763428-a5ce8600-503b-11eb-80bb-7f25bf363620.png">
