### PR TITLE
#1155 display user's country in export compliance admin

### DIFF
--- a/compliance/admin.py
+++ b/compliance/admin.py
@@ -2,6 +2,7 @@
 Admin site bindings for compliance
 """
 
+import pycountry
 from django.conf import settings
 from django.contrib import admin
 
@@ -17,10 +18,19 @@ class ExportsInquiryLogAdmin(admin.ModelAdmin):
 
     model = ExportsInquiryLog
     search_fields = ["user__email", "computed_result", "info_code", "reason_code"]
-    list_filter = ["computed_result", "info_code", "reason_code"]
-    list_display = ["user", "computed_result", "info_code", "reason_code"]
+    list_filter = [
+        "computed_result",
+        "info_code",
+        "reason_code",
+        "user__legal_address__country",
+    ]
+    list_display = ["user", "computed_result", "info_code", "reason_code", "country"]
+    list_select_related = ["user__legal_address"]
     readonly_fields = [] if settings.DEBUG else get_field_names(ExportsInquiryLog)
     actions = ["manually_approve_inquiry"]
+
+    def country(self, instance):
+        return pycountry.countries.get(alpha_2=instance.user.legal_address.country).name
 
     def manually_approve_inquiry(self, request, queryset):
         """Admin action to manually approve export compliance inquiry records"""

--- a/compliance/admin.py
+++ b/compliance/admin.py
@@ -30,6 +30,7 @@ class ExportsInquiryLogAdmin(admin.ModelAdmin):
     actions = ["manually_approve_inquiry"]
 
     def country(self, instance):
+        """ generate country name from pycountry """
         return pycountry.countries.get(alpha_2=instance.user.legal_address.country).name
 
     def manually_approve_inquiry(self, request, queryset):


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1155 

#### What's this PR do?
display user's country in export compliance admin

#### How should this be manually tested?
Just see the country in the list display of the admin

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2021-02-09 at 17 35 38" src="https://user-images.githubusercontent.com/4043989/107364482-4e6d7b00-6afd-11eb-9b22-35184de3cbb5.png">
