### PR TITLE
Admin: Added Bootcamp run filter on BootcampRunEnrollment

### DIFF
--- a/klasses/admin.py
+++ b/klasses/admin.py
@@ -57,6 +57,7 @@ class BootcampRunEnrollmentAdmin(TimestampedModelAdmin):
         "change_status",
         "active",
         "bootcamp_run__bootcamp",
+        "bootcamp_run",
         "user_certificate_is_blocked",
     )
     raw_id_fields = ("bootcamp_run", "user")


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #1143 

#### What's this PR do?
Adds a filter by `bootcamp runs` on `Bootcamp Run Enrollment` admin page.

#### How should this be manually tested?
- Open bootcamp run enrollment model in admin and verify that there is a new filter `By bootcamp run` on the page
- Click any bootcamp run in the filter and verify the filtered results

#### Screenshots (if appropriate)

<img width="1439" alt="Screenshot 2021-01-22 at 12 48 05 PM" src="https://user-images.githubusercontent.com/34372316/105462832-0bb04400-5cb1-11eb-99a4-a7ce9b3c86a3.png">
