### PR TITLE
fix: warning to run uwsgi with flags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       sleep 3 &&
       python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --no-input &&
-      uwsgi uwsgi.ini --honour-stdin'
+      uwsgi uwsgi.ini --honour-stdin --enable-threads --py-call-uwsgi-fork-hooks'
     stdin_open: true
     tty: true
     ports:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4993

### Description (What does it do?)
<!--- Describe your changes in detail -->
It fixes a uwsgi warning to add a couple of flags.
<img width="1012" alt="Screenshot 2024-08-01 at 12 07 04 PM" src="https://github.com/user-attachments/assets/e0567ea7-67b3-4f34-8ed5-a7063b5849d6">

Similar xpro PR: https://github.com/mitodl/mitxpro/pull/3005

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Checkout master
2. Start the project using docker-compose up
3. monitor the web instance logs and you will get the warning attached in the Description
4. Stop the project with docker-compose stop and checkout this branch
5. Run the project with docker-compose up
6. You should not get the warning again.
