### PR TITLE
Remove Resume / LinkedIn URL step for webinar-style (no application steps) Bootcamps

### DIFF
--- a/applications/api.py
+++ b/applications/api.py
@@ -70,6 +70,8 @@ def derive_application_state(
     """
     if not is_user_info_complete(bootcamp_application.user):
         return AppStates.AWAITING_PROFILE_COMPLETION.value
+    if bootcamp_application.bootcamp_run.application_steps.count() == 0:
+        return AppStates.AWAITING_PAYMENT.value
     if not bootcamp_application.resume_file and not bootcamp_application.linkedin_url:
         return AppStates.AWAITING_RESUME.value
     submissions = list(bootcamp_application.submissions.all())

--- a/applications/api_test.py
+++ b/applications/api_test.py
@@ -160,6 +160,27 @@ def test_get_or_create_bootcamp_application_for_alumni():
     bootcamp_run = BootcampRunFactory.create()
     bootcamp_run.allows_skipped_steps = True
     bootcamp_run.save()
+
+    run_step = BootcampRunApplicationStepFactory.create(bootcamp_run=bootcamp_run)
+    bootcamp_app, created = get_or_create_bootcamp_application(
+        bootcamp_run_id=bootcamp_run.id, user=user
+    )
+    assert bootcamp_app.bootcamp_run == bootcamp_run
+    assert bootcamp_app.user == user
+    assert bootcamp_app.state == AppStates.AWAITING_PAYMENT.value
+    assert created is True
+    assert bootcamp_app.bootcamp_run.application_steps.count() == 1
+    assert bootcamp_app.bootcamp_run.application_steps.first() == run_step
+    assert bootcamp_app.state == AppStates.AWAITING_PAYMENT.value
+
+
+def test_get_or_create_no_step_bootcamp_application():
+    """
+    get or create stepless bootcamp application that directly set to AWAITING PAYMENT
+    """
+    user = UserFactory.create()
+    bootcamp_run = BootcampRunFactory.create()
+    bootcamp_run.save()
     bootcamp_app, created = get_or_create_bootcamp_application(
         bootcamp_run_id=bootcamp_run.id, user=user
     )

--- a/static/js/pages/applications/ApplicationDashboardPage.js
+++ b/static/js/pages/applications/ApplicationDashboardPage.js
@@ -420,7 +420,10 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
     if (!application.bootcamp_run.is_payable) {
       paymentReady = false
     } else {
-      if (isEligibleToSkipSteps(currentUser, application)) {
+      if (
+        isEligibleToSkipSteps(currentUser, application) ||
+        applicationDetail.run_application_steps.length === 0
+      ) {
         paymentReady = true
       } else {
         // If there are no submissions required for this application, payment should be ready after the resume
@@ -456,7 +459,9 @@ export class ApplicationDashboardPage extends React.Component<Props, State> {
         {!isEligibleToSkipSteps(currentUser, application) && (
           <Fragment>
             {profileRow}
-            {resumeRow}
+            {applicationDetail.run_application_steps.length === 0 ?
+              null :
+              resumeRow}
             {submissionStepRows}
           </Fragment>
         )}


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1289 

#### What's this PR do?
Remove Resume / LinkedIn URL step for webinar-style (no application steps) Bootcamps

#### How should this be manually tested?
Try to upload twice, first the linkedin url and secondly adding resume so it will not raise the transition not allowed error anymore.

#### Screenshots

**NOMRAL USER**

<img width="1440" alt="Screenshot 2021-11-01 at 17 07 19" src="https://user-images.githubusercontent.com/4043989/139670108-ee2afe41-461f-493a-a3b2-1b7c43939dc6.png">

**Alumni**

<img width="1440" alt="Screenshot 2021-11-01 at 17 07 35" src="https://user-images.githubusercontent.com/4043989/139670168-8372bec9-c0bd-4046-8474-b6517d025c39.png">


