### PR TITLE
Updated bootcamp and order admin classes

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -27,6 +27,19 @@ class LineAdmin(TimestampedModelAdmin):
         return False
 
 
+class LineInline(admin.StackedInline):
+    """Admin Inline for Line objects"""
+
+    model = Line
+    extra = 0
+    show_change_link = True
+    can_delete = False
+    readonly_fields = get_field_names(Line)
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
 class OrderAdmin(TimestampedModelAdmin):
     """Admin for Order"""
 
@@ -46,6 +59,7 @@ class OrderAdmin(TimestampedModelAdmin):
     list_filter = ("status", "payment_type")
     search_fields = ("user__email", "user__username")
     raw_id_fields = ("user", "application")
+    inlines = [LineInline]
 
     def has_add_permission(self, request):
         return False

--- a/klasses/admin.py
+++ b/klasses/admin.py
@@ -28,6 +28,7 @@ class BootcampAdmin(admin.ModelAdmin):
 
     model = models.Bootcamp
     list_display = ("title",)
+    search_fields = ("title",)
     inlines = [BootcampRunInline]
 
 
@@ -43,6 +44,12 @@ class BootcampRunAdmin(admin.ModelAdmin):
         "end_date",
     )
     raw_id_fields = ("bootcamp",)
+    search_fields = (
+        "title",
+        "novoed_course_stub",
+        "bootcamp_run_id",
+        "bootcamp__title",
+    )
     inlines = [InstallmentInline]
 
 
@@ -96,6 +103,10 @@ class InstallmentAdmin(admin.ModelAdmin):
     model = models.Installment
     list_display = ("id", "bootcamp_run", "deadline", "amount")
     raw_id_fields = ("bootcamp_run",)
+    search_fields = (
+        "bootcamp_run__title",
+        "bootcamp_run__bootcamp__title",
+    )
 
 
 class PersonalPriceAdmin(admin.ModelAdmin):


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket. Noticed this while testing SAML login

#### What's this PR do?
Makes `Bootcamp`s/`BootcampRun`s searchable in admin, and adds inline `Line` objects to `Order` admin

#### How should this be manually tested?
- Use the search bar for `Bootcamp`s/`BootcampRun`s in Django admin
- Review some `Order`s in admin and make sure the inline `Line` objects display properly
