### PR TITLE
Upgrade deps: pip-tool, lxml and pygments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,114 +4,322 @@
 #
 #    pip-compile requirements.in
 #
-amqp==2.5.2               # via kombu
-appdirs==1.4.3            # via zeep
-arrow==0.16.0             # via djangosaml2idp
-attrs==19.3.0             # via zeep
-beautifulsoup4==4.8.2     # via wagtail
-billiard==3.6.3.0         # via celery
-boto3==1.12.42            # via -r requirements.in
-botocore==1.15.42         # via boto3, s3transfer
-cached-property==1.5.1    # via zeep
-cachetools==4.1.0         # via premailer
-celery==4.3.0             # via -r requirements.in, django-server-status
-certifi==2018.10.15       # via requests, sentry-sdk
-cffi==1.14.0              # via cryptography, pynacl
-chardet==3.0.4            # via requests
-cryptography==3.4.4       # via pyopenssl, pysaml2
-cssselect==1.1.0          # via premailer
-cssutils==1.0.2           # via premailer
-decorator==4.0.11         # via ipython, traitlets
-defusedxml==0.5.0         # via pysaml2, python3-openid, social-auth-core, zeep
-dj-database-url==0.3.0    # via -r requirements.in
-dj-static==0.0.6          # via -r requirements.in
-django-anymail[mailgun]==6.1.0  # via -r requirements.in
-django-cache-memoize==0.1.7  # via -r requirements.in
-django-classy-tags==1.0.0  # via -r requirements.in
-django-compat==1.0.15     # via -r requirements.in, django-hijack, django-hijack-admin
-django-filter==2.2.0      # via -r requirements.in
-django-fsm==2.6.1         # via -r requirements.in
-django-hijack-admin==2.1.7  # via -r requirements.in
-django-hijack==2.1.10     # via -r requirements.in, django-hijack-admin
-django-ipware==3.0.0      # via -r requirements.in
-django-mathfilters==1.0.0  # via -r requirements.in
-django-modelcluster==5.0.1  # via wagtail
-django-redis==4.7.0       # via -r requirements.in
-django-server-status==0.5.0  # via -r requirements.in
-django-storages==1.9.1    # via -r requirements.in
-django-taggit==1.2.0      # via wagtail
-django-templated-mail==1.1.1  # via djoser
-django-treebeard==4.3.1   # via wagtail
-django-webpack-loader==0.5.0  # via -r requirements.in
-django==2.2.18            # via -r requirements.in, django-anymail, django-classy-tags, django-filter, django-storages, django-taggit, django-treebeard, djangosaml2idp, dynamic-rest, wagtail
-djangorestframework-serializer-extensions==2.0.0  # via -r requirements.in
-djangorestframework==3.9.2  # via -r requirements.in, dynamic-rest, wagtail
-git+git://github.com/OTA-Insight/djangosaml2idp.git@e12319949dc4911657d0fff91c93317fdef691d4#egg=djangosaml2idp  # via -r requirements.in
-djoser==1.7.0             # via -r requirements.in
-docutils==0.15.2          # via botocore
-draftjs-exporter==2.1.7   # via wagtail
-dynamic-rest==1.9.6       # via -r requirements.in
-elasticsearch==5.4.0      # via django-server-status
-elementpath==2.1.3        # via xmlschema
-hashids==1.2.0            # via djangorestframework-serializer-extensions
-html5lib==0.999999999     # via -r requirements.in, wagtail
-idna==2.7                 # via requests
-importlib-metadata==1.6.0  # via kombu
-importlib-resources==5.1.0  # via pysaml2
-inflection==0.3.1         # via dynamic-rest
-ipython-genutils==0.2.0   # via traitlets
-ipython==6.1.0            # via -r requirements.in
-isodate==0.6.0            # via zeep
-jedi==0.10.2              # via ipython
-jmespath==0.9.5           # via boto3, botocore
-kombu==4.6.7              # via celery, django-server-status
-l18n==2018.5              # via wagtail
-lxml==4.6.2               # via premailer, zeep
-newrelic==2.86.3.70       # via -r requirements.in
-oauthlib==2.0.2           # via requests-oauthlib, social-auth-core
-pexpect==4.2.1            # via ipython
-pickleshare==0.7.4        # via ipython
-pillow==7.1.0             # via -r requirements.in, wagtail
-premailer==3.7.0          # via -r requirements.in
-prompt-toolkit==1.0.14    # via ipython
-psycopg2==2.7.3.2         # via -r requirements.in, django-server-status
-ptyprocess==0.5.1         # via pexpect
-pycountry==19.8.18        # via -r requirements.in
-pycparser==2.20           # via cffi
-pygments==2.2.0           # via ipython
-pyjwt==1.5.0              # via social-auth-core
-pynacl==1.3.0             # via -r requirements.in
-pyopenssl==19.1.0         # via pysaml2
-pysaml2==6.5.1            # via djangosaml2idp
-python-dateutil==2.8.1    # via -r requirements.in, arrow, botocore, pysaml2
-python3-openid==3.1.0     # via social-auth-core
-pytz==2019.3              # via -r requirements.in, celery, django, django-modelcluster, djangosaml2idp, l18n, pysaml2, zeep
-redis==3.2.0              # via -r requirements.in, django-redis, django-server-status
-requests-oauthlib==0.8.0  # via social-auth-core
-requests-toolbelt==0.9.1  # via zeep
-requests==2.20.1          # via -r requirements.in, django-anymail, dynamic-rest, premailer, pysaml2, requests-oauthlib, requests-toolbelt, social-auth-core, wagtail, zeep
-s3transfer==0.3.3         # via boto3
-sentry-sdk==0.14.3        # via -r requirements.in
-simplegeneric==0.8.1      # via ipython
-six==1.15.0               # via django-anymail, django-classy-tags, django-compat, django-server-status, html5lib, isodate, l18n, prompt-toolkit, pynacl, pyopenssl, pysaml2, python-dateutil, social-auth-app-django, social-auth-core, traitlets, zeep
-social-auth-app-django==2.1.0  # via -r requirements.in
-social-auth-core==1.4.0   # via social-auth-app-django
-soupsieve==2.0.1          # via beautifulsoup4
-sqlparse==0.3.1           # via django
-static3==0.5.1            # via -r requirements.in, dj-static
-traitlets==4.3.2          # via ipython
-unidecode==1.1.1          # via wagtail
-urllib3==1.24.2           # via -r requirements.in, botocore, elasticsearch, requests, sentry-sdk
-uwsgi==2.0.18             # via -r requirements.in
-vine==1.3.0               # via amqp, celery
-wagtail==2.9.3            # via -r requirements.in
-wcwidth==0.1.7            # via prompt-toolkit
-webencodings==0.5.1       # via html5lib
-willow==1.3               # via wagtail
-xlsxwriter==1.2.9         # via wagtail
-xmlschema==1.4.2          # via pysaml2
-zeep==3.4.0               # via -r requirements.in
-zipp==3.1.0               # via importlib-metadata, importlib-resources
+amqp==2.5.2
+    # via kombu
+appdirs==1.4.3
+    # via zeep
+arrow==0.16.0
+    # via djangosaml2idp
+attrs==19.3.0
+    # via zeep
+beautifulsoup4==4.8.2
+    # via wagtail
+billiard==3.6.3.0
+    # via celery
+boto3==1.12.42
+    # via -r requirements.in
+botocore==1.15.42
+    # via
+    #   boto3
+    #   s3transfer
+cached-property==1.5.1
+    # via zeep
+cachetools==4.1.0
+    # via premailer
+celery==4.3.0
+    # via
+    #   -r requirements.in
+    #   django-server-status
+certifi==2018.10.15
+    # via
+    #   requests
+    #   sentry-sdk
+cffi==1.14.0
+    # via
+    #   cryptography
+    #   pynacl
+chardet==3.0.4
+    # via requests
+cryptography==3.4.4
+    # via
+    #   pyopenssl
+    #   pysaml2
+cssselect==1.1.0
+    # via premailer
+cssutils==1.0.2
+    # via premailer
+decorator==4.0.11
+    # via
+    #   ipython
+    #   traitlets
+defusedxml==0.5.0
+    # via
+    #   pysaml2
+    #   python3-openid
+    #   social-auth-core
+    #   zeep
+dj-database-url==0.3.0
+    # via -r requirements.in
+dj-static==0.0.6
+    # via -r requirements.in
+django-anymail[mailgun]==6.1.0
+    # via -r requirements.in
+django-cache-memoize==0.1.7
+    # via -r requirements.in
+django-classy-tags==1.0.0
+    # via -r requirements.in
+django-compat==1.0.15
+    # via
+    #   -r requirements.in
+    #   django-hijack
+    #   django-hijack-admin
+django-filter==2.2.0
+    # via -r requirements.in
+django-fsm==2.6.1
+    # via -r requirements.in
+django-hijack-admin==2.1.7
+    # via -r requirements.in
+django-hijack==2.1.10
+    # via
+    #   -r requirements.in
+    #   django-hijack-admin
+django-ipware==3.0.0
+    # via -r requirements.in
+django-mathfilters==1.0.0
+    # via -r requirements.in
+django-modelcluster==5.0.1
+    # via wagtail
+django-redis==4.7.0
+    # via -r requirements.in
+django-server-status==0.5.0
+    # via -r requirements.in
+django-storages==1.9.1
+    # via -r requirements.in
+django-taggit==1.2.0
+    # via wagtail
+django-templated-mail==1.1.1
+    # via djoser
+django-treebeard==4.3.1
+    # via wagtail
+django-webpack-loader==0.5.0
+    # via -r requirements.in
+django==2.2.18
+    # via
+    #   -r requirements.in
+    #   django-anymail
+    #   django-classy-tags
+    #   django-filter
+    #   django-storages
+    #   django-taggit
+    #   django-treebeard
+    #   djangosaml2idp
+    #   dynamic-rest
+    #   wagtail
+djangorestframework-serializer-extensions==2.0.0
+    # via -r requirements.in
+djangorestframework==3.9.2
+    # via
+    #   -r requirements.in
+    #   dynamic-rest
+    #   wagtail
+git+git://github.com/OTA-Insight/djangosaml2idp.git@e12319949dc4911657d0fff91c93317fdef691d4#egg=djangosaml2idp
+    # via -r requirements.in
+djoser==1.7.0
+    # via -r requirements.in
+docutils==0.15.2
+    # via botocore
+draftjs-exporter==2.1.7
+    # via wagtail
+dynamic-rest==1.9.6
+    # via -r requirements.in
+elasticsearch==5.4.0
+    # via django-server-status
+elementpath==2.1.3
+    # via xmlschema
+hashids==1.2.0
+    # via djangorestframework-serializer-extensions
+html5lib==0.999999999
+    # via
+    #   -r requirements.in
+    #   wagtail
+idna==2.7
+    # via requests
+importlib-metadata==1.6.0
+    # via kombu
+importlib-resources==5.1.0
+    # via pysaml2
+inflection==0.3.1
+    # via dynamic-rest
+ipython-genutils==0.2.0
+    # via traitlets
+ipython==6.1.0
+    # via -r requirements.in
+isodate==0.6.0
+    # via zeep
+jedi==0.10.2
+    # via ipython
+jmespath==0.9.5
+    # via
+    #   boto3
+    #   botocore
+kombu==4.6.7
+    # via
+    #   celery
+    #   django-server-status
+l18n==2018.5
+    # via wagtail
+lxml==4.6.3
+    # via
+    #   premailer
+    #   zeep
+newrelic==2.86.3.70
+    # via -r requirements.in
+oauthlib==2.0.2
+    # via
+    #   requests-oauthlib
+    #   social-auth-core
+pexpect==4.2.1
+    # via ipython
+pickleshare==0.7.4
+    # via ipython
+pillow==7.1.0
+    # via
+    #   -r requirements.in
+    #   wagtail
+premailer==3.7.0
+    # via -r requirements.in
+prompt-toolkit==1.0.14
+    # via ipython
+psycopg2==2.7.3.2
+    # via
+    #   -r requirements.in
+    #   django-server-status
+ptyprocess==0.5.1
+    # via pexpect
+pycountry==19.8.18
+    # via -r requirements.in
+pycparser==2.20
+    # via cffi
+pygments==2.8.1
+    # via ipython
+pyjwt==1.5.0
+    # via social-auth-core
+pynacl==1.3.0
+    # via -r requirements.in
+pyopenssl==19.1.0
+    # via pysaml2
+pysaml2==6.5.1
+    # via djangosaml2idp
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   arrow
+    #   botocore
+    #   pysaml2
+python3-openid==3.1.0
+    # via social-auth-core
+pytz==2019.3
+    # via
+    #   -r requirements.in
+    #   celery
+    #   django
+    #   django-modelcluster
+    #   djangosaml2idp
+    #   l18n
+    #   pysaml2
+    #   zeep
+redis==3.2.0
+    # via
+    #   -r requirements.in
+    #   django-redis
+    #   django-server-status
+requests-oauthlib==0.8.0
+    # via social-auth-core
+requests-toolbelt==0.9.1
+    # via zeep
+requests==2.20.1
+    # via
+    #   -r requirements.in
+    #   django-anymail
+    #   dynamic-rest
+    #   premailer
+    #   pysaml2
+    #   requests-oauthlib
+    #   requests-toolbelt
+    #   social-auth-core
+    #   wagtail
+    #   zeep
+s3transfer==0.3.3
+    # via boto3
+sentry-sdk==0.14.3
+    # via -r requirements.in
+simplegeneric==0.8.1
+    # via ipython
+six==1.15.0
+    # via
+    #   django-anymail
+    #   django-classy-tags
+    #   django-compat
+    #   django-server-status
+    #   html5lib
+    #   isodate
+    #   l18n
+    #   prompt-toolkit
+    #   pynacl
+    #   pyopenssl
+    #   pysaml2
+    #   python-dateutil
+    #   social-auth-app-django
+    #   social-auth-core
+    #   traitlets
+    #   zeep
+social-auth-app-django==2.1.0
+    # via -r requirements.in
+social-auth-core==1.4.0
+    # via social-auth-app-django
+soupsieve==2.0.1
+    # via beautifulsoup4
+sqlparse==0.3.1
+    # via django
+static3==0.5.1
+    # via
+    #   -r requirements.in
+    #   dj-static
+traitlets==4.3.2
+    # via ipython
+unidecode==1.1.1
+    # via wagtail
+urllib3==1.24.2
+    # via
+    #   -r requirements.in
+    #   botocore
+    #   elasticsearch
+    #   requests
+    #   sentry-sdk
+uwsgi==2.0.18
+    # via -r requirements.in
+vine==1.3.0
+    # via
+    #   amqp
+    #   celery
+wagtail==2.9.3
+    # via -r requirements.in
+wcwidth==0.1.7
+    # via prompt-toolkit
+webencodings==0.5.1
+    # via html5lib
+willow==1.3
+    # via wagtail
+xlsxwriter==1.2.9
+    # via wagtail
+xmlschema==1.4.2
+    # via pysaml2
+zeep==3.4.0
+    # via -r requirements.in
+zipp==3.1.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,7 +10,7 @@ factory_boy==2.12.0
 faker==4.1.0
 nplusone==1.0.0
 pdbpp==0.10.2
-pip-tools==5.1.2
+pip-tools==6.0.1
 pylint==2.5.3
 pylint-django==2.1.0
 pytest==4.6


### PR DESCRIPTION
#### What are the relevant tickets?
One related ticket: https://github.com/mitodl/bootcamp-ecommerce/issues/1199
Two related alerts: https://github.com/mitodl/bootcamp-ecommerce/security/dependabot/requirements.txt/lxml/open, https://github.com/mitodl/bootcamp-ecommerce/security/dependabot/requirements.txt/Pygments/open

#### What's this PR do?
- Upgrades `pip-tools` to `6.0.1`
- Upgrades lxml to 4.6.3
- upgrades pygments to `2.8.1`

#### How should this be tested?
- Check that the Django shell works fine
- Tests are passing
- A general look over the website (Signup - Log in) works fine
