### PR TITLE
Fix: check for course admission page

### DIFF
--- a/cms/serializers.py
+++ b/cms/serializers.py
@@ -14,11 +14,19 @@ class BootcampRunPageSerializer(serializers.ModelSerializer):
 
     def get_bootcamp_location(self, instance):
         """Get the value of the bootcamp location"""
-        return instance.admissions_section.bootcamp_location
+        return (
+            None
+            if not instance.admissions_section
+            else instance.admissions_section.bootcamp_location
+        )
 
     def get_bootcamp_location_details(self, instance):
         """Get the value of the bootcamp location description"""
-        return instance.admissions_section.bootcamp_location_details
+        return (
+            None
+            if not instance.admissions_section
+            else instance.admissions_section.bootcamp_location_details
+        )
 
     def get_thumbnail_image_src(self, bootcamp_run_page):
         """Gets the versioned image source URL for the page's thumbnail image"""

--- a/cms/serializers_test.py
+++ b/cms/serializers_test.py
@@ -34,3 +34,19 @@ def test_bootcamp_run_page_serializer(mocker):
     bootcamp_run_page.thumbnail_image = None
     serialized = BootcampRunPageSerializer(instance=bootcamp_run_page).data
     assert serialized["thumbnail_image_src"] is None
+
+
+@pytest.mark.django_db
+def test_bootcamp_run_page_serializer_without_admission_page(mocker):
+    """The bootcamp run page serializer should define None for location fields if no admission page exists"""
+    bootcamp_run_page = BootcampRunPageFactory.create()
+    fake_image_url = "fake-image.jpg"
+    mocker.patch("cms.serializers.image_version_url", return_value=fake_image_url)
+    serialized = BootcampRunPageSerializer(instance=bootcamp_run_page).data
+    assert serialized == {
+        "description": bootcamp_run_page.description,
+        "subhead": bootcamp_run_page.subhead,
+        "thumbnail_image_src": fake_image_url,
+        "bootcamp_location": None,
+        "bootcamp_location_details": None,
+    }


### PR DESCRIPTION
check for admission page before grabbing location values.

#### What's this PR do?
Fixes an issue where a bootcamp without an admissions page would stop all other bootcamps from displaying.
https://sentry.io/organizations/mit-office-of-digital-learning/issues/3732777181/events/a3ce8fbe109d493c85245624e64e8b34/?project=159445

#### How should this be manually tested?

- Once you have bootcamp up and running locally, perform the initial step of seeding it with data (https://github.com/mitodl/bootcamp-ecommerce#seed-data).
- Perform a docker-compose run web ./manage.py migrate to ensure that you have the database changes.
- Go to <bootcamp_base_url>/cms and login with your admin user.
- Create a bootcamp index page and a bootcamp page through CMS. The pages don't need to be completely filled out or require any specific data. 
- Attempt to enroll into a bootcamp through the application. 
- Verify that all of the courses are displayed.
