### PR TITLE
bump urllib3=1.26.5 through boto3 and requests

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 Django==2.2.24
 celery==4.3.0
-boto3==1.12.42
+boto3==1.16.63
 dj-database-url==0.3.0
 django-anymail[mailgun]==6.1.0
 dj-static==0.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,9 @@ beautifulsoup4==4.8.2
     # via wagtail
 billiard==3.6.3.0
     # via celery
-boto3==1.12.42
+boto3==1.16.63
     # via -r requirements.in
-botocore==1.15.42
+botocore==1.19.63
     # via
     #   boto3
     #   s3transfer
@@ -146,8 +146,6 @@ git+git://github.com/OTA-Insight/djangosaml2idp.git@e12319949dc4911657d0fff91c93
     # via -r requirements.in
 djoser==2.1.0
     # via -r requirements.in
-docutils==0.15.2
-    # via botocore
 draftjs-exporter==2.1.7
     # via wagtail
 dynamic-rest==2.0.0
@@ -269,7 +267,7 @@ requests-oauthlib==0.8.0
     # via social-auth-core
 requests-toolbelt==0.9.1
     # via zeep
-requests==2.20.1
+requests==2.25.1
     # via
     #   -r requirements.in
     #   coreapi
@@ -322,7 +320,7 @@ traitlets==4.3.2
     # via ipython
 uritemplate==3.0.1
     # via coreapi
-urllib3==1.24.2
+urllib3==1.26.5
     # via
     #   -r requirements.in
     #   botocore


### PR DESCRIPTION
#### What are the relevant tickets?

Alert: https://github.com/mitodl/bootcamp-ecommerce/security/dependabot/requirements.txt/urllib3/open

#### What's this PR do?
- Updates a transitive dependency `urllib3` to version `1.26.5` as suggested by a security alert
- In other to do the above we had to update `boto3` and `requests` as well. (So, here they are upgraded as well)

#### How should this be manually tested?
Check basic file uploads or any functionality dependent on `boto3 and requests`
