### PR TITLE
Fix interaction between hubspot contact creation form and hubspot api contact sync

### DIFF
--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -281,3 +281,11 @@ def send_user_to_hubspot(request, **kwargs):
     requests.post(url=url, data=data, headers=headers)
 
     return {}
+
+def sync_user_profile_to_hubspot(
+    backend, user, response, is_new, *args, **kwargs
+):  # pylint: disable=unused-argument
+    """
+    Sync the user's latest profile data with hubspot on login
+    """
+    sync_hubspot_user(user)

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -1,23 +1,23 @@
 """Tests of user pipeline actions"""
 # pylint: disable=redefined-outer-name
 
-from django.contrib.sessions.middleware import SessionMiddleware
 import pytest
-from social_django.utils import load_strategy, load_backend
+from django.contrib.sessions.middleware import SessionMiddleware
+from social_django.utils import load_backend, load_strategy
 
-from profiles.factories import UserFactory
-from authentication.pipeline import user as user_actions
 from authentication.exceptions import (
     InvalidPasswordException,
-    RequirePasswordException,
-    RequireRegistrationException,
     RequirePasswordAndPersonalInfoException,
+    RequirePasswordException,
     RequireProfileException,
+    RequireRegistrationException,
     UserCreationFailedException,
 )
+from authentication.pipeline import user as user_actions
 from authentication.utils import SocialAuthState
-from compliance.constants import RESULT_SUCCESS, RESULT_DENIED, RESULT_UNKNOWN
+from compliance.constants import RESULT_DENIED, RESULT_SUCCESS, RESULT_UNKNOWN
 from compliance.factories import ExportsInquiryLogFactory
+from profiles.factories import UserFactory
 
 
 @pytest.fixture
@@ -412,7 +412,6 @@ def test_send_user_to_hubspot(mocker, settings):
     Tests that send_user_to_hubspot sends the correct data
     """
     mock_requests = mocker.patch("authentication.pipeline.user.requests")
-    mock_log = mocker.patch("authentication.pipeline.user.log")
 
     mock_request = mocker.Mock(COOKIES={"hubspotutk": "somefakedata"})
 
@@ -421,7 +420,6 @@ def test_send_user_to_hubspot(mocker, settings):
         mock_request, details={"email": "test@test.co"}
     )
     assert ret_val == {}
-    mock_log.error.assert_called_once()
 
     # Test with appropriate settings set
     settings.HUBSPOT_CONFIG["HUBSPOT_PORTAL_ID"] = "123456"
@@ -502,3 +500,20 @@ def test_activate_user_social_auth_disabled(mocker, user, mock_create_user_strat
         == {}
     )
     mock_compliance_api.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("is_active", [True, False])
+def test_sync_user_profile_to_hubspot(
+    mocker, user, is_active, mock_create_user_strategy
+):
+    """sync_hubspot_user should be called for active users"""
+    mock_sync = mocker.patch("authentication.pipeline.user.sync_hubspot_user")
+    user.is_active = is_active
+    assert (
+        user_actions.sync_user_to_hubspot(
+            mock_create_user_strategy, None, user=user, is_new=False
+        )
+        == {}
+    )
+    assert mock_sync.call_count == (1 if is_active else 0)

--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -9,7 +9,6 @@ import pytz
 
 from backends.edxorg import EdxOrgOAuth2
 from backends.utils import get_social_username
-from hubspot_sync.task_helpers import sync_hubspot_user
 from profiles.models import Profile
 
 log = logging.getLogger(__name__)

--- a/backends/pipeline_api.py
+++ b/backends/pipeline_api.py
@@ -9,6 +9,7 @@ import pytz
 
 from backends.edxorg import EdxOrgOAuth2
 from backends.utils import get_social_username
+from hubspot_sync.task_helpers import sync_hubspot_user
 from profiles.models import Profile
 
 log = logging.getLogger(__name__)

--- a/main/settings.py
+++ b/main/settings.py
@@ -323,6 +323,8 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.user.user_details",
     # fetch data from edx for those users
     "backends.pipeline_api.update_profile_from_edx",
+    # Sync user data with hubspot
+    "authentication.pipeline.user.sync_user_to_hubspot",
 )
 
 SOCIAL_AUTH_LOGIN_ERROR_URL = "login"


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #1421 

#### What's this PR do?
Makes HUBSPOT_CREATE_USER_FORM_ID optional (no error logged if null).
Makes an API call to sync the user to hubspot on login, which should ensure it's up to date regardless of whether or not the form above is being used.

#### How should this be manually tested?
- Set `HUBSPOT_CREATE_USER_FORM_ID` to the same value as RC in your .env file
- Follow the instructions for https://github.com/mitodl/bootcamp-ecommerce/pull/1419
- Log out and back in a couple times.
- There should not be any errors in the log.
- Repeat the above but with `HUBSPOT_CREATE_USER_FORM_ID` removed from your .env file

Related: https://github.com/mitodl/salt-ops/pull/1567