### PR TITLE
chore: update browserslist version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3355,9 +3355,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001219:
-  version "1.0.30001236"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz#0a80de4cdf62e1770bb46a30d884fc8d633e3958"
-  integrity sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==
+  version "1.0.30001296"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz"
+  integrity sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
- Updates browserslist version which fixes the failing CI check for JS tests. as seen [Here](https://github.com/mitodl/bootcamp-ecommerce/runs/4726820960?check_suite_focus=true)

#### How should this be manually tested?
- Just check the failing CI on [this PR](https://github.com/mitodl/bootcamp-ecommerce/runs/4726820960?check_suite_focus=true)
- Tests should pass on this PR

