### PR TITLE
Try to avoid localStorage error on mobile phones

### DIFF
--- a/static/js/components/notifications/NotificationContainer.js
+++ b/static/js/components/notifications/NotificationContainer.js
@@ -8,7 +8,11 @@ import wait from "waait"
 
 import { notificationConfigMap } from "."
 import { removeUserNotification } from "../../actions"
-import { newSetWith, newSetWithout } from "../../util/util"
+import {
+  isLocalStorageSupported,
+  newSetWith,
+  newSetWithout
+} from "../../util/util"
 import {
   ALERT_TYPES,
   CMS_NOTIFICATION_LCL_STORAGE_ID,
@@ -45,7 +49,7 @@ export class NotificationContainer extends React.Component<Props, State> {
       const { userNotifications } = this.props
       const notification = userNotifications[notificationKey]
       const notificationId = notification.props.persistedId
-      if (notificationId) {
+      if (notificationId && isLocalStorageSupported()) {
         window.localStorage.setItem(
           CMS_NOTIFICATION_LCL_STORAGE_ID,
           notificationId

--- a/static/js/components/notifications/NotificationContainer_test.js
+++ b/static/js/components/notifications/NotificationContainer_test.js
@@ -13,6 +13,48 @@ import {
 } from "../../constants"
 import IntegrationTestHelper from "../../util/integration_test_helper"
 import { shouldIf } from "../../lib/test_utils"
+import * as util from "../../util/util"
+
+describe("NotificationContainer component without localStorage", () => {
+  let helper, render
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    helper.sandbox.stub(util, "isLocalStorageSupported").callsFake(() => {
+      return false
+    })
+    render = helper.configureHOCRenderer(
+      NotificationContainer,
+      InnerNotificationContainer,
+      {
+        ui: {
+          userNotifications: {}
+        }
+      },
+      {}
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("skips attempted setting of localStorage item if it is unavailable", async () => {
+    const { inner } = await render({
+      ui: {
+        userNotifications: {
+          [CMS_SITE_WIDE_NOTIFICATION]: {
+            type:  ALERT_TYPE_TEXT,
+            props: { text: "Cms Notification", persistedId: 1 }
+          }
+        }
+      }
+    })
+
+    const alert = inner.find("Alert").at(0)
+    alert.prop("toggle")()
+    assert.isNull(window.localStorage.getItem(CMS_NOTIFICATION_LCL_STORAGE_ID))
+  })
+})
 
 describe("NotificationContainer component", () => {
   const messages = {

--- a/static/js/lib/notifications.js
+++ b/static/js/lib/notifications.js
@@ -8,6 +8,7 @@ import {
   CMS_NOTIFICATION_SELECTOR,
   CMS_SITE_WIDE_NOTIFICATION
 } from "../constants"
+import { isLocalStorageSupported } from "../util/util"
 
 export const handleCmsNotifications = (addUserNotification: Function) => {
   const cmsNotification = document.querySelector(CMS_NOTIFICATION_SELECTOR)
@@ -17,8 +18,9 @@ export const handleCmsNotifications = (addUserNotification: Function) => {
     )
     const notificationHtml = cmsNotification.innerHTML
     if (
+      isLocalStorageSupported() &&
       window.localStorage.getItem(CMS_NOTIFICATION_LCL_STORAGE_ID) !==
-      notificationId
+        notificationId
     ) {
       addUserNotification({
         [CMS_SITE_WIDE_NOTIFICATION]: {

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -225,3 +225,14 @@ export const recoverableErrorCode = (error: string) =>
 
 export const transformError = (error: string) =>
   CS_ERROR_MESSAGES[recoverableErrorCode(error) || CS_DEFAULT]
+
+export const isLocalStorageSupported = () => {
+  try {
+    const key = "__local_storage_access_key__"
+    window.localStorage.setItem(key, key)
+    window.localStorage.getItem(key)
+    return true
+  } catch (e) {
+    return false
+  }
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1226 (hopefully)

#### What's this PR do?
Tries to avoid the localStorage error that happens on some mobile phones

#### How should this be manually tested?
??? Couldn't replicate the problem on my phone or an android 9 emulator

Tests should pass, CMS notification should still work:
- Create a site-wide CMS notification (http://bc.odl.local:8099/cms/snippets/cms/sitenotification/)
- Go to any page on the site in an incognito browser, you should be able to see and then dismiss that notification.
- Temporarily change the `isLocalStorageSupported` function to always return `false`.  Try the above again.  You should not see a notification nor get any console error message.  

