### PR TITLE
Ignore submit, do not throw error, if partial token is null on password page

### DIFF
--- a/static/js/pages/login/LoginPasswordPage.js
+++ b/static/js/pages/login/LoginPasswordPage.js
@@ -64,17 +64,15 @@ export class LoginPasswordPage extends React.Component<Props> {
       auth: { partial_token }
     } = this.props
 
-    if (!partial_token) {
-      throw Error("Invalid state: password page with no partialToken")
-    }
-
     try {
-      const { body } = await loginPassword(password, partial_token)
+      if (partial_token) {
+        const { body } = await loginPassword(password, partial_token)
 
-      handleAuthResponse(history, body, {
-        [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
-          setErrors(field_errors)
-      })
+        handleAuthResponse(history, body, {
+          [STATE_ERROR]: ({ field_errors }: AuthResponse) =>
+            setErrors(field_errors)
+        })
+      }
     } finally {
       setSubmitting(false)
     }

--- a/static/js/pages/login/LoginPasswordPage_test.js
+++ b/static/js/pages/login/LoginPasswordPage_test.js
@@ -105,4 +105,18 @@ describe("LoginPasswordPage", () => {
     sinon.assert.notCalled(setErrorsStub)
     sinon.assert.calledWith(setSubmittingStub, false)
   })
+
+  it("onSubmit will not do anything if partial_token is null", async () => {
+    const { inner } = await renderPage()
+
+    auth.partial_token = null
+    const onSubmit = inner.find("LoginPasswordForm").prop("onSubmit")
+
+    await onSubmit(
+      { password },
+      { setSubmitting: setSubmittingStub, setErrors: setErrorsStub }
+    )
+    sinon.assert.notCalled(helper.handleRequestStub)
+    sinon.assert.calledWith(setSubmittingStub, false)
+  })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1130 

#### What's this PR do?
Instead of throwing an error,  the submit button does nothing if pressed while the auth partial_token is null.  After talking with Nathan, best guess is that this scenario should only happen on a double submission.  If the token is null on page load, the user would be redirected back to the signin page.


#### How should this be manually tested?
Tests should pass.
