### PR TITLE
Change NovoEd links to point directly to the desired course

### DIFF
--- a/app.json
+++ b/app.json
@@ -331,6 +331,10 @@
       "description": "The NovoEd API secret",
       "required": false
     },
+    "NOVOED_BASE_URL": {
+      "description": "The base URL of the NovoEd",
+      "required": false
+    },
     "NOVOED_SAML_CERT": {
       "description": "Contents of the SAML certificate for NovoEd ('\n' line separators)",
       "required": false
@@ -345,10 +349,6 @@
     },
     "NOVOED_SAML_KEY": {
       "description": "Contents of the SAML key for NovoEd ('\n' line separators)",
-      "required": false
-    },
-    "NOVOED_SAML_LOGIN_URL": {
-      "description": "The SP-initiated SAML login URL for NovoEd",
       "required": false
     },
     "PGBOUNCER_DEFAULT_POOL_SIZE": {

--- a/main/context_processors.py
+++ b/main/context_processors.py
@@ -42,7 +42,7 @@ def js_settings(request):
                 "upload_max_size": settings.MAX_FILE_UPLOAD_MB * 1_000_000,
                 "support_url": settings.SUPPORT_URL,
                 "terms_url": get_resource_page_urls(request.site)["terms_of_service"],
-                "novoed_login_url": settings.NOVOED_SAML_LOGIN_URL,
+                "novoed_base_url": settings.NOVOED_BASE_URL,
             }
         )
     }

--- a/main/context_processors_test.py
+++ b/main/context_processors_test.py
@@ -84,5 +84,5 @@ def test_get_context_js_settings(mocker, settings, patched_get_resource_page_url
         "upload_max_size": 123_000_000,
         "support_url": settings.SUPPORT_URL,
         "terms_url": patched_get_resource_page_urls.return_value["terms_of_service"],
-        "novoed_login_url": settings.NOVOED_SAML_LOGIN_URL,
+        "novoed_base_url": settings.NOVOED_BASE_URL,
     }

--- a/main/settings.py
+++ b/main/settings.py
@@ -987,11 +987,10 @@ NOVOED_API_BASE_URL = get_string(
     default=None,
     description="The base URL of the NovoEd API",
 )
