### PR TITLE
Handle hubspot syncing for contacts w/multiple conflicting emails

### DIFF
--- a/hubspot_sync/tasks.py
+++ b/hubspot_sync/tasks.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from hubspot.crm.associations import BatchInputPublicAssociation, PublicAssociation
-from hubspot.crm.objects import BatchInputSimplePublicObjectInput
+from hubspot.crm.objects import ApiException, BatchInputSimplePublicObjectInput
 from mitol.common.decorators import single_task
 from mitol.common.utils.collections import chunks
 from mitol.hubspot_api.api import HubspotApi, HubspotAssociationType, HubspotObjectType
@@ -74,6 +74,50 @@ def batched_chunks(
     if len(batch_ids) <= max_chunk_size:
         return [batch_ids]
     return chunks(batch_ids, chunk_size=max_chunk_size)
+
+
+def sync_failed_contacts(chunk: list[int]) -> list[int]:
+    """
+    Consecutively try individual contact syncs for a failed batch sync
+    Args:
+        chunk[list]: list of user id's
+
+    Returns:
+        list of contact ids that still failed
+    """
+    failed_ids = []
+    for user_id in chunk:
+        try:
+            api.sync_contact_with_hubspot(user_id)
+            time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+        except ApiException:
+            failed_ids.append(user_id)
+    return failed_ids
+
+
+def handle_failed_batch_chunk(chunk: list[int], hubspot_type: str) -> list[int]:
+    """
+    Try reprocessing a chunk of contacts individually, in case conflicting emails are the problem
+
+    Args:
+        chunk [list]: list of object ids
+        hubspot_type: The type of Hubspot object
+
+    Returns:
+        list of still failing object ids
+
+    """
+    failed = chunk
+    if hubspot_type == HubspotObjectType.CONTACTS.value:
+        # Might be due to conflicting emails, try updating individually
+        failed = sync_failed_contacts(chunk)
+    if failed:
+        log.exception(
+            "Exception when batch syncing Hubspot ids %s of type %s",
+            f"{failed}",
+            hubspot_type,
+        )
+    return failed
 
 
 @app.task(
@@ -167,34 +211,47 @@ def batch_create_hubspot_objects_chunked(
     created_ids = []
     # Chunk again, by max allowed for object type (10 for contacts, 100 for all else)
     chunked_ids = batched_chunks(hubspot_type, object_ids)
+    errored_chunks = []
+    last_error_status = None
     for chunk in chunked_ids:
-        response = HubspotApi().crm.objects.batch_api.create(
-            hubspot_type,
-            BatchInputSimplePublicObjectInput(
-                inputs=[
-                    api.MODEL_FUNCTION_MAPPING[ct_model_name](obj_id)
-                    for obj_id in chunk
-                ]
-            ),
-        )
-        for result in response.results:
-            if ct_model_name == "user":
-                object_id = (
-                    User.objects.filter(
-                        email__iexact=result.properties["email"], is_active=True
-                    )
-                    .first()
-                    .id
-                )
-            else:
-                object_id = result.properties["unique_app_id"].split("-")[-1]
-            HubspotObject.objects.update_or_create(
-                content_type=ContentType.objects.get(model=ct_model_name),
-                hubspot_id=result.id,
-                object_id=object_id,
+        try:
+            response = HubspotApi().crm.objects.batch_api.create(
+                hubspot_type,
+                BatchInputSimplePublicObjectInput(
+                    inputs=[
+                        api.MODEL_FUNCTION_MAPPING[ct_model_name](obj_id)
+                        for obj_id in chunk
+                    ]
+                ),
             )
-            created_ids.append(result.id)
+            for result in response.results:
+                if ct_model_name == "user":
+                    object_id = (
+                        User.objects.filter(
+                            email__iexact=result.properties["email"], is_active=True
+                        )
+                        .first()
+                        .id
+                    )
+                else:
+                    object_id = result.properties["unique_app_id"].split("-")[-1]
+                HubspotObject.objects.update_or_create(
+                    content_type=ContentType.objects.get(model=ct_model_name),
+                    hubspot_id=result.id,
+                    object_id=object_id,
+                )
+                created_ids.append(result.id)
+        except ApiException as ae:
+            last_error_status = ae.status
+            still_failed = handle_failed_batch_chunk(chunk, hubspot_type)
+            if still_failed:
+                errored_chunks.append(still_failed)
         time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+    if errored_chunks:
+        raise ApiException(
+            status=last_error_status,
+            reason=f"Batch hubspot create failed for the following chunks: {errored_chunks}",
+        )
     return created_ids
 
 
@@ -223,21 +280,36 @@ def batch_update_hubspot_objects_chunked(
     updated_ids = []
     # Chunk again, by max allowed for object type (10 for contacts, 100 for all else)
     chunked_ids = batched_chunks(hubspot_type, object_ids)
+    errored_chunks = []
+    last_error_status = None
     for chunk in chunked_ids:
-        inputs = [
-            {
-                "id": obj_id[1],
-                "properties": api.MODEL_FUNCTION_MAPPING[ct_model_name](
-                    obj_id[0]
-                ).properties,
-            }
-            for obj_id in chunk
-        ]
-        response = HubspotApi().crm.objects.batch_api.update(
-            hubspot_type, BatchInputSimplePublicObjectInput(inputs=inputs)
-        )
-        updated_ids.extend([result.id for result in response.results])
+        try:
+            inputs = [
+                {
+                    "id": obj_id[1],
+                    "properties": api.MODEL_FUNCTION_MAPPING[ct_model_name](
+                        obj_id[0]
+                    ).properties,
+                }
+                for obj_id in chunk
+            ]
+            response = HubspotApi().crm.objects.batch_api.update(
+                hubspot_type, BatchInputSimplePublicObjectInput(inputs=inputs)
+            )
+            updated_ids.extend([result.id for result in response.results])
+        except ApiException as ae:
+            last_error_status = ae.status
+            still_failed = handle_failed_batch_chunk(
+                [item[0] for item in chunk], hubspot_type
+            )
+            if still_failed:
+                errored_chunks.append(still_failed)
         time.sleep(settings.HUBSPOT_TASK_DELAY / 1000)
+    if errored_chunks:
+        raise ApiException(
+            status=last_error_status,
+            reason=f"Batch hubspot update failed for the following chunks: {errored_chunks}",
+        )
     return updated_ids
 
 

--- a/hubspot_sync/tasks_test.py
+++ b/hubspot_sync/tasks_test.py
@@ -198,6 +198,30 @@ def test_batch_update_hubspot_objects_chunked(mocker, id_count):
     )
 
 
+@pytest.mark.parametrize(
+    "status, expected_error", [[429, TooManyRequestsException], [500, ApiException]]
+)
+def test_batch_update_hubspot_objects_chunked_error(mocker, status, expected_error):
+    """batch_update_hubspot_objects_chunked should raise expected exception"""
+    mock_hubspot_api = mocker.patch("hubspot_sync.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.update.side_effect = (
+        ApiException(status=status)
+    )
+    mock_sync_contacts = mocker.patch(
+        "hubspot_sync.tasks.api.sync_contact_with_hubspot",
+        side_effect=(ApiException(status=status)),
+    )
+    chunk = [(user.id, "123") for user in UserFactory.create_batch(3)]
+    with pytest.raises(expected_error):
+        tasks.batch_update_hubspot_objects_chunked(
+            HubspotObjectType.CONTACTS.value,
+            "user",
+            chunk,
+        )
+    for item in chunk:
+        mock_sync_contacts.assert_any_call(item[0])
+
+
 @pytest.mark.parametrize("id_count", [5, 15])
 def test_batch_create_hubspot_objects_chunked(mocker, id_count):
     """batch_create_hubspot_objects_chunked should make expected api calls and args"""
@@ -226,6 +250,30 @@ def test_batch_create_hubspot_objects_chunked(mocker, id_count):
             ]
         ),
     )
+
+
+@pytest.mark.parametrize(
+    "status, expected_error", [[429, TooManyRequestsException], [500, ApiException]]
+)
+def test_batch_create_hubspot_objects_chunked_error(mocker, status, expected_error):
+    """batch_create_hubspot_objects_chunked raise expected exception"""
+    mock_hubspot_api = mocker.patch("hubspot_sync.tasks.HubspotApi")
+    mock_hubspot_api.return_value.crm.objects.batch_api.create.side_effect = (
+        ApiException(status=status)
+    )
+    mock_sync_contact = mocker.patch(
+        "hubspot_sync.tasks.api.sync_contact_with_hubspot",
+        side_effect=(ApiException(status=status)),
+    )
+    chunk = sorted([user.id for user in UserFactory.create_batch(3)])
+    with pytest.raises(expected_error):
+        tasks.batch_create_hubspot_objects_chunked(
+            HubspotObjectType.CONTACTS.value,
+            "user",
+            chunk,
+        )
+    for item in chunk:
+        mock_sync_contact.assert_any_call(item)
 
 
 def test_batch_upsert_associations(settings, mocker, mocked_celery):
@@ -303,3 +351,48 @@ def test_batch_upsert_associations_chunked(settings, mocker):
             inputs=expected_contact_associations
         ),
     )
