### PR TITLE
Fixed application state for personal prices set to zero

### DIFF
--- a/klasses/admin.py
+++ b/klasses/admin.py
@@ -45,7 +45,7 @@ class BootcampRunEnrollmentAdmin(TimestampedModelAdmin):
 
     model = models.BootcampRunEnrollment
     include_created_on_in_list = True
-    list_display = ("id", "bootcamp_run", "user", "change_status", "active")
+    list_display = ("id", "get_user_email", "bootcamp_run", "change_status", "active")
     list_filter = ("change_status", "active", "bootcamp_run__bootcamp")
     raw_id_fields = ("bootcamp_run", "user")
     search_fields = (
@@ -63,6 +63,13 @@ class BootcampRunEnrollmentAdmin(TimestampedModelAdmin):
             .select_related("user", "bootcamp_run__bootcamp")
         )
 
+    def get_user_email(self, obj):
+        """Returns the user email"""
+        return obj.user.email
+
+    get_user_email.short_description = "User"
+    get_user_email.admin_order_field = "user__email"
+
 
 class InstallmentAdmin(admin.ModelAdmin):
     """Admin for Installment"""
@@ -76,8 +83,8 @@ class PersonalPriceAdmin(admin.ModelAdmin):
     """Admin for PersonalPrice"""
 
     model = models.PersonalPrice
-    list_display = ("id", "bootcamp_run", "user", "price")
-    list_filter = ("bootcamp_run__bootcamp", "bootcamp_run")
+    list_display = ("id", "get_user_email", "bootcamp_run", "price")
+    list_filter = ("bootcamp_run__bootcamp",)
     raw_id_fields = ("bootcamp_run", "user")
     search_fields = (
         "price",
@@ -89,13 +96,28 @@ class PersonalPriceAdmin(admin.ModelAdmin):
         "user__legal_address__last_name",
     )
 
+    def get_queryset(self, request):
+        """Overrides base queryset"""
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("user", "bootcamp_run__bootcamp")
+        )
+
+    def get_user_email(self, obj):
+        """Returns the user email"""
+        return obj.user.email
+
+    get_user_email.short_description = "User"
+    get_user_email.admin_order_field = "user__email"
+
 
 class BootcampRunCertificateAdmin(TimestampedModelAdmin):
     """Admin for BootcampRunCertificate"""
 
     model = models.BootcampRunCertificate
     include_timestamps_in_list = True
-    list_display = ["uuid", "user", "bootcamp_run", "get_revoked_state"]
+    list_display = ["uuid", "get_user_email", "bootcamp_run", "get_revoked_state"]
     search_fields = [
         "bootcamp_run__id",
         "bootcamp_run__title",
@@ -104,6 +126,11 @@ class BootcampRunCertificateAdmin(TimestampedModelAdmin):
     ]
     raw_id_fields = ("user",)
 
+    def get_queryset(self, request):
+        return self.model.all_objects.get_queryset().select_related(
+            "user", "bootcamp_run"
+        )
+
     def get_revoked_state(self, obj):
         """ return the revoked state"""
         return obj.is_revoked is not True
@@ -111,10 +138,12 @@ class BootcampRunCertificateAdmin(TimestampedModelAdmin):
     get_revoked_state.short_description = "Active"
     get_revoked_state.boolean = True
 
-    def get_queryset(self, request):
-        return self.model.all_objects.get_queryset().select_related(
-            "user", "bootcamp_run"
-        )
+    def get_user_email(self, obj):
+        """Returns the user email"""
+        return obj.user.email
+
+    get_user_email.short_description = "User"
+    get_user_email.admin_order_field = "user__email"
 
 
 admin.site.register(models.Bootcamp, BootcampAdmin)

--- a/klasses/api.py
+++ b/klasses/api.py
@@ -77,7 +77,8 @@ def adjust_app_state_for_new_price(user, bootcamp_run, new_price=None):
         order__user=user, bootcamp_run=bootcamp_run
     ).aggregate(aggregate_total_paid=Sum("price"))
     total_paid = total_paid_qset["aggregate_total_paid"] or 0
-    needs_payment = total_paid < (new_price or bootcamp_run.price)
+    new_price = new_price if new_price is not None else bootcamp_run.price
+    needs_payment = total_paid < new_price
     application = user.bootcamp_applications.filter(
         bootcamp_run=bootcamp_run,
         # The state needs to change if (a) it's currently complete and now needs more payment, or (b) it's currently

--- a/klasses/api_test.py
+++ b/klasses/api_test.py
@@ -124,6 +124,21 @@ def test_adjust_app_state_for_new_price(personal_price_amt, init_state, expected
     assert app.state == expected_state
 
 
+@factory.django.mute_signals(signals.post_save)
+@pytest.mark.django_db
+def test_adjust_app_state_for_zero_price():
+    """
+    adjust_app_state_for_new_price should update a bootcamp application state to complete if the application was
+    awaiting payment and the personal price was set to zero
+    """
+    app = BootcampApplicationFactory.create(state=AppStates.AWAITING_PAYMENT.value)
+    InstallmentFactory.create(bootcamp_run=app.bootcamp_run, amount=10)
+    returned_app = adjust_app_state_for_new_price(
+        user=app.user, bootcamp_run=app.bootcamp_run, new_price=0
+    )
+    assert returned_app.state == AppStates.COMPLETE.value
+
+
 @pytest.mark.django_db
 def test_fetch_bootcamp_run():
     """fetch_bootcamp_run should fetch a bootcamp run with a field value that matches the given property"""


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #1112 

#### What's this PR do?
- Fixes personal price adjustment behavior such that if a personal price is set to 0, and a user has an application for that bootcamp run in the "awaiting payment" state, that application is then set to "complete"
- Streamlines some of the `klasses` app admin class definitions

#### How should this be manually tested?
1. Start out with a user with an application that is awaiting payment (use the `set_application_state` command)
1. Ensure that the given bootcamp run has an installment with a non-zero amount
1. Create/update a personal price for that user/run with the amount set to zero

This is signals-based, so your application should be automatically set to "complete"

#### Any background context you want to provide?
Initial implementation for this personal price adjustment behavior was in this PR: https://github.com/mitodl/bootcamp-ecommerce/pull/1094