### PR TITLE
Upgrade caniuse-lite to fix breaking JS tests

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3387,9 +3387,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001039:
-  version "1.0.30001144"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001144.tgz"
-  integrity sha512-4GQTEWNMnVZVOFG3BK0xvGeaDAtiPAbG2N8yuMXuXzx/c2Vd4XoMPO8+E918zeXn5IF0FRVtGShBfkfQea2wHQ==
+  version "1.0.30001204"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz"
+  integrity sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Upgrades `caniuse-lite` package, in turn fixing the caniuse-lite outdated error seen in https://github.com/mitodl/bootcamp-ecommerce/runs/2163859986

#### How should this be manually tested?
The tests should pass.
