### PR TITLE
fix: invalid certificate uuid should raise 404

### DIFF
--- a/cms/models.py
+++ b/cms/models.py
@@ -8,6 +8,7 @@ import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.templatetags.static import static
 from django.db import models
 from django.http.response import Http404
@@ -937,7 +938,7 @@ class CertificateIndexPage(RoutablePageMixin, Page):
             and not parent.get_children().type(cls).exists()
         )
 
-    @route(r"^([A-Fa-f0-9-]+)/?$")
+    @route(r"^([A-Fa-f0-9-]{36})/?$")
     def bootcamp_certificate(
         self, request, uuid, *args, **kwargs
     ):  # pylint: disable=unused-argument
@@ -953,7 +954,7 @@ class CertificateIndexPage(RoutablePageMixin, Page):
             certificate = BootcampRunCertificate.objects.get(
                 uuid=uuid, is_revoked=False
             )
-        except BootcampRunCertificate.DoesNotExist:
+        except (BootcampRunCertificate.DoesNotExist,ValidationError):
             raise Http404()
         # Get a CertificatePage to serve this request
         certificate_page = (

--- a/cms/models.py
+++ b/cms/models.py
@@ -954,7 +954,7 @@ class CertificateIndexPage(RoutablePageMixin, Page):
             certificate = BootcampRunCertificate.objects.get(
                 uuid=uuid, is_revoked=False
             )
-        except (BootcampRunCertificate.DoesNotExist,ValidationError):
+        except (BootcampRunCertificate.DoesNotExist, ValidationError):
             raise Http404()
         # Get a CertificatePage to serve this request
         certificate_page = (

--- a/cms/models.py
+++ b/cms/models.py
@@ -8,7 +8,6 @@ import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.templatetags.static import static
 from django.db import models
 from django.http.response import Http404

--- a/cms/models.py
+++ b/cms/models.py
@@ -954,7 +954,7 @@ class CertificateIndexPage(RoutablePageMixin, Page):
             certificate = BootcampRunCertificate.objects.get(
                 uuid=uuid, is_revoked=False
             )
-        except (BootcampRunCertificate.DoesNotExist, ValidationError):
+        except BootcampRunCertificate.DoesNotExist:
             raise Http404()
         # Get a CertificatePage to serve this request
         certificate_page = (

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -386,6 +386,7 @@ def test_certificate_index_page(rf, user_client):
     with pytest.raises(Http404):
         certifcate_index_page.index_route(request)
 
+
 @override_settings(**{"FEATURES": {"ENABLE_CERTIFICATE_USER_VIEW": True}})
 @pytest.mark.parametrize(
     "uuid_string",

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -378,6 +378,7 @@ def test_certificate_index_page(rf):
 
     with pytest.raises(Http404):
         certifcate_index_page.bootcamp_certificate(request, "")
+
     with pytest.raises(Http404):
         certifcate_index_page.bootcamp_certificate(
             request, "00000000-0000-0000-0000-000000000000000"

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -399,14 +399,13 @@ def test_certificate_index_page(rf, user_client):
         "1bebd843-ebf0-40c0-850e-fe73baa31b94-4ab4",
     ],
 )
-def test_certificate_request_with_invalid_uuid(rf, user_client, uuid_string):
+def test_certificate_request_with_invalid_uuid(user_client, uuid_string):
     """Test that bootcamp certificate request returns a 404 for invalid uuids."""
     home_page = HomePageFactory()
-    certifcate_index_page = CertificateIndexPageFactory.create(
+    CertificateIndexPageFactory.create(
         parent=home_page, slug="certificate"
     )
-    request = rf.get(certifcate_index_page.get_url())
     bootcamp_run_page = BootcampRunPageFactory.create()
-    certificate_page = CertificatePageFactory.create(parent=bootcamp_run_page)
+    CertificatePageFactory.create(parent=bootcamp_run_page)
     course_certificate_resp = user_client.get(f"/certificate/{uuid_string}/")
     assert course_certificate_resp.status_code == 404

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -352,7 +352,9 @@ def test_certificate_index_page(rf, user_client):
     home_page = HomePageFactory()
     assert models.CertificateIndexPage.can_create_at(home_page)
 
-    certifcate_index_page = CertificateIndexPageFactory.create(parent=home_page, slug="certificate")
+    certifcate_index_page = CertificateIndexPageFactory.create(
+        parent=home_page, slug="certificate"
+    )
     request = rf.get(certifcate_index_page.get_url())
     bootcamp_run_page = BootcampRunPageFactory.create()
     certificate = BootcampRunCertificateFactory.create(
@@ -363,7 +365,7 @@ def test_certificate_index_page(rf, user_client):
     # Test that certificate request is successful for bootcamp certificates.
     resp = user_client.get(f"/certificate/{certificate.uuid}/")
     assert resp.status_code == 200
-    
+
     request = rf.get(certificate_page.get_url())
     assert (
         certifcate_index_page.bootcamp_certificate(
@@ -400,7 +402,9 @@ def test_certificate_index_page(rf, user_client):
 def test_certificate_request_with_invalid_uuid(rf, user_client, uuid_string):
     """Test that bootcamp certificate request returns a 404 for invalid uuids."""
     home_page = HomePageFactory()
-    certifcate_index_page = CertificateIndexPageFactory.create(parent=home_page, slug="certificate")
+    certifcate_index_page = CertificateIndexPageFactory.create(
+        parent=home_page, slug="certificate"
+    )
     request = rf.get(certifcate_index_page.get_url())
     bootcamp_run_page = BootcampRunPageFactory.create()
     certificate_page = CertificatePageFactory.create(parent=bootcamp_run_page)

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -371,17 +371,13 @@ def test_certificate_index_page(rf):
         certifcate_index_page.bootcamp_certificate(
             request, "00000000-0000-0000-0000-000000000000"
         )
-    
+
     # Testing invalid UUIDs
     with pytest.raises(Http404):
-        certifcate_index_page.bootcamp_certificate(
-            request, "00000000-0000-"
-        )
+        certifcate_index_page.bootcamp_certificate(request, "00000000-0000-")
 
     with pytest.raises(Http404):
-        certifcate_index_page.bootcamp_certificate(
-            request, ""
-        )
+        certifcate_index_page.bootcamp_certificate(request, "")
     with pytest.raises(Http404):
         certifcate_index_page.bootcamp_certificate(
             request, "00000000-0000-0000-0000-000000000000000"

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -371,6 +371,21 @@ def test_certificate_index_page(rf):
         certifcate_index_page.bootcamp_certificate(
             request, "00000000-0000-0000-0000-000000000000"
         )
+    
+    # Testing invalid UUIDs
+    with pytest.raises(Http404):
+        certifcate_index_page.bootcamp_certificate(
+            request, "00000000-0000-"
+        )
+
+    with pytest.raises(Http404):
+        certifcate_index_page.bootcamp_certificate(
+            request, ""
+        )
+    with pytest.raises(Http404):
+        certifcate_index_page.bootcamp_certificate(
+            request, "00000000-0000-0000-0000-000000000000000"
+        )
 
     # Revoke the certificate and check index page returns 404
     certificate.revoke()

--- a/cms/models_test.py
+++ b/cms/models_test.py
@@ -402,9 +402,7 @@ def test_certificate_index_page(rf, user_client):
 def test_certificate_request_with_invalid_uuid(user_client, uuid_string):
     """Test that bootcamp certificate request returns a 404 for invalid uuids."""
     home_page = HomePageFactory()
-    CertificateIndexPageFactory.create(
-        parent=home_page, slug="certificate"
-    )
+    CertificateIndexPageFactory.create(parent=home_page, slug="certificate")
     bootcamp_run_page = BootcampRunPageFactory.create()
     CertificatePageFactory.create(parent=bootcamp_run_page)
     course_certificate_resp = user_client.get(f"/certificate/{uuid_string}/")


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/4650

### Description (What does it do?)
<!--- Describe your changes in detail -->
Using an invalid UUID to get a certificate results in a 500 server error. It should return 404.

Steps to reproduce:

- Checkout master branch
- fetch `/certificate/f5ab714b-a7ee-498f-bbec-/`
- It will raise a validation error

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Create certificate pages in CMS
- Create certificate in the Django Admin for a user
- Fetch the certificate at `/certificate/<uuid>/`. You should see the valid certificates.
- Now fetch the certificate with invalid UUID i.e. `f5ab714b-a7ee-498f-bbec-`. You should see a 404 page.
