### PR TITLE
add validation for linkedin url

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -233,7 +233,15 @@ class UploadResumeView(GenericAPIView):
                 {"errors": "The URL should be less than 200 characters."}
             )
 
-        regex = re.compile("^https://[a-z]{2,3}[.]linkedin[.]com/.*$", re.I)
+        regex = re.compile(
+            "^(http|https)://"  # Support for both http and https
+            "([a-zA-Z]{2,3}[.]|)"  # Support for global or localized prefix
+            "linkedin[.]"  # Contains the linkedin domain
+            "([a-zA-Z]{2,3})/"  # Support for .com or localized postfix
+            "+([a-zA-Z0-9-_])"  # Support for /<in or org>
+            "+/+([a-zA-Z0-9-_])+.*$",  # Any type of username
+            re.I,
+        )
         if not regex.match(str(linkedin_url)):
             raise ValidationError({"errors": "Please enter a valid LinkedIn URL"})
 

--- a/applications/views.py
+++ b/applications/views.py
@@ -230,7 +230,7 @@ class UploadResumeView(GenericAPIView):
         """
         if len(linkedin_url) > 200:
             raise ValidationError(
-                {"errors": "The URL should be of 200 characters at max"}
+                {"errors": "The URL should be less than 200 characters."}
             )
 
         regex = re.compile("^https://[a-z]{2,3}[.]linkedin[.]com/.*$", re.I)

--- a/applications/views_test.py
+++ b/applications/views_test.py
@@ -467,14 +467,24 @@ def test_upload_resume_view(
 
 
 @pytest.mark.parametrize(
-    "linkedin_url",
+    "linkedin_url, status_code",
     [
-        "some-url",
-        "https://www.some-valid-url.com",
-        "https://www.linkedin.com",
+        ["some-url", status.HTTP_400_BAD_REQUEST],
+        ["https://www.some-valid-url.com", status.HTTP_400_BAD_REQUEST],
+        ["https://www.linkedin.com", status.HTTP_400_BAD_REQUEST],
+        ["https://www.linkedin.com/in", status.HTTP_400_BAD_REQUEST],
+        ["https://www.linkedin.com/in/some-user-name_1", status.HTTP_200_OK],
+        ["https://linkedin.com/in/some-user-name_1", status.HTTP_200_OK],
+        ["httpS://www.linkedin.com/in/some-user-name", status.HTTP_200_OK],
+        ["http://www.linkedin.com/in/some-user-name", status.HTTP_200_OK],
+        ["Http://www.linkedin.com/in/some-user-name", status.HTTP_200_OK],
+        ["https://us.linkedin.com/in/some-user-name", status.HTTP_200_OK],
+        ["https://www.linkedin.us/in/some-user-name", status.HTTP_200_OK],
+        ["https://us.linkedin.com/in/some-user-name", status.HTTP_200_OK],
+        ["https://www.linkedin.com/some-org/in/some-user-name", status.HTTP_200_OK],
     ],
 )
-def test_linkedin_url_validation(client, mocker, linkedin_url):
+def test_linkedin_url_validation(client, mocker, linkedin_url, status_code):
     """
     Upload resume view should return 400 if linkedin url validation fails
     """
@@ -490,7 +500,7 @@ def test_linkedin_url_validation(client, mocker, linkedin_url):
     data = {"linkedin_url": linkedin_url}
     resp = client.post(url, data)
 
-    assert resp.status_code == 400
+    assert resp.status_code == status_code
 
 
 def test_application_detail_queryset_orders(client):

--- a/applications/views_test.py
+++ b/applications/views_test.py
@@ -444,7 +444,7 @@ def test_upload_resume_view(
     url = reverse("upload-resume", kwargs={"pk": bootcamp_application.id})
     data = {}
     if has_linkedin:
-        data["linkedin_url"] = "some_url"
+        data["linkedin_url"] = "https://www.linkedin.com/in/User-Name-7472b48/"
     if has_resume:
         resume_file = SimpleUploadedFile("resume.pdf", b"file_content")
         data["file"] = resume_file
@@ -464,6 +464,33 @@ def test_upload_resume_view(
 
     if has_resume:
         assert resume_file.name in bootcamp_application.resume_file.name
+
+
+@pytest.mark.parametrize(
+    "linkedin_url",
+    [
+        "some-url",
+        "https://www.some-valid-url.com",
+        "https://www.linkedin.com",
+    ],
+)
+def test_linkedin_url_validation(client, mocker, linkedin_url):
+    """
+    Upload resume view should return 400 if linkedin url validation fails
+    """
+    mocker.patch(
+        "applications.views.UserIsOwnerPermission.has_permission", return_value=True
+    )
+    bootcamp_application = BootcampApplicationFactory.create(
+        state=AppStates.AWAITING_RESUME.value
+    )
+    client.force_login(bootcamp_application.user)
+
+    url = reverse("upload-resume", kwargs={"pk": bootcamp_application.id})
+    data = {"linkedin_url": linkedin_url}
+    resp = client.post(url, data)
+
+    assert resp.status_code == 400
 
 
 def test_application_detail_queryset_orders(client):

--- a/static/js/components/ResumeLinkedIn.js
+++ b/static/js/components/ResumeLinkedIn.js
@@ -233,6 +233,11 @@ export const resumeLinkedInValidation = yup.object().shape({
     .label("LinkedIn URL")
     .trim()
     .url()
+    .max(200, "The URL should be less than 200 characters.")
+    .matches(
+      "^https://[a-z]{2,3}[.]linkedin[.]com/.*$",
+      "Please enter a valid LinkedIn URL"
+    )
     .when("resumeFilename", (resumeFilename, schema) => {
       if (isNilOrBlank(resumeFilename)) {
         return schema.required("A resume or a LinkedIn URL must be provided.")

--- a/static/js/components/ResumeLinkedIn.js
+++ b/static/js/components/ResumeLinkedIn.js
@@ -234,8 +234,9 @@ export const resumeLinkedInValidation = yup.object().shape({
     .trim()
     .url()
     .max(200, "The URL should be less than 200 characters.")
+    .lowercase()
     .matches(
-      "^https://[a-z]{2,3}[.]linkedin[.]com/.*$",
+      "^(http|https)://([a-zA-Z]{2,3}[.]|)linkedin[.]([a-zA-Z]{2,3})/+([a-zA-Z0-9-_])+/+([a-zA-Z0-9-_])+.*$",
       "Please enter a valid LinkedIn URL"
     )
     .when("resumeFilename", (resumeFilename, schema) => {


### PR DESCRIPTION
#### What are the relevant tickets?
#1246 

#### What's this PR do?
Adds two types of validation on the LinkedIn URLs:
- The length of the URL is not more than 200
- The URL format is correct for a profile

#### How should this be manually tested?
- Run the app
- Add a Linkedin URL with more than 200 characters (You should see an error message)
- Add a non-LinkedIn or ill-formatted LinkedIn URL (You should see an error message)
- You should be able to verify the LinkedIn URL pattern introduced in this PR.

#### Where should the reviewer start?
- On Home page click `Apply Now`
- Next step, Click `View/Edit Resume or LinkedIn Profile`
- Next step, Add URLs in the linked in the field

#### Any background context you want to provide?
Some users were adding URLs having a length of more than 200 characters.

#### Screenshots (if appropriate)
**When URL is not valid (If its is not a linked in or URL or an invalid linkedin URL)**
<img width="559" alt="Screenshot 2021-07-07 at 5 49 35 PM" src="https://user-images.githubusercontent.com/34372316/124763280-3a636380-df4d-11eb-99b8-e2d4e60784ce.png">

**When URL length is more then 200**
<img width="600" alt="Screenshot 2021-07-07 at 5 50 29 PM" src="https://user-images.githubusercontent.com/34372316/124763301-3d5e5400-df4d-11eb-940a-6901229cc23a.png">
