### PR TITLE
Fixed external bootcamp link icon positioning in dashboard

### DIFF
--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -480,7 +480,10 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
                       rel="noopener noreferrer"
                     >
                       {titleText}
-                      <i className="material-icons">open_in_new</i>
+                      <span>
+                        {/*&#65279; == zero-width non-breaking space. Necessary to prevent icon wrapping.*/}
+                        &#65279;<i className="material-icons">open_in_new</i>
+                      </span>
                     </a>
                   ) : (
                     titleText

--- a/static/scss/application.scss
+++ b/static/scss/application.scss
@@ -22,11 +22,18 @@ $border-style: 1px solid $black;
   }
 
   h2 a {
-    display: inline-flex;
+    display: inline;
     align-items: center;
 
     i {
       padding-left: 3px;
+      vertical-align: top;
+    }
+
+    span {
+      // Wrapping the material icon in a span with this styling prevents it from being "orphaned" on the next line
+      // after the title text.
+      white-space: nowrap;
     }
 
     &:hover {


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a styling bug in the application dashboard. See screenshots for an example of the bug.

#### How should this be manually tested?
Go to you application dashboard and ensure that you have an application for a bootcamp run with a `novoed_course_stub` value. This will make the bootcamp title a link with an external/new window link icon at the end. No matter what the length of the title is, the icon should be show immediately next to the last character of the title, and it should never be "orphaned" on its own line.

#### Any background context you want to provide?
🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 

#### Screenshots (if appropriate)

##### Before
![bootcamp-dash-ui-bug](https://user-images.githubusercontent.com/14932219/105396569-105ff400-5bee-11eb-89f6-d96a4d3c18ce.png)

##### After
![ss 2021-01-21 at 13 32 53 ](https://user-images.githubusercontent.com/14932219/105396284-b5c69800-5bed-11eb-9b38-fb847dc925e3.png)
![ss 2021-01-21 at 13 29 15 ](https://user-images.githubusercontent.com/14932219/105396291-b6f7c500-5bed-11eb-9745-e46d2a3a1e20.png)

