### PR TITLE
chore: upgrade redis version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - 5432:5432
 
       redis:
-        image: redis:5.0.8
+        image: redis:6.2.14
         ports:
           - 6379:6379
 


### PR DESCRIPTION
### What are the relevant tickets?
This PR is created in replacement of https://github.com/mitodl/bootcamp-ecommerce/pull/1461

### Description (What does it do?)
The docker redis has been updated to v6 in bootcamps. This PR updates the redis to v6 in CI.

### How can this be tested?
- Validate that there's no warning and errors on CI
