### PR TITLE
Upgrading cryptography to 3.4.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ celery==4.3.0             # via -r requirements.in, django-server-status
 certifi==2018.10.15       # via requests, sentry-sdk
 cffi==1.14.0              # via cryptography, pynacl
 chardet==3.0.4            # via requests
-cryptography==3.2.1       # via pyopenssl, pysaml2
+cryptography==3.4.4       # via pyopenssl, pysaml2
 cssselect==1.1.0          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.0.11         # via ipython, traitlets
@@ -93,7 +93,7 @@ requests==2.20.1          # via -r requirements.in, django-anymail, dynamic-rest
 s3transfer==0.3.3         # via boto3
 sentry-sdk==0.14.3        # via -r requirements.in
 simplegeneric==0.8.1      # via ipython
-six==1.15.0               # via cryptography, django-anymail, django-classy-tags, django-compat, django-server-status, html5lib, isodate, l18n, prompt-toolkit, pynacl, pyopenssl, pysaml2, python-dateutil, social-auth-app-django, social-auth-core, traitlets, zeep
+six==1.15.0               # via django-anymail, django-classy-tags, django-compat, django-server-status, html5lib, isodate, l18n, prompt-toolkit, pynacl, pyopenssl, pysaml2, python-dateutil, social-auth-app-django, social-auth-core, traitlets, zeep
 social-auth-app-django==2.1.0  # via -r requirements.in
 social-auth-core==1.4.0   # via social-auth-app-django
 soupsieve==2.0.1          # via beautifulsoup4


### PR DESCRIPTION
#### What are the relevant tickets?
**Dependabot Alert:**
https://github.com/mitodl/bootcamp-ecommerce/security/dependabot/requirements.txt/cryptography/open

#### What's this PR do?
It upgrades Cryptography to 3.4.4 

#### How should this be manually tested?
Checking on the tests. Nothing should break
