### PR TITLE
chore: disable gemini auto review

### DIFF
--- a/.gemini/config.yml
+++ b/.gemini/config.yml
@@ -1,0 +1,10 @@
+---
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false # Don't leave a summary of the PR when opened
+    code_review: false # Only post a code review when prompted


### PR DESCRIPTION
### What are the relevant tickets?
None, Code inspired by https://github.com/mitodl/open-edx-plugins/pull/455
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Disables the auto review and summary from Gemini. 
### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
There should be no more summary and code review from genini automatically.
