### PR TITLE
upgrade lxml to v4.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ jedi==0.10.2              # via ipython
 jmespath==0.9.5           # via boto3, botocore
 kombu==4.6.7              # via celery, django-server-status
 l18n==2018.5              # via wagtail
-lxml==4.5.0               # via premailer, zeep
+lxml==4.6.2               # via premailer, zeep
 newrelic==2.86.3.70       # via -r requirements.in
 oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
 pexpect==4.2.1            # via ipython


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/bootcamp-ecommerce/issues/1138

#### What's this PR do?
Upgrades lxml  version to v4.6.2

