### PR TITLE
feat: add a command to reset user's Jobma interview state

### DIFF
--- a/applications/management/commands/reset_application_interview_state.py
+++ b/applications/management/commands/reset_application_interview_state.py
@@ -1,0 +1,61 @@
+"""Management command to reset Jobma interview state for a user"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from applications.constants import AppStates, REVIEWABLE_APP_STATES
+from applications.management.utils import fetch_bootcamp_run
+from applications.models import BootcampApplication
+from applications.tasks import refresh_pending_interview_links
+from profiles.api import fetch_user
+
+
+class Command(BaseCommand):
+    """
+    Reset Jobma interview based on the provided "run" and "user".
+    """
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--run",
+            type=str,
+            help="The id, title, or display title of the bootcamp run",
+            required=True,
+        )
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="The id, email, or username of the User",
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        user = fetch_user(options["user"])
+        bootcamp_run = fetch_bootcamp_run(options["run"])
+
+        # Ideally, there should only be one application for a user in single bootcamp run
+        try:
+            user_run_application = BootcampApplication.objects.get(
+                user=user, bootcamp_run=bootcamp_run
+            )
+        except BootcampApplication.DoesNotExist:
+            raise CommandError(
+                f"No application found for User={user}, Run={bootcamp_run}."
+            )
+        if user_run_application.state not in REVIEWABLE_APP_STATES:
+            raise CommandError(
+                f"User's application is already in approved state. User={user}, Run={bootcamp_run}, "
+                f"State={user_run_application.state}."
+            )
+
+        # Reset User's application state back to Awaiting submissions
+        user_run_application.state = AppStates.AWAITING_USER_SUBMISSIONS.value
+        user_run_application.save()
+        refresh_pending_interview_links()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Jobma interview state has been reset for User={user} Run={bootcamp_run}."
+            )
+        )

--- a/applications/management/commands/test_reset_application_interview_state.py
+++ b/applications/management/commands/test_reset_application_interview_state.py
@@ -1,0 +1,44 @@
+"""Tests for application interview state reset management command"""
+
+import pytest
+from django.core.management.base import CommandError
+from applications.management.commands import reset_application_interview_state
+from applications.constants import REVIEWABLE_APP_STATES, AppStates
+from applications.factories import BootcampApplicationFactory
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.mark.parametrize(
+    "state",
+    set(item.value for item in AppStates).difference(set(REVIEWABLE_APP_STATES)),
+)
+def test_reset_application_state_prints_error_on_invalid_states(state):
+    """Test that the reset interview command throws an error when the application is in Approved state already"""
+    user_application = BootcampApplicationFactory.create(state=state)
+    with pytest.raises(CommandError) as command_error:
+        reset_application_interview_state.Command().handle(
+            user=user_application.user.username,
+            run=str(user_application.bootcamp_run.id),
+        )
+    assert (
+        str(command_error.value)
+        == f"User's application is already in approved state. User={user_application.user}, Run={user_application.bootcamp_run}, "
+        f"State={user_application.state}."
+    )
+
+
+@pytest.mark.parametrize(
+    "state",
+    REVIEWABLE_APP_STATES,
+)
+def test_reset_application_state_success(state):
+    """Test that the reset interview command throws an error when the application is in Approved state already"""
+    user_application = BootcampApplicationFactory.create(state=state)
+
+    reset_application_interview_state.Command().handle(
+        user=user_application.user.username, run=str(user_application.bootcamp_run.id)
+    )
+
+    user_application.refresh_from_db()
+    assert user_application.state == AppStates.AWAITING_USER_SUBMISSIONS.value

--- a/applications/management/commands/test_reset_application_interview_state.py
+++ b/applications/management/commands/test_reset_application_interview_state.py
@@ -13,7 +13,7 @@ pytestmark = [pytest.mark.django_db]
     "state",
     set(item.value for item in AppStates).difference(set(REVIEWABLE_APP_STATES)),
 )
-def test_reset_application_state_prints_error_on_invalid_states(state):
+def test_reset_application_interview_state_prints_error_on_invalid_states(state):
     """Test that the reset interview command throws an error when the application is in Approved state already"""
     user_application = BootcampApplicationFactory.create(state=state)
     with pytest.raises(CommandError) as command_error:
@@ -23,7 +23,7 @@ def test_reset_application_state_prints_error_on_invalid_states(state):
         )
     assert (
         str(command_error.value)
-        == f"User's application is already in approved state. User={user_application.user}, Run={user_application.bootcamp_run}, "
+        == f"User's application is not in a reviewable state. User={user_application.user}, Run={user_application.bootcamp_run}, "
         f"State={user_application.state}."
     )
 
@@ -32,7 +32,7 @@ def test_reset_application_state_prints_error_on_invalid_states(state):
     "state",
     REVIEWABLE_APP_STATES,
 )
-def test_reset_application_state_success(state):
+def test_reset_application_interview_state_success(state):
     """Test that the reset interview command throws an error when the application is in Approved state already"""
     user_application = BootcampApplicationFactory.create(state=state)
 

--- a/jobma/admin.py
+++ b/jobma/admin.py
@@ -4,7 +4,7 @@ Admin views for jobma
 
 from django.contrib import admin
 
-from jobma.models import Interview, Job
+from jobma.models import Interview, Job, InterviewAudit
 
 
 class InterviewAdmin(admin.ModelAdmin):
@@ -66,5 +66,21 @@ class JobAdmin(admin.ModelAdmin):
     get_run_display_title.admin_order_field = "run__title"
 
 
+class InterviewAuditAdmin(admin.ModelAdmin):
+    """Admin for Interview Audit model"""
+
+    model = InterviewAudit
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+
 admin.site.register(Interview, InterviewAdmin)
 admin.site.register(Job, JobAdmin)
+admin.site.register(InterviewAudit, InterviewAuditAdmin)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3336,9 +3336,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001219:
-  version "1.0.30001441"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz"
-  integrity sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==
+  version "1.0.30001512"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz"
+  integrity sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==
 
 casual-browserify@^1.5.19-2:
   version "1.5.19-2"


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/bootcamp-ecommerce/issues/1362

#### What's this PR do?
- Adds a command to reset user's Jobma interview state

#### How should this be manually tested?
- Setup bootcamp(s) and runs along with user(s) - Can be done with seed command
- Enroll user in the bootcamp
- Fill the user profile in the bootcamps and make them reach a state where they have failed the Video interview in Jobma. If you can't setup the things locally to complete the user's steps in the bootcamp, you can use an existing command to change the user's state using an existing command e.g. `./manage.py set_application_state --app-id=5 --state=AWAITING_PAYMENT`
- Check that the submissions exist for the user and there are `VideoInterviewSubmission` and `Interview` records  - Check in the Django Admin

**Now check the following:**

- InterviewAudit entries are now available in Dango Admin
- On the frontend, Bootcamp enrollment page, the user should be showing `Awaiting payment` state
- Now run, `./manage.py reset_application_interview_state --user=<username or email or id> --run=2` for the user and it should now delete the `Interview` and its related submission records, and the user on the frontend should be back to the `Video Interview` stage.
- Also, check the fail cases for the command. e.g. if the user's application is not in `applications/constants/REVIEWABLE_APP_STATES`. The command should show an error
- Also test this flow as per mentioned in the Original Ticket. Because I've refactored the logic around that a bit too.

**Also, note**, Application should only reset if its state is in `REVIEWABLE_APP_STATES`, Otherwise the `reset_application_interview_state` should print an error message.


#### Where should the reviewer start?
Set up user, bootcamp enrollment, and a state where the user has passed the Video interview step.
