### PR TITLE
Bump django from 2.2.13 to 2.2.18

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django==2.2.13
+Django==2.2.18
 celery==4.3.0
 boto3==1.12.42
 dj-database-url==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ django-taggit==1.2.0      # via wagtail
 django-templated-mail==1.1.1  # via djoser
 django-treebeard==4.3.1   # via wagtail
 django-webpack-loader==0.5.0  # via -r requirements.in
-django==2.2.13            # via -r requirements.in, django-anymail, django-classy-tags, django-filter, django-storages, django-taggit, django-treebeard, djangosaml2idp, dynamic-rest, wagtail
+django==2.2.18            # via -r requirements.in, django-anymail, django-classy-tags, django-filter, django-storages, django-taggit, django-treebeard, djangosaml2idp, dynamic-rest, wagtail
 djangorestframework-serializer-extensions==2.0.0  # via -r requirements.in
 djangorestframework==3.9.2  # via -r requirements.in, dynamic-rest, wagtail
 git+git://github.com/OTA-Insight/djangosaml2idp.git@e12319949dc4911657d0fff91c93317fdef691d4#egg=djangosaml2idp  # via -r requirements.in


### PR DESCRIPTION
#### What are the relevant tickets?
Related to a security alert: https://github.com/mitodl/bootcamp-ecommerce/security/dependabot/requirements.txt/django/open

#### What's this PR do?
Upgrades Django from 2.2.13 to 2.2.18

#### How should this be manually tested?
Though our code coverage should be a good pointer to see that nothing breaks after this change & A general go through of the application parts that specifically uses Django
