### PR TITLE
set `can_skip_application_steps` to True and unblock the certificate for the alumni

### DIFF
--- a/profiles/api.py
+++ b/profiles/api.py
@@ -305,7 +305,7 @@ def import_alum(alum):
         from profiles.models import Profile, LegalAddress
 
         LegalAddress.objects.create(user=user)
-        Profile.objects.create(user=user)
+        Profile.objects.create(user=user, can_skip_application_steps=True)
         user.username = usernameify("", user.email)
         user.save()
 
@@ -327,12 +327,10 @@ def import_alum(alum):
         end_date__lte=bootcamp_end_date + timedelta(days=1),
     )
 
-    enrollment, created = BootcampRunEnrollment.objects.get_or_create(
+    _, created = BootcampRunEnrollment.objects.get_or_create(
         user=user, bootcamp_run=bootcamp_run
     )
     if created:
-        enrollment.user_certificate_is_blocked = True
-        enrollment.save()
         log.info(
             "User=%s successfully enrolled in bootcamp run %s",
             alum.learner_email,

--- a/profiles/api_test.py
+++ b/profiles/api_test.py
@@ -316,7 +316,8 @@ def test_import_alumni_with_enrollment(caplog):
     assert enrollment
     assert enrollment.user == user
     assert enrollment.bootcamp_run == run
-    assert enrollment.user_certificate_is_blocked
+    assert enrollment.user.profile.can_skip_application_steps
+    assert enrollment.user_certificate_is_blocked is False
 
     # check for alreading existing enrollments
     import_alum(alum)


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1182 

#### What's this PR do?
set `can_skip_application_steps` to True and unblock the certificate for the alumni

#### How should this be manually tested?
Just run the management command for importing the alumni
`docker-compose exec web python manage.py import_alumni profiles/testdata/example_alumni.csv`

Verify the following as shown in the attached screenshots

- User profiles are set `can_skip_application_steps` is `True`
- Enrollment record should have `user_certificate_is_blocked` is `False`


#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2021-04-02 at 14 31 37" src="https://user-images.githubusercontent.com/4043989/113403879-c56a1600-93c0-11eb-85b3-6ff9e4911b18.png">
<img width="1440" alt="Screenshot 2021-04-02 at 14 32 04" src="https://user-images.githubusercontent.com/4043989/113403898-c9963380-93c0-11eb-8ff5-f70e12fbae2e.png">
