### PR TITLE
Replace ubuntu-latest with ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push]
 jobs:
   python-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     services:
       db:
@@ -15,7 +15,7 @@ jobs:
           --health-retries 5
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
           POSTGRES_DB: postgres
         ports:
           - 5432:5432
@@ -95,7 +95,7 @@ jobs:
           CELERY_TASK_ALWAYS_EAGER: 'True'
           CELERY_BROKER_URL: redis://localhost:6379/4
           CELERY_RESULT_BACKEND: redis://localhost:6379/4
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres  # pragma: allowlist secret
           DEBUG: 'False'
           ELASTICSEARCH_URL: localhost:9200
           MAILGUN_URL: 'http://fake.example.com'
@@ -108,7 +108,7 @@ jobs:
           file: ./coverage.xml
 
   javascript-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # runs if CI workflow was successful OR if this was manually triggered
   on-success:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
@@ -26,7 +26,7 @@ jobs:
           branch: release
   # runs ONLY on a failure of the CI workflow
   on-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/release-candiate.yml
+++ b/.github/workflows/release-candiate.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # runs if CI workflow was successful OR if this was manually triggered
   on-success:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
@@ -26,7 +26,7 @@ jobs:
           branch: release-candidate
   # runs ONLY on a failure of the CI workflow
   on-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'failure'


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1386 

#### What's this PR do?
Replaces `ubuntu-latest` with `ubuntu-22.04` in github actions files

#### How should this be manually tested?
Tests should pass in github

#### Any background context you want to provide?
Whenever the heroku stack is upgraded, `runs-on` values in these files should be updated again to match the same version of ubuntu.
