### PR TITLE
quiet CSOURCE_PAYLOAD error

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -1055,6 +1055,7 @@ class CertificatePage(BootcampRunChildPage):
 
         # The share image url needs to be absolute
         return {
+            "CSOURCE_PAYLOAD": None,
             "site_name": settings.SITE_NAME,
             "share_image_url": urljoin(
                 request.build_absolute_uri("///"),


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/bootcamp-ecommerce/issues/974

#### What's this PR do?
Fixes a quiet error in template rendering when accessing a variable that wasn't defined in the first place

#### How should this be manually tested?
Go to any certificate and you will not see `CSOURCE_PAYLOAD` error anymore.
