### PR TITLE
1365: Auto extend SAML SP metadata validUntil date

### DIFF
--- a/app.json
+++ b/app.json
@@ -369,6 +369,10 @@
       "description": "RedisCloud connection url",
       "required": false
     },
+    "SAML_IDP_FALLBACK_EXPIRATION_DAYS": {
+      "description": "The number of days to extend the SP metadata if validUntil does not exist or is in the past",
+      "required": false
+    },
     "SECRET_KEY": {
       "description": "Django secret key.",
       "generator": "secret",

--- a/main/settings.py
+++ b/main/settings.py
@@ -1040,6 +1040,12 @@ NOVOED_SAML_CONFIG_TTL_HOURS = get_int(
     description="The number of hours that the SAML config is expected to be accurate",
 )
 
+SAML_IDP_FALLBACK_EXPIRATION_DAYS = get_int(
+    name="SAML_IDP_FALLBACK_EXPIRATION_DAYS",
+    default=30,
+    description="The number of days to extend the SP metadata if validUntil does not exist or is in the past",
+)
+
 if _novoed_saml_key and _novoed_saml_cert:
     with NamedTemporaryFile(prefix="saml_", suffix=".key", delete=False) as f:
         lines = _novoed_saml_key.split("\\n")

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ django-webpack-loader==0.7.0
 djangorestframework==3.11.2
 djangorestframework-serializer-extensions==2.0.0
 # Using specific Git commit for this lib until they release their support for TZ-aware dates
-git+https://github.com/OTA-Insight/djangosaml2idp.git@e12319949dc4911657d0fff91c93317fdef691d4#egg=djangosaml2idp
+git+https://github.com/OTA-Insight/djangosaml2idp.git@0b4325782a6fd2c034677b5923041b5df10087ec#egg=djangosaml2idp
 djoser==2.1.0
 dynamic-rest==2.1.2
 html5lib==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -156,7 +156,7 @@ djangorestframework-serializer-extensions==2.0.0
     # via -r requirements.in
 djangorestframework-simplejwt==4.6.0
     # via djoser
-djangosaml2idp @ git+https://github.com/OTA-Insight/djangosaml2idp.git@e12319949dc4911657d0fff91c93317fdef691d4
+djangosaml2idp @ git+https://github.com/OTA-Insight/djangosaml2idp.git@0b4325782a6fd2c034677b5923041b5df10087ec
     # via -r requirements.in
 djoser==2.1.0
     # via


### PR DESCRIPTION
Upgrade SAML IDP library version and add metadata fallback env with default

#### What are the relevant tickets?
https://github.com/mitodl/bootcamp-ecommerce/issues/1365

#### What's this PR do?
Upgrades the https://github.com/OTA-Insight/djangosaml2idp version being used, which then allows for the use of `SAML_IDP_FALLBACK_EXPIRATION_DAYS` which is referred to when the remote SP metadata does not include a `validUntil` attribute.  The value defined with `SAML_IDP_FALLBACK_EXPIRATION_DAYS` will be used to indicate when the IDP (`bootcamp-ecommerce`) should re-retrieve the SP metadata from the metadata URL.  Basically this works as a fill-in for the missing `validUntil`.

#### How should this be manually tested?
Buckle up.  There might be an easier way, and I've tried my best to make this easy for whoever takes this on while also providing visibility into what's going on.

1. Have `bootcamp-ecommerce` running locally
2. Have a valid user with the profile information completed.

**Setting up a dummy SP**

1. Clone https://github.com/collinpreston/saml-test-sp
3. From the root project directory, run `docker build -t saml-test-sp .`
4. Run `docker-compose up`
5. Confirm your SP is working by opening `http://localhost:9009/saml/metadata` in your browser.

Each time you run step 4, the metadata will be valid for 2 minutes.

Negative test:
Using the main `bootcamp-ecommerce` branch...

1. In `config/nginx.conf` add ```uwsgi_buffer_size 256k;
        uwsgi_buffers 8 256k;
        uwsgi_busy_buffers_size 256k;``` starting at line 24.

3. In `uwsgi.ini` set `buffer-size = 800000` and `post-buffering = 800000`
4. In your `.env` file add:
```
NOVOED_SAML_KEY=-----BEGIN PRIVATE KEY-----\nMIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAKhEJQCNSURLLCeE\nKwgpOHxIwpU4rGJgen2lbGl/uf+naDOXGDq9ogrTf+UT3/OHge9TwYjQg8ehWKgk\n1ryRmBx94n7Rt0J7IpIWDRDtkg6a03owm+V6V6Pf3WDOq9I6UpAre8na/9XUU4fu\n597Mdg7HE6DRBCHNYrebpWGJdb9tAgMBAAECgYEAgMKUphV3qWD0ytBitX4FkWWE\nMPgLQcSeNyOtEBYDWNTb8g5/JgQSycIKrltFFm/tSByJjo4xKUQYOaLnB6lKAdXP\nOO30/RMdV5f97lRv+HeNYaAPDyFXMVWqgif9QgruWiVHZsZvWVUgLypfJyS1tcSB\n5gptdz/huN/yiNo8gakCQQDSRsr5axpivBdE+y92v4AxjBz9r9bGvwop+FNGDKSt\nb8jNJnUgcq+qpeOBL5nDzxeK8HvB+zrG4dpRas4Vmt5/AkEAzNrQJkRSHdb7wRWb\nAeScr7bIe1qmRJFJfbk8Mru7vtk3ofPKVNB4ijCghpkx3xsdh3a3Q/ZyD1mVyQMF\n0GLEEwJAYyplsMi00dl4c9yt3qejUjqMtYsGlAYmSfLFeuSdiPmNzkoTtLDBbY38\nQ8FqF7EDnk+ZXbsYVhDPP9RJymCWCwJAW8EePiWXyjnCpWcx+JUXATUTcvzVQBz7\nF87iAa9IlmDgpC93zqlZdDv3ipIPXmjcvxITX+OAjxOHHXO3JPE39QJAHNhhedap\n5cqibVlCNaCO453O+emMcNyjGLHBYw6G7vT4ijox/Liz5Icp5ad4AE9I6zNOwEry\nvs9WGjBDf0wtew==\n-----END PRIVATE KEY-----
NOVOED_SAML_CERT=-----BEGIN CERTIFICATE-----\nMIIC2DCCAkGgAwIBAgIBADANBgkqhkiG9w0BAQ0FADCBiDELMAkGA1UEBhMCdXMx\nETAPBgNVBAgMCE5ldyBZb3JrMQwwCgYDVQQKDANNSVQxDDAKBgNVBAMMA21pdDES\nMBAGA1UEBwwJUm9jaGVzdGVyMRYwFAYDVQQLDA1PcGVuIExlYXJuaW5nMR4wHAYJ\nKoZIhvcNAQkBFg9jb2xsaW5wQG1pdC5lZHUwHhcNMjIxMDIwMTI1ODU4WhcNMjMx\nMDIwMTI1ODU4WjCBiDELMAkGA1UEBhMCdXMxETAPBgNVBAgMCE5ldyBZb3JrMQww\nCgYDVQQKDANNSVQxDDAKBgNVBAMMA21pdDESMBAGA1UEBwwJUm9jaGVzdGVyMRYw\nFAYDVQQLDA1PcGVuIExlYXJuaW5nMR4wHAYJKoZIhvcNAQkBFg9jb2xsaW5wQG1p\ndC5lZHUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKhEJQCNSURLLCeEKwgp\nOHxIwpU4rGJgen2lbGl/uf+naDOXGDq9ogrTf+UT3/OHge9TwYjQg8ehWKgk1ryR\nmBx94n7Rt0J7IpIWDRDtkg6a03owm+V6V6Pf3WDOq9I6UpAre8na/9XUU4fu597M\ndg7HE6DRBCHNYrebpWGJdb9tAgMBAAGjUDBOMB0GA1UdDgQWBBSNejgHzuN7eWXl\na6E+JKVDKKXCuTAfBgNVHSMEGDAWgBSNejgHzuN7eWXla6E+JKVDKKXCuTAMBgNV\nHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBAKQM3FdvYsHWGkeGPmmZ6SbB+lP+\nyXGPEUseTkBMyASsj3Yedbk5ZQoiQez1ObeBTbgFXfejrPORA0IjmCNQTqHtQSLq\n7rotEwztGETS89EGX3YuuFREbH1fDVACBfh3V/CT8zuvn4bIwJgegJCXJ1FxkWGW\n+SJ5fLHv+h7H30ZF\n-----END CERTIFICATE-----
```
5. Run `docker-compose up`
6. Navigate to http://bc.odl.local:8099/admin/djangosaml2idp/serviceprovider/
7. Add a new Service Provider
![Screen Shot 2022-10-20 at 11 39 28](https://user-images.githubusercontent.com/8311573/196994634-345d34de-912c-42b3-bade-d06ae8e9b1e0.png)
8. The metadata entry should match `http://localhost:9009/saml/metadata`, but you will need to remove the `validUntil` attribute (it occurs twice in the metadata).  When you try to save the configuration, you should receive an error.
9. Now, add back the `http://localhost:9009/saml/metadata` including the `validUntil`.  If it's already been 2 minutes since you started the dummy SP, well don't fret.  With an expired `validUntil` try saving the Service Provider record.  You should receive an error again.
10. And now, let's just confirm that a metadata with a non-expired `validUntil` value actually work.  So restart the dummy SP in order to get a fresh metadata record or just change the `validUntil` value in the existing metadata.  Save the Service Provider record in `bootcamp-ecommerce`.
11. Now navigate to http://localhost:9009/ which will redirect you to login through `bootcamp-ecommerce`.
12. Complete the login and you should be shown a page showing the login information if all was successful.
13. Now, wait until the `validUntil` value is expired and try step 11 again using a new incognito window.  This time you should receive that the Service Provider could not be found.

**Positive Test**

1. Now check out this PR branch.
2. Perform a `docker-compose build`
3. Remove the `validUntil` attribute in the metadata in the Service Provider record in `bootcamp-ecommerce`.  You should be able to save the record now.
4. If you look at the `Metadata valid until` value in the Service Provider record in Django Admin, you should see that the date is 30 days from today.
5. Now navigate to http://localhost:9009/ which will redirect you to login through `bootcamp-ecommerce`.
6. You should be able to login correctly.

#### What GIF best describes this PR or how it makes you feel?
too_much_prep.gif
