### PR TITLE
fix: fix personal prices with unfulfilled orders

### DIFF
--- a/klasses/api.py
+++ b/klasses/api.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta
 
 import pytz
-from django.core.exceptions import ValidationError, ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import Sum
 
 from applications.constants import AppStates
@@ -15,7 +15,6 @@ from klasses.constants import DATE_RANGE_MONTH_FMT, ENROLL_CHANGE_STATUS_DEFERRE
 from klasses.models import BootcampRun, BootcampRunEnrollment
 from main import features
 from novoed import tasks as novoed_tasks
-
 
 log = logging.getLogger(__name__)
 
@@ -76,7 +75,7 @@ def adjust_app_state_for_new_price(user, bootcamp_run, new_price=None):
             if it was modified (otherwise, None will be returned)
     """
     total_paid_qset = Line.objects.filter(
-        order__user=user, bootcamp_run=bootcamp_run
+        order__user=user, bootcamp_run=bootcamp_run, order__status=Order.FULFILLED
     ).aggregate(aggregate_total_paid=Sum("price"))
     total_paid = total_paid_qset["aggregate_total_paid"] or 0
     new_price = new_price if new_price is not None else bootcamp_run.price

--- a/klasses/api_test.py
+++ b/klasses/api_test.py
@@ -191,7 +191,7 @@ def test_adjust_app_state_for_new_price_with_existing_orders(order_status):
     user = app.user
     personal_price = PersonalPriceFactory.create(price=990, user=user, bootcamp_run=run)
     InstallmentFactory.create(bootcamp_run=run, amount=RUN_PRICE)
-    # Create payments such that the user has paid the original bootcamp run price
+    # Create payments to test fulfilled and pending payments
     LineFactory.create_batch(
         2,
         order__user=user,

--- a/klasses/api_test.py
+++ b/klasses/api_test.py
@@ -163,7 +163,7 @@ def test_adjust_app_state_for_new_price(personal_price_amt, init_state, expected
     InstallmentFactory.create(bootcamp_run=run, amount=RUN_PRICE)
     # Create payments such that the user has paid the original bootcamp run price
     LineFactory.create_batch(
-        2, order__user=user, bootcamp_run=run, price=int(RUN_PRICE / 2)
+        2, order__user=user, order__status=Order.FULFILLED, bootcamp_run=run, price=int(RUN_PRICE / 2)
     )
     returned_app = adjust_app_state_for_new_price(
         user=user, bootcamp_run=run, new_price=getattr(personal_price, "price", None)

--- a/klasses/api_test.py
+++ b/klasses/api_test.py
@@ -163,7 +163,11 @@ def test_adjust_app_state_for_new_price(personal_price_amt, init_state, expected
     InstallmentFactory.create(bootcamp_run=run, amount=RUN_PRICE)
     # Create payments such that the user has paid the original bootcamp run price
     LineFactory.create_batch(
-        2, order__user=user, order__status=Order.FULFILLED, bootcamp_run=run, price=int(RUN_PRICE / 2)
+        2,
+        order__user=user,
+        order__status=Order.FULFILLED,
+        bootcamp_run=run,
+        price=int(RUN_PRICE / 2),
     )
     returned_app = adjust_app_state_for_new_price(
         user=user, bootcamp_run=run, new_price=getattr(personal_price, "price", None)

--- a/wire-transfers.csv
+++ b/wire-transfers.csv
@@ -1,4 +1,0 @@
-Id,Learner Email,Amount,Bootcamp Run ID,Bootcamp Start Date,Bootcamp Name
-123321,asad.ali@arbisoft.com,120,bootcamp-v1:asad:wagtail,"Feb. 11, 2024, 7:16 a.m.",ASAD'S WAGTAIL BOOTCAMP
-https://drive.google.com/file/d/1LcpzbstID122-GIhn-EcdYtQfa-YNKvu/view?usp=sharing
-https://drive.google.com/file/d/1LcpzbstID122-GIhn-EcdYtQfa-YNKvu/view?usp=drive_link

--- a/wire-transfers.csv
+++ b/wire-transfers.csv
@@ -1,0 +1,4 @@
+Id,Learner Email,Amount,Bootcamp Run ID,Bootcamp Start Date,Bootcamp Name
+123321,asad.ali@arbisoft.com,120,bootcamp-v1:asad:wagtail,"Feb. 11, 2024, 7:16 a.m.",ASAD'S WAGTAIL BOOTCAMP
+https://drive.google.com/file/d/1LcpzbstID122-GIhn-EcdYtQfa-YNKvu/view?usp=sharing
+https://drive.google.com/file/d/1LcpzbstID122-GIhn-EcdYtQfa-YNKvu/view?usp=drive_link


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4043

#### What's this PR do?
Fixes a bug when PersonalPrice is created and unfulfilled orders exist with a greater amount.

#### How should this be manually tested?

1. Create an application for a boot camp.
2. Complete all the steps except the payment.
3. Make sure that the application state is `AWAITING_PAYMENT` at `/admin/applications/bootcampapplication/`
4. Click on make a payment and make a partial payment like **half** of the total amount. When redirected to CyberSource, just close the tab and do not complete the payment.
5. Now go to `/admin/klasses/personalprice/` and create a personal price with an amount less than the partial payment. i.e. Total BootCamp price was 1000 and you created an order of 500 then create a personal price of less than 500.
6. Go to the applications, your application state should be `AWAITING_PAYMENT`.
7. Now change the order status to `fulfilled` and change the personal price to a price lower than the order price.
8. Application should move to the fulfilled state now.

#### Where should the reviewer start?
Reproducing the Bug following the steps:
**Steps to reproduce:**

1. Create an application for a boot camp.
2. Complete all the steps except the payment.
3. Make sure that the application state is `AWAITING_PAYMENT` at `/admin/applications/bootcampapplication/`
4. Click on make a payment and make a partial payment like **half** of the total amount. When redirected to CyberSource, just close the tab and do not complete the payment.
5. Now go to `/admin/klasses/personalprice/` and create a personal price with an amount less than the partial payment. i.e. Total BootCamp price was 1000 and you created an order of 500 then create a personal price of less than 500.
6. Go to the applications, your application is moved to `COMPLETE` due to an unfulfilled order.
