### PR TITLE
Upgrade redis to support M1 users

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "5432"
 
   redis:
-    image: redis:3.0.3
+    image: redis:6.0.16
     ports:
       - "6379"
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

I got errors (Cannot connect to redis://redis:6379/4: Error) when running Bootcamp locally, After looking, it was due to redis:3.0.3 wasn't listed with support for M1 (arm64) on docker https://hub.docker.com/_/redis. After updating the Redis instance to 6.0.16 in docker-compose.xml, I no longer get errors and run bootcamps fine locally

#### What's this PR do?
Upgrades the docker redis instance to 6.0 to support M1 users. It also matches with MITxOnline (6.0.5)


#### How should this be manually tested?
Run `docker-compose up` should function as expected

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
