### PR TITLE
fix css issue of program description section steps rich text links

### DIFF
--- a/static/scss/cms/program-description.scss
+++ b/static/scss/cms/program-description.scss
@@ -102,7 +102,7 @@
       li {
         padding: 0 0 20px;
 
-        a {
+        a:not(.rich-text p a) {
           display: inline-block;
           vertical-align: top;
           color: $matterhorn;


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #1304 

#### What's this PR do?
fix css issue of program description section steps rich text links

#### How should this be manually tested?
Just visit the bootcam page program description section steps rich text links

##### Screenshots

**NOW**

<img width="1292" alt="Screenshot 2021-11-02 at 16 01 57" src="https://user-images.githubusercontent.com/4043989/139834905-dddc61f5-1607-4e0d-acb9-80b7a165474a.png">

**BEFORE**

<img width="1266" alt="Screenshot 2021-11-02 at 16 03 15" src="https://user-images.githubusercontent.com/4043989/139835038-4247aa1f-b72e-4bbf-bb19-8d85a2272a8f.png">

