### PR TITLE
chore: bump pillow to 8.3.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -42,5 +42,5 @@ urllib3>=1.24.2
 uwsgi
 wagtail==2.12.5
 zeep==3.4.0
-Pillow==8.2.0
+Pillow==8.3.2
 user-util==0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -225,7 +225,7 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.4
     # via ipython
-pillow==8.2.0
+pillow==8.3.2
     # via
     #   -r requirements.in
     #   wagtail


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/bootcamp-ecommerce/issues/1285

#### What's this PR do?
Bumps pillow to 8.3.2 in response to the critical severity alert https://github.com/mitodl/bootcamp-ecommerce/security/dependabot/requirements.txt/pillow/open

#### How should this be manually tested?
- Check that things related to images are working fine, e.g. wagtail images upload, profile
- Tests should pass
