### PR TITLE
make import alumni case insensitive

### DIFF
--- a/profiles/api.py
+++ b/profiles/api.py
@@ -296,7 +296,7 @@ def import_alum(alum):
         alum (Alum namedtuple)
     """
     try:
-        user = User.objects.get(email=alum.learner_email)
+        user = User.objects.get(email__iexact=alum.learner_email)
     except User.DoesNotExist:
         user = User.objects.create(
             email=alum.learner_email, username=alum.learner_email


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1201 

#### What's this PR do?
make import alumni (`email`) case insensitive

#### How should this be manually tested?
Please perform these following steps

1. Convert the emails to uppercase in the testdata
for example
`bootcamper@example.com` -> `BOOTCAMPER@EXAMPLE.COM`


2. Just run the import alumni command after updating the
`docker-compose exec web python manage.py import_alumni profiles/testdata/example_alumni.csv`

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
