### PR TITLE
Wiretransfer: after data is imported, update the application state

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -257,7 +257,6 @@ class BootcampApplication(TimestampedModel):
     )
     def complete(self):
         """Mark the application as completed"""
-        # import pdb; pdb.set_trace()
         BootcampRunEnrollment.objects.update_or_create(
             user=self.user,
             bootcamp_run=self.bootcamp_run,

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -559,7 +559,7 @@ def import_wire_transfer(wire_transfer, header_row):
 
     with transaction.atomic():
         order = Order.objects.create(
-            status=Order.FULFILLED,
+            status=Order.CREATED,
             total_price_paid=wire_transfer.amount,
             application=application,
             user=user,
@@ -571,7 +571,6 @@ def import_wire_transfer(wire_transfer, header_row):
             description=f"Wire transfer payment for {bootcamp_run}",
             price=wire_transfer.amount,
         )
-        order.save_and_log(None)  # save record in audit table
 
         WireTransferReceipt.objects.create(
             wire_transfer_id=wire_transfer.id,
@@ -580,6 +579,8 @@ def import_wire_transfer(wire_transfer, header_row):
             },
             order=order,
         )
+        complete_successful_order(order, send_receipt=False)
+
     log.info("Wire transfer %d successfully imported", wire_transfer.id)
 
 

--- a/ecommerce/api.py
+++ b/ecommerce/api.py
@@ -579,7 +579,7 @@ def import_wire_transfer(wire_transfer, header_row):
             },
             order=order,
         )
-        complete_successful_order(order, send_receipt=False)
+        complete_successful_order(order)
 
     log.info("Wire transfer %d successfully imported", wire_transfer.id)
 


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1032 

#### What's this PR do?
Wiretransfer: after data is imported, update the application state

#### How should this be manually tested?
Run the `import_wire_transfers` management command for `AWAITING_PAYMENT` application


#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2021-01-26 at 17 11 32" src="https://user-images.githubusercontent.com/4043989/105845474-9ae49100-5ffc-11eb-8e55-816b1ed96ef4.png">