-NOVOED_SAML_LOGIN_URL = get_string(
-    name="NOVOED_SAML_LOGIN_URL",
-    default=None,
-    description="The SP-initiated SAML login URL for NovoEd",
+NOVOED_BASE_URL = get_string(
+    "NOVOED_BASE_URL", None, description="The base URL of the NovoEd"
 )
+
 
 # Relative URL to be used by Djoser for the link in the password reset email
 # (see: http://djoser.readthedocs.io/en/stable/settings.html#password-reset-confirm-url)

--- a/main/settings.py
+++ b/main/settings.py
@@ -988,7 +988,7 @@ NOVOED_API_BASE_URL = get_string(
     description="The base URL of the NovoEd API",
 )
 NOVOED_BASE_URL = get_string(
-    "NOVOED_BASE_URL", None, description="The base URL of the NovoEd"
+    name="NOVOED_BASE_URL", default=None, description="The base URL of the NovoEd"
 )
 
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -991,7 +991,6 @@ NOVOED_BASE_URL = get_string(
     name="NOVOED_BASE_URL", default=None, description="The base URL of the NovoEd"
 )
 
-
 # Relative URL to be used by Djoser for the link in the password reset email
 # (see: http://djoser.readthedocs.io/en/stable/settings.html#password-reset-confirm-url)
 PASSWORD_RESET_CONFIRM_URL = "password_reset/confirm/{uid}/{token}/"

--- a/static/js/components/applications/detail_sections.js
+++ b/static/js/components/applications/detail_sections.js
@@ -259,6 +259,13 @@ export const BootcampStartDetail = (
   props: BootcampStartProps
 ): React$Element<*> => {
   const { ready, fulfilled, applicationDetail } = props
+  let novoedUrl = null
+  if (
+    SETTINGS.novoed_base_url &&
+    applicationDetail.bootcamp_run.novoed_course_stub
+  ) {
+    novoedUrl = `${SETTINGS.novoed_base_url}/#!/courses/${applicationDetail.bootcamp_run.novoed_course_stub}/home`
+  }
 
   return (
     <ProgressDetailRow className="bootcampStart" fulfilled={fulfilled}>
@@ -271,11 +278,7 @@ export const BootcampStartDetail = (
       )}
       {ready && fulfilled ? (
         <div className="col-12 col-sm-5 text-sm-right">
-          <a
-            href={SETTINGS.novoed_login_url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href={novoedUrl} target="_blank" rel="noopener noreferrer">
             Start Bootcamp
           </a>
         </div>

--- a/static/js/components/applications/detail_sections.js
+++ b/static/js/components/applications/detail_sections.js
@@ -25,6 +25,7 @@ import type {
   ApplicationSubmission
 } from "../../flow/applicationTypes"
 import type { User } from "../../flow/authTypes"
+import {createNovoEdLinkUrl} from "../../util/util"
 
 type DetailSectionProps = {
   ready: boolean,
@@ -259,14 +260,8 @@ export const BootcampStartDetail = (
   props: BootcampStartProps
 ): React$Element<*> => {
   const { ready, fulfilled, applicationDetail } = props
-  let novoedUrl = null
-  if (
-    SETTINGS.novoed_base_url &&
-    applicationDetail.bootcamp_run.novoed_course_stub
-  ) {
-    novoedUrl = `${SETTINGS.novoed_base_url}/#!/courses/${applicationDetail.bootcamp_run.novoed_course_stub}/home`
-  }
-
+  const novoedUrl = createNovoEdLinkUrl(SETTINGS.novoed_base_url, applicationDetail.bootcamp_run.novoed_course_stub)
+  
   return (
     <ProgressDetailRow className="bootcampStart" fulfilled={fulfilled}>
       <h3>Bootcamp Starts</h3>
@@ -276,7 +271,7 @@ export const BootcampStartDetail = (
           {formatReadableDateFromStr(applicationDetail.bootcamp_run.start_date)}
         </div>
       )}
-      {ready && fulfilled ? (
+      {ready && fulfilled && novoedUrl ? (
         <div className="col-12 col-sm-5 text-sm-right">
           <a href={novoedUrl} target="_blank" rel="noopener noreferrer">
             Start Bootcamp

--- a/static/js/components/applications/detail_sections.js
+++ b/static/js/components/applications/detail_sections.js
@@ -25,7 +25,7 @@ import type {
   ApplicationSubmission
 } from "../../flow/applicationTypes"
 import type { User } from "../../flow/authTypes"
-import {createNovoEdLinkUrl} from "../../util/util"
+import { createNovoEdLinkUrl } from "../../util/util"
 
 type DetailSectionProps = {
   ready: boolean,
@@ -260,8 +260,17 @@ export const BootcampStartDetail = (
   props: BootcampStartProps
 ): React$Element<*> => {
   const { ready, fulfilled, applicationDetail } = props
-  const novoedUrl = createNovoEdLinkUrl(SETTINGS.novoed_base_url, applicationDetail.bootcamp_run.novoed_course_stub)
-  
+  let novoedUrl = null
+  if (
+    SETTINGS.novoed_base_url &&
+    applicationDetail.bootcamp_run.novoed_course_stub
+  ) {
+    novoedUrl = createNovoEdLinkUrl(
+      SETTINGS.novoed_base_url,
+      applicationDetail.bootcamp_run.novoed_course_stub
+    )
+  }
+
   return (
     <ProgressDetailRow className="bootcampStart" fulfilled={fulfilled}>
       <h3>Bootcamp Starts</h3>

--- a/static/js/components/applications/detail_sections_test.js
+++ b/static/js/components/applications/detail_sections_test.js
@@ -287,7 +287,14 @@ describe("application detail section component", () => {
       it(`should show correct link if ready === ${String(
         ready
       )}, fulfilled === ${String(fulfilled)}`, () => {
-        SETTINGS.novoed_login_url = "https://novoed.com"
+        SETTINGS.novoed_base_url = "https://novoed.com"
+        let novoedUrl = null
+        if (
+          SETTINGS.novoed_base_url &&
+          applicationDetail.bootcamp_run.novoed_course_stub
+        ) {
+          novoedUrl = `${SETTINGS.novoed_base_url}/#!/courses/${applicationDetail.bootcamp_run.novoed_course_stub}/home`
+        }
         const wrapper = shallow(
           <BootcampStartDetail
             {...defaultProps}
@@ -300,7 +307,7 @@ describe("application detail section component", () => {
         assert.equal(link.exists(), expLinkText !== undefined)
         if (expLinkText !== undefined) {
           assert.equal(link.prop("children"), expLinkText)
-          assert.equal(link.prop("href"), SETTINGS.novoed_login_url)
+          assert.equal(link.prop("href"), novoedUrl)
         }
       })
     })

--- a/static/js/components/applications/detail_sections_test.js
+++ b/static/js/components/applications/detail_sections_test.js
@@ -280,11 +280,18 @@ describe("application detail section component", () => {
     })
     //
     ;[
-      [false, false, "", false, "not ready"],
-      [true, false, "", false, "not fulfilled"],
-      [true, true, "", false, "course stub is null"],
-      [true, true, "some-stub", true, "fulfilled with a valid course stub"]
-    ].forEach(([ready, fulfilled, novoEdStub, expLink, desc]) => {
+      [false, false, "", false, "not ready", undefined],
+      [true, false, "", false, "not fulfilled", undefined],
+      [true, true, "", false, "course stub is null", undefined],
+      [
+        true,
+        true,
+        "some-stub",
+        true,
+        "fulfilled with a valid course stub",
+        "Start Bootcamp"
+      ]
+    ].forEach(([ready, fulfilled, novoEdStub, expLink, desc, expLinkText]) => {
       it(`${shouldIf(expLink)} show correct link if ${desc}`, () => {
         SETTINGS.novoed_base_url = "https://novoed.com"
         applicationDetail.bootcamp_run.novoed_course_stub = novoEdStub
@@ -297,9 +304,9 @@ describe("application detail section component", () => {
             applicationDetail={applicationDetail}
           />
         )
-        const expLinkText = "Start Bootcamp"
         if (expLink) {
           const link = wrapper.find("ProgressDetailRow a")
+          assert.equal(link.exists(), expLinkText !== undefined)
           assert.equal(link.prop("children"), expLinkText)
           assert.equal(
             link.prop("href"),

--- a/static/js/components/applications/detail_sections_test.js
+++ b/static/js/components/applications/detail_sections_test.js
@@ -283,9 +283,10 @@ describe("application detail section component", () => {
       [false, false, "", false, "not ready"],
       [true, false, "", false, "not fulfilled"],
       [true, true, "", false, "course stub is null"],
-      [true, true, "some-stub", true, "fulfilled with a valid course stub"],
+      [true, true, "some-stub", true, "fulfilled with a valid course stub"]
     ].forEach(([ready, fulfilled, novoEdStub, expLink, desc]) => {
       it(`${shouldIf(expLink)} show correct link if ${desc}`, () => {
+        SETTINGS.novoed_base_url = "https://novoed.com"
         applicationDetail.bootcamp_run.novoed_course_stub = novoEdStub
 
         const wrapper = shallow(
@@ -296,12 +297,14 @@ describe("application detail section component", () => {
             applicationDetail={applicationDetail}
           />
         )
-
-        const link = wrapper.find("ProgressDetailRow a")
-        assert.equal(link.exists(), expLinkText !== undefined)
+        const expLinkText = "Start Bootcamp"
         if (expLink) {
+          const link = wrapper.find("ProgressDetailRow a")
           assert.equal(link.prop("children"), expLinkText)
-          assert.equal(link.prop("href"), `${SETTINGS.novoed_base_url}/#!/courses/${novoEdStub}/home`)
+          assert.equal(
+            link.prop("href"),
+            `${SETTINGS.novoed_base_url}/#!/courses/${novoEdStub}/home`
+          )
         }
       })
     })

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -6,7 +6,7 @@ declare var SETTINGS: {
   upload_max_size:  number,
   support_url:      string,
   terms_url:        string,
-  novoed_login_url: ?string,
+  novoed_base_url: ?string,
   zendesk_config:  {
     help_widget_enabled: boolean,
     help_widget_key: ?string

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -6,7 +6,7 @@ declare var SETTINGS: {
   upload_max_size:  number,
   support_url:      string,
   terms_url:        string,
-  novoed_base_url: ?string,
+  novoed_base_url: string,
   zendesk_config:  {
     help_widget_enabled: boolean,
     help_widget_key: ?string

--- a/static/js/lib/applicationApi.js
+++ b/static/js/lib/applicationApi.js
@@ -49,7 +49,7 @@ export const findAppByRunTitle = (
 
 export const isNovoEdEnrolled = (application: Application): boolean =>
   !!application.bootcamp_run.novoed_course_stub &&
-  !!SETTINGS.novoed_login_url &&
+  !!SETTINGS.novoed_base_url &&
   !!application.enrollment &&
   !!application.enrollment.novoed_sync_date
 

--- a/static/js/lib/applicationApi_test.js
+++ b/static/js/lib/applicationApi_test.js
@@ -77,12 +77,12 @@ describe("applications API", () => {
   })
 
   it("isNovoEdEnrolled should return true if certain settings are present and an enrollment has been synced", () => {
-    SETTINGS.novoed_login_url = null
+    SETTINGS.novoed_base_url = null
     const application = makeApplication()
     application.bootcamp_run.novoed_course_stub = null
     application.enrollment = null
     assert.isFalse(api.isNovoEdEnrolled(application))
-    SETTINGS.novoed_login_url = "http://novoed.com"
+    SETTINGS.novoed_base_url = "http://novoed.com"
     application.bootcamp_run.novoed_course_stub = "some-bootcamp"
     application.enrollment = generateFakeEnrollment()
     application.enrollment.novoed_sync_date = null

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -50,7 +50,8 @@ import {
   formatStartEndDateStrings,
   formatTitle,
   isErrorResponse,
-  isNilOrBlank
+  isNilOrBlank,
+  createNovoEdLinkUrl
 } from "../../util/util"
 import {
   APP_STATE_TEXT_MAP,
@@ -474,13 +475,8 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
       application.bootcamp_run.page.thumbnail_image_src :
       null
     const titleText = application.bootcamp_run.bootcamp.title
-    let novoedUrl = null
-    if (
-      SETTINGS.novoed_base_url &&
-      application.bootcamp_run.novoed_course_stub
-    ) {
-      novoedUrl = `${SETTINGS.novoed_base_url}/#!/courses/${application.bootcamp_run.novoed_course_stub}/home`
-    }
+    const novoedUrl = createNovoEdLinkUrl(SETTINGS.novoed_base_url, applicationDetail.bootcamp_run.novoed_course_stub)
+
     return (
       <div className="application-card" key={application.id}>
         <div className="p-3 d-flex flex-wrap flex-sm-nowrap">
@@ -490,7 +486,7 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
             <div className="row">
               <div className={`col-12 col-md-6 mr-auto no-padding`}>
                 <h2>
-                  {isNovoEdEnrolled(application) ? (
+                  {isNovoEdEnrolled(application) && novoedUrl ? (
                     <a
                       href={novoedUrl}
                       target="_blank"

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -475,7 +475,16 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
       application.bootcamp_run.page.thumbnail_image_src :
       null
     const titleText = application.bootcamp_run.bootcamp.title
-    const novoedUrl = createNovoEdLinkUrl(SETTINGS.novoed_base_url, applicationDetail.bootcamp_run.novoed_course_stub)
+    let novoedUrl = null
+    if (
+      SETTINGS.novoed_base_url &&
+      application.bootcamp_run.novoed_course_stub
+    ) {
+      novoedUrl = createNovoEdLinkUrl(
+        SETTINGS.novoed_base_url,
+        application.bootcamp_run.novoed_course_stub
+      )
+    }
 
     return (
       <div className="application-card" key={application.id}>

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -474,7 +474,13 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
       application.bootcamp_run.page.thumbnail_image_src :
       null
     const titleText = application.bootcamp_run.bootcamp.title
-
+    let novoedUrl = null
+    if (
+      SETTINGS.novoed_base_url &&
+      application.bootcamp_run.novoed_course_stub
+    ) {
+      novoedUrl = `${SETTINGS.novoed_base_url}/#!/courses/${application.bootcamp_run.novoed_course_stub}/home`
+    }
     return (
       <div className="application-card" key={application.id}>
         <div className="p-3 d-flex flex-wrap flex-sm-nowrap">
@@ -486,7 +492,7 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
                 <h2>
                   {isNovoEdEnrolled(application) ? (
                     <a
-                      href={SETTINGS.novoed_login_url}
+                      href={novoedUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -236,3 +236,10 @@ export const isLocalStorageSupported = () => {
     return false
   }
 }
+
+export const createNovoEdLinkUrl = (baseUrl: string, stub: string): string => {
+  if(baseUrl && stub) {
+    return `${baseUrl}/#!/courses/${stub}/home`
+  }
+  return null
+}

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -238,8 +238,5 @@ export const isLocalStorageSupported = () => {
 }
 
 export const createNovoEdLinkUrl = (baseUrl: string, stub: string): string => {
-  if(baseUrl && stub) {
-    return `${baseUrl}/#!/courses/${stub}/home`
-  }
-  return null
+  return `${baseUrl}/#!/courses/${stub}/home`
 }


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1233 

#### What's this PR do?
Change NovoEd links to point directly to the desired course

#### How should this be manually tested?
Enable Novoed and see the link it should be the course url rather than the SAML login
set the `NOVOED_BASE_URL`

#### Screenshots (if appropriate)
<img width="1439" alt="Screenshot 2021-06-17 at 16 20 30" src="https://user-images.githubusercontent.com/4043989/122387154-03221800-cf88-11eb-945f-04b850cf7584.png">