+
+
+@pytest.mark.parametrize("mode", ["update", "create"])
+def test_sync_failed_contacts(mocker, mode):
+    """sync_failed_contacts should try to sync each contact and return a list of failed contact ids"""
+    user_ids = sorted(user.id for user in UserFactory.create_batch(4))
+    mock_sync = mocker.patch(
+        "hubspot_sync.tasks.api.sync_contact_with_hubspot",
+        side_effect=[
+            mocker.Mock(),
+            ApiException(status=500, reason="err"),
+            mocker.Mock(),
+            ApiException(status=429, reason="tmr"),
+        ],
+    )
+    result = tasks.sync_failed_contacts(user_ids)
+    assert mock_sync.call_count == 4
+    assert result == [user_ids[1], user_ids[3]]
+
+
+@pytest.mark.parametrize("for_contacts", [True, False])
+@pytest.mark.parametrize("has_errors", [True, False])
+def test_handle_failed_batch_chunk(mocker, for_contacts, has_errors):
+    """handle_failed_batch_chunk should retry contacts only and log exceptions as appropriate"""
+    object_ids = [1, 2, 3, 4]
+    expected_sync_result = object_ids if has_errors or not for_contacts else []
+    hubspot_type = (
+        HubspotObjectType.CONTACTS.value
+        if for_contacts
+        else HubspotObjectType.DEALS.value
+    )
+    mock_sync_contacts = mocker.patch(
+        "hubspot_sync.tasks.sync_failed_contacts", return_value=expected_sync_result
+    )
+    mock_log = mocker.patch("hubspot_sync.tasks.log.exception")
+    tasks.handle_failed_batch_chunk(object_ids, hubspot_type)
+    assert mock_sync_contacts.call_count == (
+        1 if hubspot_type == HubspotObjectType.CONTACTS.value else 0
+    )
+    if has_errors or not for_contacts:
+        mock_log.assert_called_once_with(
+            "Exception when batch syncing Hubspot ids %s of type %s",
+            f"{expected_sync_result}",
+            hubspot_type,
+        )

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ hubspot-api-client
 django-storages==1.9.1
 ipython==7.31.1
 mitol-django-common==2.7.0
