### PR TITLE
make a payment for (and therefore enroll in) a bootcamp with no application steps

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -179,6 +179,7 @@ class BootcampApplication(TimestampedModel):
         target=RETURN_VALUE(
             AppStates.AWAITING_USER_SUBMISSIONS.value,
             AppStates.AWAITING_SUBMISSION_REVIEW.value,
+            AppStates.AWAITING_PAYMENT.value,
         ),
     )
     def add_resume(self, *, resume_file=None, linkedin_url=None):
@@ -192,7 +193,11 @@ class BootcampApplication(TimestampedModel):
         self.save()
 
         if self.state == AppStates.AWAITING_RESUME.value:
-            return AppStates.AWAITING_USER_SUBMISSIONS.value
+            bootcamp_run_steps = BootcampRunApplicationStep.objects.filter(bootcamp_run=self.bootcamp_run)
+            if bootcamp_run_steps.exists():
+                return AppStates.AWAITING_USER_SUBMISSIONS.value
+            else:
+                return AppStates.AWAITING_PAYMENT.value
         return self.state
 
     @transition(

--- a/applications/models.py
+++ b/applications/models.py
@@ -193,10 +193,10 @@ class BootcampApplication(TimestampedModel):
         self.save()
 
         if self.state == AppStates.AWAITING_RESUME.value:
-            bootcamp_run_steps = BootcampRunApplicationStep.objects.filter(
+            application_steps = BootcampRunApplicationStep.objects.filter(
                 bootcamp_run=self.bootcamp_run
             )
-            if bootcamp_run_steps.exists():
+            if application_steps.exists():
                 return AppStates.AWAITING_USER_SUBMISSIONS.value
             else:
                 return AppStates.AWAITING_PAYMENT.value

--- a/applications/models.py
+++ b/applications/models.py
@@ -193,7 +193,9 @@ class BootcampApplication(TimestampedModel):
         self.save()
 
         if self.state == AppStates.AWAITING_RESUME.value:
-            bootcamp_run_steps = BootcampRunApplicationStep.objects.filter(bootcamp_run=self.bootcamp_run)
+            bootcamp_run_steps = BootcampRunApplicationStep.objects.filter(
+                bootcamp_run=self.bootcamp_run
+            )
             if bootcamp_run_steps.exists():
                 return AppStates.AWAITING_USER_SUBMISSIONS.value
             else:

--- a/applications/models_test.py
+++ b/applications/models_test.py
@@ -20,6 +20,7 @@ from applications.factories import (
     BootcampRunApplicationStepFactory,
     ApplicationStepSubmissionFactory,
     BootcampApplicationFactory,
+    ApplicationStepFactory,
 )
 from applications.constants import AppStates
 from ecommerce.test_utils import create_test_application, create_test_order
@@ -93,6 +94,18 @@ def test_submission_types():
     )  # pylint: disable=protected-access
 
 
+def test_bootcamp_application_with_no_steps_file_submission():
+    """
+    A bootcamp application with no steps
+    """
+    bootcamp_application = BootcampApplicationFactory(
+        state=AppStates.AWAITING_RESUME.value
+    )
+    resume_file = SimpleUploadedFile("resume.pdf", b"file_content")
+    bootcamp_application.add_resume(resume_file=resume_file)
+    assert bootcamp_application.state == AppStates.AWAITING_PAYMENT.value
+
+
 @pytest.mark.parametrize(
     "file_name,state,expected",
     [
@@ -112,6 +125,14 @@ def test_bootcamp_application_resume_file_validation(file_name, state, expected)
     """
     bootcamp_application = BootcampApplicationFactory(state=state)
     resume_file = SimpleUploadedFile(file_name, b"file_content")
+
+    application_step = ApplicationStepFactory(
+        bootcamp=bootcamp_application.bootcamp_run.bootcamp
+    )
+    BootcampRunApplicationStepFactory(
+        bootcamp_run=bootcamp_application.bootcamp_run,
+        application_step=application_step,
+    )
 
     if expected:
         new_state = (

--- a/applications/views_test.py
+++ b/applications/views_test.py
@@ -23,6 +23,7 @@ from applications.factories import (
     ApplicantLetterFactory,
     QuizSubmissionFactory,
     VideoInterviewSubmissionFactory,
+    ApplicationStepFactory,
 )
 from applications.serializers import (
     BootcampApplicationDetailSerializer,
@@ -426,6 +427,14 @@ def test_upload_resume_view(client, mocker, has_resume, has_linkedin, resp_statu
     bootcamp_application = BootcampApplicationFactory.create(
         state=AppStates.AWAITING_RESUME.value
     )
+    application_step = ApplicationStepFactory(
+        bootcamp=bootcamp_application.bootcamp_run.bootcamp
+    )
+    BootcampRunApplicationStepFactory(
+        bootcamp_run=bootcamp_application.bootcamp_run,
+        application_step=application_step,
+    )
+
     client.force_login(bootcamp_application.user)
 
     url = reverse("upload-resume", kwargs={"pk": bootcamp_application.id})


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1269 

#### What's this PR do?
make a payment for (and therefore enroll in) a bootcamp with no application steps

#### How should this be manually tested?
Just confirm that for applications with no steps is transiting the state to from `AWAITING_RESUME` to `AWAITING_PAYMENT` after resume or linkedin upload / submission

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)

#### Application with no steps

<img width="1440" alt="Screenshot 2021-06-25 at 17 19 41" src="https://user-images.githubusercontent.com/4043989/123426525-f67f6e80-d5dc-11eb-8986-9a45e5130561.png">

#### Application with steps

<img width="1440" alt="Screenshot 2021-06-25 at 17 19 50" src="https://user-images.githubusercontent.com/4043989/123426538-faab8c00-d5dc-11eb-87f0-7c86cee52f3a.png">
