### PR TITLE
bootcamp_run_id hubspot sync & mapping

### DIFF
--- a/hubspot/management/commands/configure_hubspot_bridge.py
+++ b/hubspot/management/commands/configure_hubspot_bridge.py
@@ -207,6 +207,19 @@ CUSTOM_ECOMMERCE_PROPERTIES = {
             },
         ],
     },
+    "products": {
+        "groups": [],
+        "properties": [
+            {
+                "description": "Bootcamp Run ID",
+                "fieldType": "text",
+                "groupName": "productinformation",
+                "label": "Bootcamp Run ID",
+                "name": "bootcamp_run_id",
+                "type": "string",
+            }
+        ],
+    },
 }
 
 HUBSPOT_ECOMMERCE_SETTINGS = {
@@ -217,7 +230,12 @@ HUBSPOT_ECOMMERCE_SETTINGS = {
                 "propertyName": "title",
                 "targetHubspotProperty": "name",
                 "dataType": "STRING",
-            }
+            },
+            {
+                "propertyName": "bootcamp_run_id",
+                "targetHubspotProperty": "bootcamp_run_id",
+                "dataType": "STRING",
+            },
         ]
     },
     "dealSyncSettings": {


### PR DESCRIPTION
#### What are the relevant tickets?
Hubspot box on this ticket https://github.com/mitodl/bootcamp-ecommerce/issues/1173

#### What's this PR do?
- Adds a new field mapping for `bootcamp_run_id` in product properties of Hubspot.

#### How should this be manually tested?
- You will need to check the Hubspot account and verify that there is a new custom key added in properties of the product
- The group associated with it should be `productinformation`
- We will need to run `configure_hubspot_bridge` command to sync the new custom property with Hubspot before we start syncing `BootcampRun` objects.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
We recently added `bootcamp_run_id` field in BootcampRunModel and now we are syncing it with Hubspot -- This PR creates the right mapping and the request data has already been implemented in https://github.com/mitodl/bootcamp-ecommerce/pull/1178 that is merged.

#### Screenshots
<img width="1180" alt="Screenshot 2021-04-01 at 4 30 52 PM" src="https://user-images.githubusercontent.com/34372316/113288193-0e11c880-9308-11eb-8d0a-2040accc8f9f.png">
<img width="736" alt="Screenshot 2021-04-01 at 4 31 23 PM" src="https://user-images.githubusercontent.com/34372316/113288200-11a54f80-9308-11eb-96d8-9df5cf6d36d3.png">
