### PR TITLE
Send compliance emails to ADMIN_EMAIL instead of EMAIL_SUPPORT

### DIFF
--- a/authentication/pipeline/compliance.py
+++ b/authentication/pipeline/compliance.py
@@ -102,8 +102,8 @@ def verify_exports_compliance(
                     mail.send_mail(
                         f"Exports Compliance: denied {user.email}",
                         f"User with first name '{user.legal_address.first_name}', last name '{user.legal_address.last_name}, address '{' '.join(user.legal_address.street_address)}{city}{state}{postal_code}{country}' , and email '{user.email}' was denied due to exports violation, for reason_code={export_inquiry.reason_code}, info_code={export_inquiry.info_code}",
-                        settings.ADMIN_EMAIL,
-                        [settings.EMAIL_SUPPORT],
+                        settings.EMAIL_SUPPORT,
+                        [settings.ADMIN_EMAIL],
                         connection=connection,
                     )
             except Exception:  # pylint: disable=broad-except

--- a/main/settings.py
+++ b/main/settings.py
@@ -527,7 +527,9 @@ BOOTCAMP_REPLY_TO_ADDRESS = get_string(
 
 # e-mail configurable admins
 ADMIN_EMAIL = get_string(
-    "BOOTCAMP_ADMIN_EMAIL", "", description="E-mail to send 500 reports to"
+    "BOOTCAMP_ADMIN_EMAIL",
+    "admin@example.com",
+    description="E-mail to send 500 reports to",
 )
 if ADMIN_EMAIL != "":
     ADMINS = (("Admins", ADMIN_EMAIL),)


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1161 

#### What's this PR do?
Send compliance emails to ADMIN_EMAIL instead of EMAIL_SUPPORT

#### How should this be manually tested?
Try to generate the Compliance email and check you are receiving it on ADMIN_EMAIL
