### PR TITLE
fix: dates display on the bootcamp cards

### DIFF
--- a/cms/templates/partials/home-page-catalog.html
+++ b/cms/templates/partials/home-page-catalog.html
@@ -16,7 +16,15 @@
                         <div class="info d-flex flex-column flex-grow-1">
                             <a href="{% pageurl block.page %}"><h2>{{ block.page.title }}</h2></a>
                             <span class="dates">
-                                {{ block.format }} <br>{{ block.page.bootcamp_run.start_date|date:"F, Y" }} - {{ block.page.bootcamp_run.end_date|date:"F, Y" }}
+                                {% with start=block.page.bootcamp_run.start_date end=block.page.bootcamp_run.end_date%}    
+                                    {% if start|date:"F Y" == end|date:"F Y" %}
+                                        {{ start|date:"F j" }} - {{ end|date:"j, Y" }}
+                                    {% elif start|date:"F" != end|date:"F" and start|date:"Y" == end|date:"Y" %}
+                                        {{ start|date:"F j" }} - {{ end|date:"F j, Y" }}
+                                    {% elif start|date:"Y" != end|date:"Y" %}
+                                        {{ start|date:"F j, Y" }} - {{ end|date:"F j, Y" }}
+                                    {% endif %}
+                                {%endwith%}
                             </span>
                             <div class="flex-grow-1">
                                 {{ block.page.description|richtext }}


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3003

#### What's this PR do?
Fixes the format of dates in the bootcamp cards

#### How should this be manually tested?
- Create a bootcamp card page using the wagtail cms with a course run.
- Login to the admin site.
- Go to http://boot.odl.local:8099/admin/klasses/bootcamprun/ select the run you selected while creating the card page at wagtail.
- Adjust the start and end dates and see the changes on the live page.

#### Screenshots (if appropriate)

##### Same year different months

<img width="459" alt="Screenshot 2024-02-20 at 9 48 05 PM" src="https://github.com/mitodl/bootcamp-ecommerce/assets/88967643/3842e34a-45e0-4d0e-9902-a804f135a490">

##### Same year same months

<img width="459" alt="Screenshot 2024-02-20 at 9 48 49 PM" src="https://github.com/mitodl/bootcamp-ecommerce/assets/88967643/f3055ffb-1a5f-4276-bfda-6f8e9166ae20">

##### different years

<img width="459" alt="Screenshot 2024-02-20 at 9 49 15 PM" src="https://github.com/mitodl/bootcamp-ecommerce/assets/88967643/93655481-7e8c-4aed-9ac5-68f453ce5781">

