### PR TITLE
Revert "chore(deps): update yarn to v1.22.22"

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
   },
   "engines": {
     "node": "16.20.2",
-    "yarn": "1.22.22"
+    "yarn": "1.22.4"
   },
   "scripts": {
     "postinstall": "./webpack_if_prod.sh",


### PR DESCRIPTION
Reverts   mitodl/bootcamp-ecommerce#1462

There are a couple of reasons I'm reverting above PR:

1. After this PR, There was a clash between yarn versions in the production builds and the production build started breaking saying 
    ```
    $ ./webpack_if_prod.sh
           yarn run v1.22.4
           error bootcamp-ecommerce@0.1.0: The engine "yarn" is incompatible with this module. Expected version "1.22.22". Got "1.22.4"
           error Commands cannot run with an incompatible environment.
           info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
           error Command failed with exit code 1.
           info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
    -----> Build failed
    ```
2. This happened because mitodl/bootcamp-ecommerce#1462 was incomplete. It didn't update the yarn version file placed in https://github.com/mitodl/bootcamp-ecommerce/tree/master/.yarn/releases that still points to `1.22.4`
3. For a proper upgrade we will need to add 1.22.22 version .js file in `.yarn/releases` along with mitodl/bootcamp-ecommerce#1462


**HOW TO TEST:**

1. One on master go to the `watch` container shell and run ` export NODE_ENV=production` and then run  `./webpack_if_prod.sh ` you should see the above error
2. Checkout this branch and repeat step 1. You should not see this error and webpack bundle generation should be sucessful


NOTE: I'm going to create a separate issue to upgrade yarn properly.
