### PR TITLE
refactor: upgrade docker-compose & CI postgres version to 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
     services:
       db:
-        image: postgres:11.16
+        image: postgres:13.15
         # Health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready

--- a/docker-compose-notebook.yml
+++ b/docker-compose-notebook.yml
@@ -5,7 +5,7 @@ x-environment: &py-environment
   DEV_ENV: "True" # necessary to have nginx connect to web container
   NODE_ENV: "production"
   PORT: 8097
-  DATABASE_URL: postgres://postgres@db:5432/postgres
+  DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
   BOOTCAMP_SECURE_SSL_REDIRECT: "False"
   BOOTCAMP_DB_DISABLE_SSL: "True"
   CELERY_TASK_ALWAYS_EAGER: "False"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-environment: &py-environment
   DEBUG: "False"
   DEV_ENV: "True" # necessary to have nginx connect to web container
   NODE_ENV: "production"
-  DATABASE_URL: postgres://postgres@db:5432/postgres
+  DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
   BOOTCAMP_SECURE_SSL_REDIRECT: "False"
   BOOTCAMP_DB_DISABLE_SSL: "True"
   CELERY_TASK_ALWAYS_EAGER: "False"
@@ -16,7 +16,9 @@ x-environment: &py-environment
 
 services:
   db:
-    image: postgres:9.6.16
+    image: postgres:13.15
+    environment:
+      POSTGRES_PASSWORD: postgres # pragma: allowlist secret
     ports:
       - "5432"
 


### PR DESCRIPTION
### What are the relevant tickets?
[#4441](https://github.com/mitodl/hq/issues/4441)

### Description (What does it do?)
This PR upgrades the docker-compose & CI PostgreSQL version to 13.


### How can this be tested?
- Check out this branch and follow one of the solutions below to upgrade the PostgreSQL version in your local environment (with or without data migration):

## With Data Migration:
Follow these steps to upgrade PostgreSQL with data migration:

```sh
# 1. Using your old 9.6.16 database:
docker-compose exec -T db pg_dumpall -h db -U postgres > db_backup.sql
# 2. stop all containers
docker-compose stop
# 3 destroy the old database container
docker-compose rm -sv db
# 4. build+start the new database container
docker-compose up db -d
# 5. restore the database from backup
docker cp db_backup.sql $(docker-compose ps -q db):/tmp/backup.sql
docker-compose exec -T db psql -U postgres -d postgres -f /tmp/backup.sql
# 6. start the remaining containers
docker-compose up
# 7 verify postgres 13 is in use:
docker-compose exec -e PGPASSWORD=postgres db psql -h db -U postgres
```
**Note**: If you encounter `password authentication failed for user "postgres"` in STEP 6 due to no password being set for the user "postgres" in the SQL backup file, update the user password through the SQL shell:
  - `ALTER USER postgres PASSWORD 'postgres';`

## Without Data Migration
Follow these steps to upgrade PostgreSQL without data migration:
```sh
docker-compose down
docker-compose up -d
```
**Note**: These commands will cleanly restart your Docker Compose setup.