-mitol-django-hubspot-api==1.1.0
+mitol-django-hubspot-api~=2023.5.10
 mitol-django-mail==3.3.0
 mitol-django-authentication==1.6.0
 newrelic==6.2.0.156

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ hubspot-api-client
 django-storages==1.9.1
 ipython==7.31.1
 mitol-django-common==2.7.0
-mitol-django-hubspot-api~=2023.5.10
+mitol-django-hubspot-api~=2023.5.22
 mitol-django-mail==3.3.0
 mitol-django-authentication==1.6.0
 newrelic==6.2.0.156

--- a/requirements.txt
+++ b/requirements.txt
@@ -254,7 +254,7 @@ mitol-django-common==2.7.0
     #   mitol-django-authentication
     #   mitol-django-hubspot-api
     #   mitol-django-mail
-mitol-django-hubspot-api==2023.5.10
+mitol-django-hubspot-api==2023.5.22
     # via -r requirements.in
 mitol-django-mail==3.3.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -254,7 +254,7 @@ mitol-django-common==2.7.0
     #   mitol-django-authentication
     #   mitol-django-hubspot-api
     #   mitol-django-mail
-mitol-django-hubspot-api==1.1.0
+mitol-django-hubspot-api==2023.5.10
     # via -r requirements.in
 mitol-django-mail==3.3.0
     # via
@@ -292,7 +292,7 @@ prompt-toolkit==3.0.18
     # via
     #   click-repl
     #   ipython
-psycopg2-binary==2.8.6
+psycopg2==2.8.6
     # via -r requirements.in
 ptyprocess==0.5.1
     # via pexpect
@@ -352,6 +352,7 @@ requests==2.25.1
     #   django-anymail
     #   dynamic-rest
     #   mitol-django-common
+    #   mitol-django-hubspot-api
     #   premailer
     #   pysaml2
     #   requests-oauthlib

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,6 @@
 astroid==2.4.2
 black==22.10.0
 bpython==0.19
-codecov==2.1.3
 django-debug-toolbar==3.2.4
 hypothesis==4.23.9
 ipdb==0.13.2
@@ -10,7 +9,7 @@ factory_boy==3.2.0
 faker==8.8.2
 nplusone==1.0.0
 pdbpp==0.10.2
-pip-tools==6.5.1
+pip-tools
 pylint==2.5.3
 pylint-django==2.1.0
 pytest==6.1.2


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1418 

#### What's this PR do?
- Uses the new version of mitol.hubspot_api which can handle conflicts caused by a Hubspot contact having 2 emails associated with different bootcamps users
- Modifies the batch create/update tasks to try syncing contacts individually (to hit code above) if any API exceptions occur when running batch sync operations.

#### How should this be manually tested?
- Ask for access to the bootcampsdev sandbox account for hubspot if you don't already have it.
- Copy the `HUBSPOT_*` settings values from RC to your .env file

Part 1:
- Create a new user in bootcamps, something like `fake_user+1@gmail.com`
- Find the contact in hubspot (may take a minute or so to show up) and add a secondary email to that contact: `fake_user+2@gmail.com`

<img width="542" alt="Screenshot 2023-05-11 at 10 30 32 AM" src="https://github.com/mitodl/mitxonline/assets/187676/fa1cea9a-4900-4707-89e0-98ec1a301e84">

- Register another new user with that same email - `fake_user+2@gmail.com`
- Check back on hubspot, that secondary email should be gone from the contact, and there should be a new contact with email `fake_user+2@gmail.com`

Part 2:
- Comment out your hubspot .env settings and restart your containers
- Create another new user, `fake_user+3@gmail.com`
- In hubspot, add that email to one of the existing contacts as a secondary email
- Uncomment your hubspot .env settings and restart your containers
- Run `manage.py sync_db_to_hubspot --users create`.  It should complete successfully
- Check hubspot again, the secondary email from the contact should be gone and assigned to a new contact.


