### PR TITLE
fix: pin minimist to solve dependabot security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "keycode": "^2.2.0",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^1.1.2",
-    "minimist": "^1.2.6",
+    "minimist": "1.2.8",
     "mocha": "^8.0.0",
     "moment": "^2.29.4",
     "mutationobserver-shim": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "yup": "^0.32.0"
   },
   "resolutions": {
+    "minimist": "1.2.8",
     "merge": "^2.1.1",
     "webpack/watchpack/watchpack-chokidar2/**/chokidar": "^3.4.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7793,12 +7793,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@1.1.x:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
-  integrity sha512-2RbeLaM/Hbo9vJ1+iRrxzfDnX9108qb2m923U+s+Ot2eMey0IYGdSjzHmvtg2XsxoCuMnzOMw7qc573RvnLgwg==
-
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@1.1.x, minimist@1.2.8, minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==


### PR DESCRIPTION
### What are the relevant tickets?
Solve https://github.com/mitodl/bootcamp-ecommerce/security/dependabot/100

### Description (What does it do?)
Pinning minimist in resolutions to fix the critical security issue

### How can this be tested?
Make sure everything's is working
