### PR TITLE
small fixes for certificates template rendering

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1035,6 +1035,7 @@ class CertificatePage(BootcampRunChildPage):
                 if parent.bootcamp_run
                 else datetime.now(),
                 "location": self.location if self.location else "Brisbane, Australia",
+                "certificate_user": None,
             }
         elif self.certificate:
             # Verify that the certificate in fact is for this same course
@@ -1058,6 +1059,9 @@ class CertificatePage(BootcampRunChildPage):
             "share_image_url": urljoin(
                 request.build_absolute_uri("///"),
                 static("images/certificates/share-image.png"),
+            ),
+            "share_text": "I just earned a certificate in {}".format(
+                self.bootcamp_run_name
             ),
             **super().get_context(request, *args, **kwargs),
             **preview_context,

--- a/cms/templates/certificate_page.html
+++ b/cms/templates/certificate_page.html
@@ -22,7 +22,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://www.linkedin.com/profile/add?startTask={{ page.product_name|urlencode }}" target="_blank">
+                            <a href="https://www.linkedin.com/profile/add?startTask={{ page.bootcamp_run_name|urlencode }}" target="_blank">
                                 <img src="{% static 'images/certificates/icon-linkedin.svg' %}" alt="Share to LinkedIn">
                             </a>
                         </li>


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/bootcamp-ecommerce/issues/1127

#### What's this PR do?
This PR solves three small bugs regarding Certificate Template rendering:
1) `certificate_user was not present in the certificate's preview` context which caused rendering errors, this PR fixes it.
2) certificate page doesn't have any field named `product_name`, this PR replaces it with `bootcamp_run_name`
3) it adds `share_text` for the LinkedIn certificate sharing feature in the certificate context. 

#### How should this be manually tested?
Just open certificates in different modes and see if any error occurs or not
